### PR TITLE
build: enable push to dockerhub

### DIFF
--- a/.conf/Dockerfile.full
+++ b/.conf/Dockerfile.full
@@ -47,8 +47,6 @@ COPY ./scripts/inject-dynamic-env.sh /docker-entrypoint.d/00-inject-dynamic-env.
 RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
 # Install bash for env variables inject script
 RUN apk update && apk add --no-cache bash
-# temp fix for CVE-2023-23916 and CVE-2023-0464
-RUN apk upgrade --no-cache curl libcurl libssl3 libcrypto3
 # Make nginx owner of /usr/share/nginx/html/ and change to nginx user
 RUN chown -R 101:101 /usr/share/nginx/html/
 USER 101

--- a/.conf/Dockerfile.prebuilt
+++ b/.conf/Dockerfile.prebuilt
@@ -37,8 +37,6 @@ COPY ./scripts/inject-dynamic-env.sh /docker-entrypoint.d/00-inject-dynamic-env.
 RUN chmod +x /docker-entrypoint.d/00-inject-dynamic-env.sh
 # Install bash for env variables inject script
 RUN apk update && apk add --no-cache bash
-# temp fix for CVE-2023-23916 and CVE-2023-0464
-RUN apk upgrade --no-cache curl libcurl libssl3 libcrypto3
 # Make nginx owner of /usr/share/nginx/html/ and change to nginx user
 RUN chown -R 101:101 /usr/share/nginx/html/
 USER 101

--- a/.conf/notice-portal.md
+++ b/.conf/notice-portal.md
@@ -1,0 +1,23 @@
+## Notice for Docker image
+
+DockerHub: [https://hub.docker.com/r/tractusx/portal-frontend](https://hub.docker.com/r/tractusx/portal-frontend)
+
+Eclipse Tractus-X product(s) installed within the image:
+
+__Portal frontend__
+
+- GitHub: https://github.com/eclipse-tractusx/portal-frontend
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfile: https://github.com/eclipse-tractusx/portal-frontend/blob/main/.conf/Dockerfile.prebuilt
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/portal-frontend/blob/main/LICENSE)
+
+__Used base images__
+
+- Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
+- GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
+- DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,22 +28,18 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  COMMIT_SHA: ${{ github.sha }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend"
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
 
       - name: Install Dependencies
         run: yarn
@@ -57,28 +53,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract Metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=dev
+            type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
-          push: true
-          # build tag :dev with commit-sha and latest
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHA }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-portal.md"
 
   auth-and-dispatch:
     needs: build-and-push-image
@@ -99,8 +107,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ env.COMMIT_SHA }}" }}' \
+            --data '{"ref":"dev", "inputs": { "new-image":"${{ github.sha }}" }}' \
             --fail

--- a/.github/workflows/release-release_candidate.yml
+++ b/.github/workflows/release-release_candidate.yml
@@ -28,16 +28,14 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  TAG_NAME: ${{ github.ref_name }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend"
 
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -49,18 +47,18 @@ jobs:
 
       - name: Output versions
         run: |
-          echo git ${{ env.TAG_NAME }}
+          echo git ${{ github.ref_name }}
           echo npm ${{ steps.npm-tag.outputs.current-version }}
 
       - name: Versions not matching
-        if: env.TAG_NAME != steps.npm-tag.outputs.current-version
+        if: github.ref_name != steps.npm-tag.outputs.current-version
         run: |
           echo git and npm versions not equal - refusing to build release
           exit 1
 
       - name: Versions match
         run: |
-          echo versions equal - building release ${{ env.TAG_NAME }}
+          echo versions equal - building release ${{ github.ref_name }}
 
       - name: Install Dependencies
         run: yarn
@@ -74,27 +72,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract Metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.ref_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-portal.md"
 
 #      - name: Publish Shared Components to npm
 #        working-directory: ./cx-portal-shared-components
@@ -108,7 +119,7 @@ jobs:
 
     steps:
       - name: Set env
-        run: echo "RELEASE_VERSION=${{ env.TAG_NAME }}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Get token
         id: get_workflow_token
@@ -124,8 +135,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-release-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ env.RELEASE_VERSION }}" }}' \
+            --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ github.ref_name }}" }}' \
             --fail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,16 +29,14 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  TAG_NAME: ${{ github.ref_name }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend"
 
 jobs:
   build-and-push-release:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
@@ -50,18 +48,18 @@ jobs:
 
       - name: Output versions
         run: |
-          echo git ${{ env.TAG_NAME }}
+          echo git ${{ github.ref_name }}
           echo npm ${{ steps.npm-tag.outputs.current-version }}
 
       - name: Versions not matching
-        if: env.TAG_NAME != steps.npm-tag.outputs.current-version
+        if: github.ref_name != steps.npm-tag.outputs.current-version
         run: |
           echo git and npm versions not equal - refusing to build release
           exit 1
 
       - name: Versions match
         run: |
-          echo versions equal - building release ${{ env.TAG_NAME }}
+          echo versions equal - building release ${{ github.ref_name }}
 
       - name: Install Dependencies
         run: yarn
@@ -75,27 +73,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract Metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ github.ref_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TAG_NAME }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-portal.md"
 
 #      - name: Publish Shared Components to npm
 #        working-directory: ./cx-portal-shared-components
@@ -109,7 +120,7 @@ jobs:
 
     steps:
       - name: Set env
-        run: echo "RELEASE_VERSION=${{ env.TAG_NAME }}" >> $GITHUB_ENV
+        run: echo "RELEASE_VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
 
       - name: Get token
         id: get_workflow_token
@@ -125,8 +136,8 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/catenax-ng/tx-portal-cd/actions/workflows/portal-release-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
-            --data '{"ref":"helm-environments", "inputs": { "new-image":"${{ env.RELEASE_VERSION }}" }}' \
+            --data '{"ref":"dev", "inputs": { "new-image":"${{ github.ref_name }}" }}' \
             --fail

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -28,22 +28,18 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  COMMIT_SHA: ${{ github.sha }}
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend"
 
 jobs:
-  build-and-push-release:
+  build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
 
       - name: Install Dependencies
         run: yarn
@@ -57,27 +53,40 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Extract Metadata (tags, labels) for Docker
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=rc
+            type=raw,value=${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHA }}, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rc
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      # https://github.com/peter-evans/dockerhub-description
+      - name: Update Docker Hub description
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+          readme-filepath: ".conf/notice-portal.md"
 
 #      - name: Publish Shared Components to npm
 #        working-directory: ./cx-portal-shared-components
@@ -86,11 +95,10 @@ jobs:
 #          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
 
   auth-and-dispatch:
-    needs: build-and-push-release
+    needs: build-and-push-image
     runs-on: ubuntu-latest
 
     steps:
-
       - name: Get token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v2

--- a/.github/workflows/trivy-dev.yml
+++ b/.github/workflows/trivy-dev.yml
@@ -38,8 +38,8 @@ on:
   # Trigger manually
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: catenax-ng/tx-portal-frontend
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend"
 
 jobs:
   analyze-config:
@@ -91,7 +91,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev"
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:dev"
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "1"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -38,8 +38,8 @@ on:
   # Trigger manually
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: catenax-ng/tx-portal-frontend
+  IMAGE_NAMESPACE: "tractusx"
+  IMAGE_NAME: "portal-frontend"
 
 jobs:
   analyze-config:
@@ -91,7 +91,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           # Path to Docker image
-          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
+          image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"
           output: "trivy-results2.sarif"
           exit-code: "1"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Catena-X Portal Frontend
 
-This repository contains the frontend code and shared UI components for the Catena-X Portal written in React and Typescript.
-
-* INT: https://portal.int.demo.catena-x.net/
-* DEV: https://portal.dev.demo.catena-x.net/
-* Components: https://portal.dev.demo.catena-x.net/_storybook/
+This repository contains the frontend code and [Shared UI Components](https://www.npmjs.com/package/cx-portal-shared-components) for the Catena-X Portal written in React and Typescript.
 
 The Catena-X Portal application consists of
 

--- a/README.md
+++ b/README.md
@@ -13,24 +13,43 @@ The Catena-X Portal application consists of
 
 The Catena-X Portal is designed to work with the [Catena-X IAM](https://github.com/eclipse-tractusx/portal-iam).
 
+## Run locally
+
 Here are three ways to run the application locally on http://localhost:3001/
 
 Note: if you'd like to run the complete frontend application, follow the 'Run frontend on localhost' guide available within the developer documentation of [portal-assets](https://github.com/eclipse-tractusx/portal-assets).
 
-## Local build & run
+### Local build & run
 
     yarn
     yarn build
     yarn start
 
-## Local docker build & run & publish
+### Local docker build & run & publish
 
     yarn build:docker
     yarn publish:docker
     yarn start:docker
 
-## Running the image from GitHub container registry
+### Running the image from GitHub container registry
 
-    export IMAGE=ghcr.io/catenax-ng/tx-portal-frontend:latest
+    export IMAGE=tractusx/portal-frontend:latest
     docker pull $IMAGE
     docker run --rm -d -p 3001:8080 --name cx-portal $IMAGE
+
+## Notice for Docker image
+
+This application provides container images for demonstration purposes.
+
+DockerHub: https://hub.docker.com/r/tractusx/portal-frontend
+
+Base image: nginxinc/nginx-unprivileged:alpine
+
+* Dockerfile: [nginxinc/nginx-unprivileged:alpine](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
+* GitHub project: [https://github.com/nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged)
+* DockerHub: [https://hub.docker.com/r/nginxinc/nginx-unprivileged](https://hub.docker.com/r/nginxinc/nginx-unprivileged)
+
+## License
+
+Distributed under the Apache 2.0 License.
+See [LICENSE](./LICENSE) for more information.


### PR DESCRIPTION
## Description

- enable workflows for push to dockerhub
- change to tags from docker metadata action
- add notice for docker images and license in readme https://github.com/eclipse-tractusx/portal-frontend/issues/16
- remove references to consortia envs from readme
- remove temporary security fixes

## Why

https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-05
https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-06