### PR TITLE
bugfix(general) : use strong tag with specific class name

### DIFF
--- a/cx-portal/src/components/shared/templates/StaticTemplateResponsive/StaticTemplate.scss
+++ b/cx-portal/src/components/shared/templates/StaticTemplateResponsive/StaticTemplate.scss
@@ -469,7 +469,7 @@ iframe {
   width: 100%;
 }
 
-strong {
+strong.tooltip {
   position: relative;
   display: inline-block;
   cursor: pointer;


### PR DESCRIPTION
## Description

Use strong element with a class identifier to resolve issue in other places.

## Why

Strong element used in other places broken because of the common style

## Issue

Common css on strong element breaking styles in other pages.

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally