### PR TITLE
bugfix(static template): text color and position of tooltip issue fix

### DIFF
--- a/cx-portal/src/components/shared/templates/StaticTemplateResponsive/StaticTemplate.scss
+++ b/cx-portal/src/components/shared/templates/StaticTemplateResponsive/StaticTemplate.scss
@@ -469,7 +469,7 @@ iframe {
   width: 100%;
 }
 
-strong.tooltip {
+.multiTextContainer div strong {
   position: relative;
   display: inline-block;
   cursor: pointer;


### PR DESCRIPTION
## Description

Style fix based on multiple identifier rather than just class name

## Why

JSON string does not provide class name.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally