### PR TITLE
feat(api change): fetch data from single API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-New features, fixed bugs, known defects and other noteworthy changes to each release of the Catena-X Portal Frontend.
+* App Access Management
+   * Fetch data from single API
 
 ## 1.4.0
 

--- a/cx-portal/src/features/apps/apiSlice.ts
+++ b/cx-portal/src/features/apps/apiSlice.ts
@@ -191,24 +191,17 @@ export const apiSlice = createApi({
           `/api/apps/subscribed/subscription-status`
         )
         if (subscriptionApps.error) return { error: subscriptionApps.error }
-        const subscriptionData =
-          subscriptionApps.data as SubscriptionStatusItem[]
-        const activeResponse = await fetchWithBQ(`/api/apps/active`)
-        const activeData = activeResponse.data as AppMarketplaceApp[]
-        activeData.forEach(async (activeItem: AppMarketplaceApp) => {
-          subscriptionData.forEach(
-            async (subscriptionItem: SubscriptionStatusItem) => {
-              if (activeItem.id === subscriptionItem.appId)
-                subscriptionItem.image = {
-                  src: activeItem.leadPictureId
-                    ? `${getApiBase()}/api/apps/${activeItem.id}/appDocuments/${
-                        activeItem.leadPictureId
-                      }`
-                    : LogoGrayData,
-                }
+        const subscriptionData = subscriptionApps.data as SubscriptionStatusItem[]
+        subscriptionData.forEach(
+          async (subscriptionItem: SubscriptionStatusItem) => {
+            subscriptionItem.image = {
+              src: subscriptionItem.image
+                ? `${getApiBase()}/api/apps/${subscriptionItem.appId}/appDocuments/${subscriptionItem.image
+                }`
+                : LogoGrayData,
             }
-          )
-        })
+          }
+        )
         return { data: subscriptionData }
       },
     }),


### PR DESCRIPTION
## Description

App Access Management Gadget - fetch data from single API

## Why

Previously we are using 2 API's for single call. To avoid that now we are using single API

## Issue

CPLP-2731

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
