### PR TITLE
updates(service release process) : support load image in service release flow. show notifier on delete document/image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
 * Bugfix:
    * App Release Process
       * Fixed Conformity Document Deletion is not backend connected issue
+* Updates
+   * Service release process
+      * SERVICE_LEADIMAGE supported.
+      * Show notifier on delete document
 
 ## 1.4.0
 * UserMangement

--- a/cx-portal/src/assets/locales/de/servicerelease.json
+++ b/cx-portal/src/assets/locales/de/servicerelease.json
@@ -14,6 +14,8 @@
   "consultanceService": "Beratungsleistung",
   "dataspaceService": "Tool/Service",
   "loadmore": "Mehr laden",
+  "documentDeleteSuccess": "Document deleted successfully",
+  "documentDeleteError": "Something went wrong.",
   "stepper": {
     "marketCard": "Offer Card",
     "servicePage": "Offer Page Details",

--- a/cx-portal/src/assets/locales/en/servicerelease.json
+++ b/cx-portal/src/assets/locales/en/servicerelease.json
@@ -14,6 +14,8 @@
   "consultanceService": "Consultance Service",
   "dataspaceService": "Dataspace Service",
   "loadmore": "Load More",
+  "documentDeleteSuccess": "Document deleted successfully",
+  "documentDeleteError": "Something went wrong.",
   "stepper": {
     "marketCard": "Offer Card",
     "servicePage": "Offer Page Details",

--- a/cx-portal/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/cx-portal/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -166,7 +166,7 @@ export default function OfferCard() {
         setImageData({
           name: documentName,
           id: documentId,
-          status: UploadStatus.UPLOAD_SUCCESS
+          status: UploadStatus.UPLOAD_SUCCESS,
         })
       } catch (error) {
         console.error(error, 'ERROR WHILE FETCHING IMAGE')
@@ -213,7 +213,7 @@ export default function OfferCard() {
     updateServiceDocumentUpload({
       appId: appId,
       documentTypeId: DocumentTypeId.SERVICE_LEADIMAGE,
-      body: { file: uploadImageValue}
+      body: { file: uploadImageValue },
     })
       .then(() => {
         setFileStatus(UploadStatus.UPLOAD_SUCCESS)
@@ -241,7 +241,7 @@ export default function OfferCard() {
       .unwrap()
       .then(() => {
         !uploadImageValue.id &&
-            handleUploadDocument(serviceId, uploadImageValue)
+          handleUploadDocument(serviceId, uploadImageValue)
         dispatch(setServiceId(serviceId))
         buttonLabel === ButtonLabelTypes.SAVE_AND_PROCEED &&
           dispatch(serviceReleaseStepIncrement())
@@ -268,8 +268,7 @@ export default function OfferCard() {
       .unwrap()
       .then((result) => {
         if (isString(result)) {
-          !uploadImageValue.id &&
-            handleUploadDocument(result, uploadImageValue)
+          !uploadImageValue.id && handleUploadDocument(result, uploadImageValue)
           dispatch(setServiceId(result))
           buttonLabel === ButtonLabelTypes.SAVE_AND_PROCEED &&
             dispatch(serviceReleaseStepIncrement())

--- a/cx-portal/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/cx-portal/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -20,7 +20,6 @@
 
 import {
   IconButton,
-  LogoGrayData,
   UploadFileStatus,
   UploadStatus,
 } from 'cx-portal-shared-components'
@@ -51,10 +50,12 @@ import {
   CreateServiceStep1Item,
   ServiceTypeIdsType,
   useCreateServiceMutation,
-  useFetchNewDocumentByIdMutation,
+  useDeleteDocumentMutation,
+  useFetchDocumentMutation,
   useFetchServiceStatusQuery,
   useFetchServiceTypeIdsQuery,
   useSaveServiceMutation,
+  useUpdateServiceDocumentUploadMutation,
 } from 'features/serviceManagement/apiSlice'
 import {
   setServiceId,
@@ -62,6 +63,8 @@ import {
 } from 'features/serviceManagement/actions'
 import { ButtonLabelTypes } from '..'
 import RetryOverlay from '../components/RetryOverlay'
+import { success, error } from 'services/NotifyService'
+import { DocumentTypeId } from 'features/appManagement/apiSlice'
 
 type FormDataType = {
   title: string
@@ -83,8 +86,7 @@ export default function OfferCard() {
   const [serviceCardNotification, setServiceCardNotification] = useState(false)
   const [serviceCardSnackbar, setServiceCardSnackbar] = useState<boolean>(false)
   const serviceStatusData = useSelector(serviceStatusDataSelector)
-  const [fetchDocumentById] = useFetchNewDocumentByIdMutation()
-  const [cardImage, setCardImage] = useState(LogoGrayData)
+  const [fetchDocumentById] = useFetchDocumentMutation()
   const {
     data: fetchServiceStatus,
     isError,
@@ -99,22 +101,23 @@ export default function OfferCard() {
   const serviceTypeIds = useMemo(() => serviceTypeData.data, [serviceTypeData])
   const [loading, setLoading] = useState<boolean>(false)
   const [showRetryOverlay, setShowRetryOverlay] = useState<boolean>(false)
+  const [imageData, setImageData] = useState({})
+  const [deleteDocument, deleteResponse] = useDeleteDocumentMutation()
+  const [updateServiceDocumentUpload] = useUpdateServiceDocumentUploadMutation()
 
   useEffect(() => {
     setShowRetryOverlay(serviceId && isError ? true : false)
   }, [serviceId, isError])
 
+  useEffect(() => {
+    deleteResponse.isSuccess && success(t('documentDeleteSuccess'))
+    deleteResponse.isError && error(t('documentDeleteError'))
+  }, [deleteResponse, t])
+
   const defaultValues = useMemo(() => {
     return {
       title: fetchServiceStatus?.title,
-      serviceTypeIds: fetchServiceStatus?.serviceTypeIds.map(
-        (item: string, index: number) => {
-          return {
-            name: item,
-            serviceTypeId: index,
-          }
-        }
-      ),
+      serviceTypeIds: fetchServiceStatus?.serviceTypeIds,
       price: null,
       shortDescriptionEN:
         fetchServiceStatus?.descriptions?.filter(
@@ -127,11 +130,11 @@ export default function OfferCard() {
             serviceStatus.languageCode === 'de'
         )[0]?.shortDescription || '',
       uploadImage: {
-        leadPictureUri: cardImage === LogoGrayData ? null : cardImage,
+        leadPictureUri: imageData,
         alt: fetchServiceStatus?.leadPictureUri || '',
       },
     }
-  }, [fetchServiceStatus, cardImage])
+  }, [fetchServiceStatus, imageData])
 
   const {
     handleSubmit,
@@ -149,19 +152,22 @@ export default function OfferCard() {
   const fetchCardImage = useCallback(
     async (documentId: string, documentName: string) => {
       try {
-        const response = await fetchDocumentById({
+        await fetchDocumentById({
           appId: serviceId,
           documentId,
         }).unwrap()
-        const file = response.data
-
         const setFileStatus = (status: UploadFileStatus) =>
           setValue('uploadImage.leadPictureUri', {
             name: documentName,
+            id: documentId,
             status,
           } as any)
         setFileStatus(UploadStatus.UPLOAD_SUCCESS)
-        return setCardImage(URL.createObjectURL(file))
+        setImageData({
+          name: documentName,
+          id: documentId,
+          status: UploadStatus.UPLOAD_SUCCESS
+        })
       } catch (error) {
         console.error(error, 'ERROR WHILE FETCHING IMAGE')
       }
@@ -191,6 +197,32 @@ export default function OfferCard() {
     }
   }, [serviceStatusData, fetchCardImage])
 
+  const handleUploadDocument = (
+    appId: string,
+    uploadImageValue: DropzoneFile
+  ) => {
+    const setFileStatus = (status: UploadFileStatus) =>
+      setValue('uploadImage.leadPictureUri', {
+        id: uploadImageValue.id,
+        name: uploadImageValue.name,
+        size: uploadImageValue.size,
+        status,
+      } as any)
+
+    setFileStatus(UploadStatus.UPLOADING)
+    updateServiceDocumentUpload({
+      appId: appId,
+      documentTypeId: DocumentTypeId.SERVICE_LEADIMAGE,
+      body: { file: uploadImageValue}
+    })
+      .then(() => {
+        setFileStatus(UploadStatus.UPLOAD_SUCCESS)
+      })
+      .catch(() => {
+        setFileStatus(UploadStatus.UPLOAD_ERROR)
+      })
+  }
+
   useEffect(() => {
     if (fetchServiceStatus) dispatch(setServiceStatus(fetchServiceStatus))
     reset(defaultValues)
@@ -200,13 +232,16 @@ export default function OfferCard() {
     apiBody: CreateServiceStep1Item,
     buttonLabel: string
   ) => {
+    const uploadImageValue = getValues().uploadImage
+      .leadPictureUri as unknown as DropzoneFile
     await saveService({
       id: serviceId,
       body: apiBody,
     })
       .unwrap()
       .then(() => {
-        //TO-DO API INTEGRATION UPLOAD SERVICE_LEADIMAGE
+        !uploadImageValue.id &&
+            handleUploadDocument(serviceId, uploadImageValue)
         dispatch(setServiceId(serviceId))
         buttonLabel === ButtonLabelTypes.SAVE_AND_PROCEED &&
           dispatch(serviceReleaseStepIncrement())
@@ -224,6 +259,8 @@ export default function OfferCard() {
     apiBody: CreateServiceStep1Item,
     buttonLabel: string
   ) => {
+    const uploadImageValue = getValues().uploadImage
+      .leadPictureUri as unknown as DropzoneFile
     await createService({
       id: '',
       body: apiBody,
@@ -231,7 +268,8 @@ export default function OfferCard() {
       .unwrap()
       .then((result) => {
         if (isString(result)) {
-          //TO-DO API INTEGRATION UPLOAD SERVICE_LEADIMAGE
+          !uploadImageValue.id &&
+            handleUploadDocument(result, uploadImageValue)
           dispatch(setServiceId(result))
           buttonLabel === ButtonLabelTypes.SAVE_AND_PROCEED &&
             dispatch(serviceReleaseStepIncrement())
@@ -442,6 +480,10 @@ export default function OfferCard() {
               note={t('serviceReleaseForm.note')}
               requiredText={t('serviceReleaseForm.fileUploadIsMandatory')}
               isRequired={false}
+              handleDelete={(documentId: string) => {
+                setImageData({})
+                documentId && deleteDocument(documentId)
+              }}
             />
           </form>
         </Grid>

--- a/cx-portal/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
+++ b/cx-portal/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
@@ -52,6 +52,7 @@ import ProviderConnectorField from '../components/ProviderConnectorField'
 import { LanguageStatusType } from 'features/appManagement/types'
 import { DocumentTypeId } from 'features/appManagement/apiSlice'
 import { ButtonLabelTypes } from '..'
+import { success, error } from 'services/NotifyService'
 
 type FormDataType = {
   longDescriptionEN: string
@@ -77,12 +78,17 @@ export default function OfferPage() {
   const [saveService] = useSaveServiceMutation()
   const [updateDocumentUpload] = useUpdateServiceDocumentUploadMutation()
   const [loading, setLoading] = useState<boolean>(false)
-  const [deleteDocument] = useDeleteDocumentMutation()
+  const [deleteDocument, deleteResponse] = useDeleteDocumentMutation()
 
   const onBackIconClick = () => {
     if (fetchServiceStatus) dispatch(setServiceStatus(fetchServiceStatus))
     dispatch(serviceReleaseStepDecrement())
   }
+
+  useEffect(() => {
+    deleteResponse.isSuccess && success(t('documentDeleteSuccess'))
+    deleteResponse.isError && error(t('documentDeleteError'))
+  }, [deleteResponse, t])
 
   const defaultValues = useMemo(() => {
     return {

--- a/cx-portal/src/features/apps/apiSlice.ts
+++ b/cx-portal/src/features/apps/apiSlice.ts
@@ -191,13 +191,15 @@ export const apiSlice = createApi({
           `/api/apps/subscribed/subscription-status`
         )
         if (subscriptionApps.error) return { error: subscriptionApps.error }
-        const subscriptionData = subscriptionApps.data as SubscriptionStatusItem[]
+        const subscriptionData =
+          subscriptionApps.data as SubscriptionStatusItem[]
         subscriptionData.forEach(
           async (subscriptionItem: SubscriptionStatusItem) => {
             subscriptionItem.image = {
               src: subscriptionItem.image
-                ? `${getApiBase()}/api/apps/${subscriptionItem.appId}/appDocuments/${subscriptionItem.image
-                }`
+                ? `${getApiBase()}/api/apps/${
+                    subscriptionItem.appId
+                  }/appDocuments/${subscriptionItem.image}`
                 : LogoGrayData,
             }
           }


### PR DESCRIPTION
## Description

1. Support SERVICE_LEADIMAGE in service release process step1.
2. Allow user to delete the uploaded image/doc in both step1 or step2
3. Show notifier on delete action.

## Why

Notifier - User has no clue on whether the action is completed or not.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
