### PR TITLE
bugfix(connector) : clear previously added data in the overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Connectors
    * Show Managed connectors
    * Error scenarios implemented in Table component
+   * Clear previously added data in the overlay
 * App Release Process
    * technical integration style updates
 * News Section

--- a/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/cx-portal/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Dialog,
@@ -85,6 +85,10 @@ const AddConnectorOverlay = ({
 
   const [selected, setSelected] = useState<ConnectorType>({})
 
+  useEffect(() => {
+    if (openDialog) reset(formFields)
+  }, [openDialog, reset])
+
   const onFormSubmit = async () => {
     const validateFields = await trigger([
       'ConnectorName',
@@ -124,7 +128,6 @@ const AddConnectorOverlay = ({
           onCloseWithIcon={() => {
             setSelected({})
             handleOverlayClose()
-            reset(formFields)
           }}
         />
         <DialogContent
@@ -154,7 +157,6 @@ const AddConnectorOverlay = ({
               } else {
                 setSelected({})
                 handleOverlayClose()
-                reset(formFields)
               }
             }}
           >


### PR DESCRIPTION
## Description

On opening overlay in the connector page, clear the data entered previously.

## Why

after creating a connector successfully and now reopening the connector registration - previously entered data are still visible.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing tests pass locally with my changes