### PR TITLE
bugfix(registration process) : bpn overlay keeps showing a load element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@
 * Service Release Process
    * added technical user section in validate and publish
    * added technical user section in admin board
+* Bugfix:
+   * Registration Process - bpn overlay keeps showing a load element
 
 ## 1.4.0
 * UserMangement

--- a/cx-portal/src/components/pages/Admin/components/RegistrationRequests/index.tsx
+++ b/cx-portal/src/components/pages/Admin/components/RegistrationRequests/index.tsx
@@ -142,6 +142,7 @@ export default function RegistrationRequests() {
         setEnableBpnInput(false)
         setErrorOverlay(true)
       })
+    setIsLoading(false)
   }
 
   const onConfirmationCancel = (id: string, name: string) => {
@@ -274,6 +275,7 @@ export default function RegistrationRequests() {
             setEnableBpnInput(true)
             setSuccessOverlay(false)
             setErrorOverlay(false)
+            setIsLoading(false)
           }}
           onConfirmationCancel={(id: string, name: string) =>
             onConfirmationCancel(id, name)


### PR DESCRIPTION
## Description

Hide load element on opening the bpn overlay

## Why

When entering a BPN manually inside the registration approval board, I can't update the BPN of a second registration request without refreshing the page - reason - the add bpn overlay keeps showing a load element.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing tests pass locally with my changes