### PR TITLE
bugfix(usecase) : configure br tag in the components to avoid json parsing error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@
    * Fetch data from single API
 * App Detail
    * UI Changes
+* Static template
+   * Bugfix - Use case section not loading because of br tag in the JSON response
 
 
 ## Unreleased

--- a/cx-portal/src/components/shared/templates/StaticTemplateResponsive/Cards/TextCenterAlignedBody2.tsx
+++ b/cx-portal/src/components/shared/templates/StaticTemplateResponsive/Cards/TextCenterAlignedBody2.tsx
@@ -60,7 +60,7 @@ export default function TextCenterAlignedBody2({
               i18nKey={subtitle}
               components={[
                 <span key={subtitle} className="tooltiptext"></span>,
-                <br />,
+                <br key={subtitle} />,
               ]}
             ></Trans>
           ))}

--- a/cx-portal/src/components/shared/templates/StaticTemplateResponsive/Cards/TextCenterAlignedBody2.tsx
+++ b/cx-portal/src/components/shared/templates/StaticTemplateResponsive/Cards/TextCenterAlignedBody2.tsx
@@ -60,6 +60,7 @@ export default function TextCenterAlignedBody2({
               i18nKey={subtitle}
               components={[
                 <span key={subtitle} className="tooltiptext"></span>,
+                <br />,
               ]}
             ></Trans>
           ))}


### PR DESCRIPTION
## Description

Use case section is showing empty because some of the contents are not parsed properly from the usecase.json or companyroles.json. To avoid this, use html tags in the components section and use appropriate name in the json

## Why

use case section is showing empty

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally