### PR TITLE
bugfix(service admin): Page not displayed issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,6 @@
    * Make Role Desc Dynamic
    * Add Terms and Condition dynamic in overlay and handle download document functionality
    * BL & API POST CompanyRole and Consent & Error/Success
-* Bugfix:
-   * App Release Process
-      * Fixed Conformity Document Deletion is not backend connected issue
 * Shared Component
    * New About page component added
    * About page created
@@ -55,6 +52,12 @@
 * App Detail
    * UI Changes
 
+
+* Bugfix:
+   * App Release Process
+      * Fixed Conformity Document Deletion is not backend connected issue
+   * Service Admin Board
+      * Service detail page not displayed issue fixed
 
 ## Unreleased
 

--- a/cx-portal/src/components/pages/ServiceAdminBoardDetail/index.tsx
+++ b/cx-portal/src/components/pages/ServiceAdminBoardDetail/index.tsx
@@ -164,7 +164,7 @@ export default function ServiceAdminBoardDetail() {
               {t(`adminboardDetail.documents.message`)}
             </Typography>
             {serviceData?.documents &&
-              Object.keys(serviceData.documents).map((item, i) => (
+              Object.keys(serviceData.documents).map((item) => (
                 <InputLabel sx={{ mb: 0, mt: 3 }} key={item}>
                   <span
                     style={{
@@ -172,10 +172,10 @@ export default function ServiceAdminBoardDetail() {
                       cursor: 'pointer',
                       color: '#0f71cb',
                     }}
-                    onClick={() => onDownload(serviceData.documents[item][i])}
+                    onClick={() => onDownload(serviceData.documents[item][0])}
                   >
                     <ArrowForwardIcon fontSize="small" />
-                    {serviceData.documents[item][i].documentName}
+                    {serviceData.documents[item][0]?.documentName}
                   </span>
                 </InputLabel>
               ))}


### PR DESCRIPTION
## Description

Service Admin Board Detail: Page not displayed on service navigation

## Why

To avoid displaying empty screen

## Issue

Ref: CPLP-2796

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
