### PR TITLE
bugfix(my organisation) : Show missing subscription info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,13 @@
    * UI Changes
 * Static template
    * Bugfix - Use case section not loading because of br tag in the JSON response
-
-
 * Bugfix:
    * App Release Process
       * Fixed Conformity Document Deletion is not backend connected issue
    * Service Admin Board
       * Service detail page not displayed issue fixed
+   * My Organization
+      * Subscription details missing
 
 ## Unreleased
 

--- a/cx-portal/src/components/pages/Organization/index.tsx
+++ b/cx-portal/src/components/pages/Organization/index.tsx
@@ -45,7 +45,7 @@ export default function Organization() {
   } = useFetchSubscriptionStatusQuery()
   const { data } = useFetchActiveAppsQuery()
   const appSubscribedData =
-    data && subscriptionStatus && appToStatus(data, subscriptionStatus)
+    data && subscriptionStatus && appToStatus(data, subscriptionStatus.content)
   const {
     data: companyDetails,
     isError: companyDetailsError,

--- a/cx-portal/src/components/pages/UserManagement/AppArea/index.tsx
+++ b/cx-portal/src/components/pages/UserManagement/AppArea/index.tsx
@@ -34,7 +34,7 @@ export const AppArea = () => {
   const navigate = useNavigate()
   const { t } = useTranslation()
   const subscriptionStatus = useFetchSubscriptionStatusQuery().data
-  const cards = subscriptionStatus?.filter(
+  const cards = subscriptionStatus?.content.filter(
     (app) => app.offerSubscriptionStatus === SubscriptionStatus.ACTIVE
   )
 

--- a/cx-portal/src/features/apps/apiSlice.ts
+++ b/cx-portal/src/features/apps/apiSlice.ts
@@ -72,10 +72,31 @@ export enum SubscriptionStatusText {
 
 export type SubscriptionStatusItem = {
   appId: string
-  offerSubscriptionStatus: SubscriptionStatus
+  offerId: string
+  offerSubscriptionStatus?: SubscriptionStatus
   name?: string
   provider?: string
   image?: ImageType
+}
+
+export type SubscriptionStatusResponse = {
+  content: SubscriptionStatusItem[]
+  meta: {
+    contentSize: number
+    page: number
+    totalElements: number
+    totalPages: number
+  }
+}
+
+export type SubscriptionStatusDuplicateItem = {
+  appId?: string
+  offerSubscriptionStatus?: SubscriptionStatus
+  name?: string
+  provider?: string
+  image?: ImageType
+  status?: SubscriptionStatus
+  offerId?: string
 }
 
 export enum DocumentTypeText {
@@ -172,9 +193,17 @@ export const apiSlice = createApi({
           `/api/apps/subscribed/subscription-status`
         )
         const subscriptionData =
-          subscriptionStatus.data as SubscriptionStatusItem[]
+          subscriptionStatus.data as SubscriptionStatusResponse
+
+        subscriptionData.content.forEach(
+          (subscriptionItem: SubscriptionStatusDuplicateItem) => {
+            subscriptionItem.offerSubscriptionStatus = subscriptionItem.status
+            subscriptionItem.appId = subscriptionItem.offerId
+          }
+        )
+
         data.forEach(async (appItem: AppMarketplaceApp) => {
-          subscriptionData.forEach(
+          subscriptionData.content.forEach(
             async (subscriptionItem: SubscriptionStatusItem) => {
               if (appItem.id === subscriptionItem.appId)
                 appItem.subscriptionStatus =
@@ -188,15 +217,21 @@ export const apiSlice = createApi({
     fetchFavoriteApps: builder.query<string[], void>({
       query: () => `/api/apps/favourites`,
     }),
-    fetchSubscriptionStatus: builder.query<SubscriptionStatusItem[], void>({
+    fetchSubscriptionStatus: builder.query<SubscriptionStatusResponse, void>({
       async queryFn(_arg, _queryApi, _extraOptions, fetchWithBQ) {
         const subscriptionApps = await fetchWithBQ(
           `/api/apps/subscribed/subscription-status`
         )
         if (subscriptionApps.error) return { error: subscriptionApps.error }
         const subscriptionData =
-          subscriptionApps.data as SubscriptionStatusItem[]
-        subscriptionData.forEach(
+          subscriptionApps.data as SubscriptionStatusResponse
+        subscriptionData.content.forEach(
+          (subscriptionItem: SubscriptionStatusDuplicateItem) => {
+            subscriptionItem.offerSubscriptionStatus = subscriptionItem.status
+            subscriptionItem.appId = subscriptionItem.offerId
+          }
+        )
+        subscriptionData.content.forEach(
           async (subscriptionItem: SubscriptionStatusItem) => {
             subscriptionItem.image = {
               src: subscriptionItem.image


### PR DESCRIPTION
## Description

Show missing subscription info.
Backend api has updated with content and meta attributes in the response but front end app was still looking for array of objects in the response. Now updated the data in the code as well.

## Why

Subscription section is empty

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
