### PR TITLE
bugfix(service release): do refresh on action back from step2

### DIFF
--- a/cx-portal/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/cx-portal/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -91,7 +91,9 @@ export default function OfferCard() {
     data: fetchServiceStatus,
     isError,
     refetch,
-  } = useFetchServiceStatusQuery(serviceId ?? '')
+  } = useFetchServiceStatusQuery(serviceId ?? '', {
+    refetchOnMountOrArgChange: true,
+  })
   const [createService] = useCreateServiceMutation()
   const [saveService] = useSaveServiceMutation()
   const [defaultServiceTypeVal, setDefaultServiceTypeVal] = useState<


### PR DESCRIPTION
## Description

do refresh on whenever the step is loaded

## Why

While coming back from step2, added image in step1 is not appearing

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
