### PR TITLE
bugfix(service release process): show lead service image in validate & publish step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 1.5.0-RC1
+* Service release process
+   * Show lead service image in validate and publish step
 
 ### Change
 * User Management

--- a/cx-portal/src/components/shared/basic/ReleaseProcess/components/CommonValidateAndPublish.tsx
+++ b/cx-portal/src/components/shared/basic/ReleaseProcess/components/CommonValidateAndPublish.tsx
@@ -135,16 +135,14 @@ export default function CommonValidateAndPublish({
   const [cardLanguage, setCardLanguage] = useState<string>('en')
 
   const fetchImage = useCallback(
-    async (documentId: string, documentType: string) => {
+    async (documentId: string) => {
       try {
         const response = await fetchDocumentById({
           appId: id,
           documentId,
         }).unwrap()
         const file = response.data
-        if (documentType === 'APP_LEADIMAGE') {
-          return setCardImage(URL.createObjectURL(file))
-        }
+        return setCardImage(URL.createObjectURL(file))
       } catch (error) {
         console.error(error, 'ERROR WHILE FETCHING IMAGE')
       }
@@ -166,10 +164,13 @@ export default function CommonValidateAndPublish({
       statusData?.documents?.APP_LEADIMAGE &&
       statusData?.documents?.APP_LEADIMAGE[0].documentId
     ) {
-      fetchImage(
-        statusData?.documents?.APP_LEADIMAGE[0].documentId,
-        'APP_LEADIMAGE'
-      )
+      fetchImage(statusData?.documents?.APP_LEADIMAGE[0].documentId)
+    }
+    if (
+      statusData?.documents?.SERVICE_LEADIMAGE &&
+      statusData?.documents?.SERVICE_LEADIMAGE[0].documentId
+    ) {
+      fetchImage(statusData?.documents?.SERVICE_LEADIMAGE[0].documentId)
     }
     if (
       statusData?.documents?.APP_IMAGE &&
@@ -334,7 +335,7 @@ export default function CommonValidateAndPublish({
           <CardHorizontal
             borderRadius={6}
             imageAlt="Service Card"
-            imagePath={LogoGrayData}
+            imagePath={cardImage || LogoGrayData}
             label={''}
             buttonText=""
             onBtnClick={() => {}}


### PR DESCRIPTION
## Description

 show lead service image in validate & publish step. fetch details from server and show the appropriate image

## Why

Service lead image is missing in the horizontal card

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
