### PR TITLE
bugfix(subscription management): show service or app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 1.5.0-RC1
+* Service/App Subscription Management
+   * Show Service/App name
 
 ### Change
 * User Management

--- a/cx-portal/src/components/shared/templates/Subscription/SubscriptionElements.tsx
+++ b/cx-portal/src/components/shared/templates/Subscription/SubscriptionElements.tsx
@@ -142,7 +142,7 @@ export default function SubscriptionElements({
                       {subscription.companyName}
                     </Typography>
                     <Typography variant="body2" className="secondSection">
-                      {subscriptionData.serviceName}
+                      {subscriptionData.offerName}
                     </Typography>
                     <Typography variant="body3" className="thirdSection">
                       {'Placeholders for add details such as BPN; etc'}

--- a/cx-portal/src/features/appSubscription/appSubscriptionApiSlice.ts
+++ b/cx-portal/src/features/appSubscription/appSubscriptionApiSlice.ts
@@ -46,6 +46,7 @@ export type CompanySubscriptionData = {
 export type SubscriptionContent = {
   offerId: string
   serviceName: string
+  offerName: string
   companySubscriptionStatuses: CompanySubscriptionData[]
 }
 


### PR DESCRIPTION
## Description

Show service or app name on subscription management card

## Why

attribute name has been changed in the backend

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
