### PR TITLE
bugfix(app release process): app lead image load issue fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,13 @@
    * Add Admin Info
 * App Detail
    * Subscribe Button - wrong state
-* Service Release Process
-   * Bugfix
+
+* Bugfix
+   * Service Release Process
       * Service Release process not working
       * Service details page crash issue
+   * App Release Process
+      * App lead image load issue fix
 
 ## 1.5.0-RC1
 

--- a/cx-portal/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
+++ b/cx-portal/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
@@ -67,7 +67,7 @@ export default function TechnicalUserDetailsContent({
       copy: true,
     },
   ]
-  
+
   return (
     <section>
       <Button

--- a/cx-portal/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
+++ b/cx-portal/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
@@ -263,20 +263,26 @@ export default function AppMarketCard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appStatusData])
 
+  const setFileStatus = (
+    documentId: string,
+    documentName: string,
+    status: UploadFileStatus
+  ) => {
+    setValue('uploadImage.leadPictureUri', {
+      id: documentId,
+      name: documentName,
+      status,
+    } as any)
+  }
+
   const fetchCardImage = async (documentId: string, documentName: string) => {
     try {
       const response = await fetchDocumentById({ appId, documentId }).unwrap()
       const file = response.data
-
-      const setFileStatus = (status: UploadFileStatus) =>
-        setValue('uploadImage.leadPictureUri', {
-          id: documentId,
-          name: documentName,
-          status,
-        } as any)
-      setFileStatus(UploadStatus.UPLOAD_SUCCESS)
+      setFileStatus(documentId, documentName, UploadStatus.UPLOAD_SUCCESS)
       return setCardImage(URL.createObjectURL(file))
     } catch (error) {
+      setFileStatus(documentId, documentName, UploadStatus.UPLOAD_SUCCESS)
       console.error(error, 'ERROR WHILE FETCHING IMAGE')
     }
   }


### PR DESCRIPTION
## Description

app lead image load issue fix

## Why

When leadimage is in status "INACTIVE", the image in card is not displayed, but should display document details for document upload

## Issue

Ref: CPLP-2848

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally