### PR TITLE
feat(notification): mark notification done and allow to mark read/unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
    * Bugfix
       * Service Release process not working
       * Service details page crash issue
+* Notification
+   * Show done state
+   * Provide icon for marking a notification as read/unread
 
 ## 1.5.0-RC1
 

--- a/cx-portal/src/assets/locales/de/notification.json
+++ b/cx-portal/src/assets/locales/de/notification.json
@@ -124,5 +124,11 @@
     "app": "Apps",
     "info": "Information",
     "withaction": "Action"
+  },
+  "tooltip": {
+    "email": {
+      "read": "Mark it as unread",
+      "unread": "Mark it as read"
+    }
   }
 }

--- a/cx-portal/src/assets/locales/en/notification.json
+++ b/cx-portal/src/assets/locales/en/notification.json
@@ -120,5 +120,11 @@
     "app": "app only",
     "info": "info only",
     "withaction": "action required"
+  },
+  "tooltip": {
+    "email": {
+      "read": "Mark it as unread",
+      "unread": "Mark it as read"
+    }
   }
 }

--- a/cx-portal/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/cx-portal/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -24,7 +24,6 @@ import { useFetchAppDetailsQuery } from 'features/apps/apiSlice'
 import {
   useDeleteNotificationMutation,
   useSetNotificationReadMutation,
-  useSetNotificationUnReadMutation,
 } from 'features/notification/apiSlice'
 import {
   CXNotificationContent,
@@ -211,24 +210,15 @@ export default function NotificationItem({
   const { t } = useTranslation('notification')
   const [open, setOpen] = useState<boolean>(false)
   const [setNotificationRead] = useSetNotificationReadMutation()
-  const [setNotificationUnRead] = useSetNotificationUnReadMutation()
   const [deleteNotification] = useDeleteNotificationMutation()
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
   const dispatch = useDispatch()
   const [selectedId, setSelectedId] = useState<string>('')
 
-  const setRead = async (id: string) => {
+  const setRead = async (id: string, value: boolean) => {
     try {
-      await setNotificationRead(id)
-    } catch (error: unknown) {
-      console.log(error)
-    }
-  }
-
-  const setUnRead = async (id: string) => {
-    try {
-      await setNotificationUnRead(id)
+      await setNotificationRead({ id: id, flag: value })
     } catch (error: unknown) {
       console.log(error)
     }
@@ -237,7 +227,7 @@ export default function NotificationItem({
   const toggle = async () => {
     const nextState = !open
     if (nextState && !item.isRead) {
-      void setRead(item.id)
+      void setRead(item.id, true)
     }
     setOpen(nextState)
   }
@@ -357,11 +347,7 @@ export default function NotificationItem({
               className="padding-r-10"
               onClick={(e) => {
                 setSelectedId(item.id)
-                if (item.isRead) {
-                  setUnRead(item.id)
-                } else {
-                  setRead(item.id)
-                }
+                setRead(item.id, !item.isRead)
                 e.stopPropagation()
               }}
             >

--- a/cx-portal/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/cx-portal/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -33,7 +33,7 @@ import {
   SORT_OPTION,
   NOTIFICATION_TOPIC,
 } from 'features/notification/types'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { NavLink } from 'react-router-dom'
 import UserService from 'services/UserService'
@@ -214,7 +214,7 @@ export default function NotificationItem({
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
   const dispatch = useDispatch()
-  const [selectedId, setSelectedId] = useState<string>('')
+  const [userRead, setUserRead] = useState<boolean>(false)
 
   const setRead = async (id: string, value: boolean) => {
     try {
@@ -224,9 +224,14 @@ export default function NotificationItem({
     }
   }
 
+  useEffect(() => {
+    setUserRead(item.userRead)
+  }, [item.userRead])
+
   const toggle = async () => {
     const nextState = !open
-    if (nextState && !item.isRead) {
+    if (nextState && !userRead) {
+      setUserRead(true)
       void setRead(item.id, true)
     }
     setOpen(nextState)
@@ -263,15 +268,11 @@ export default function NotificationItem({
         />
       )}
       <li
-        onClick={() => {
-          toggle()
-          setSelectedId(item.id)
-        }}
+        onClick={toggle}
         style={{
-          backgroundColor:
-            item.isRead || selectedId === item.id
-              ? 'rgba(255, 255, 255, 1)'
-              : 'rgba(15, 113, 203, 0.05)',
+          backgroundColor: userRead
+            ? 'rgba(255, 255, 255, 1)'
+            : 'rgba(15, 113, 203, 0.05)',
           borderColor: open ? '#FDB943' : 'transparent',
         }}
       >
@@ -346,12 +347,12 @@ export default function NotificationItem({
             <div
               className="padding-r-10"
               onClick={(e) => {
-                setSelectedId(item.id)
-                setRead(item.id, !item.isRead)
+                setUserRead(!userRead)
+                setRead(item.id, userRead)
                 e.stopPropagation()
               }}
             >
-              {item.isRead || selectedId === item.id ? (
+              {userRead ? (
                 <Tooltips
                   additionalStyles={{
                     cursor: 'pointer',

--- a/cx-portal/src/components/pages/NotificationCenter/Notifications.scss
+++ b/cx-portal/src/components/pages/NotificationCenter/Notifications.scss
@@ -125,6 +125,10 @@
     padding-right: 5px;
   }
 
+  .padding-r-10 {
+    padding-right: 10px;
+  }
+
   .padding-l-5 {
     padding-left: 5px;
   }

--- a/cx-portal/src/components/pages/NotificationCenter/index.tsx
+++ b/cx-portal/src/components/pages/NotificationCenter/index.tsx
@@ -185,6 +185,7 @@ export default function NotificationCenter() {
     notificationItems.map((item) => ({
       ...item,
       contentParsed: item.content && JSON.parse(item.content),
+      userRead: item.isRead,
     })),
     (item: CXNotificationContent) => dayjs(item.created).format('YYYY-MM-DD')
   )

--- a/cx-portal/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
+++ b/cx-portal/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
@@ -67,7 +67,7 @@ export default function TechnicalUserDetailsContent({
       copy: true,
     },
   ]
-  
+
   return (
     <section>
       <Button

--- a/cx-portal/src/features/notification/apiSlice.ts
+++ b/cx-portal/src/features/notification/apiSlice.ts
@@ -66,7 +66,13 @@ export const apiSlice = createApi({
     }),
     setNotificationRead: builder.mutation<void, string>({
       query: (id) => ({
-        url: `/api/notification/${id}/read`,
+        url: `/api/notification/${id}/read?isRead=true`,
+        method: 'PUT',
+      }),
+    }),
+    setNotificationUnRead: builder.mutation<void, string>({
+      query: (id) => ({
+        url: `/api/notification/${id}/read?isRead=false`,
         method: 'PUT',
       }),
     }),
@@ -85,4 +91,5 @@ export const {
   useSetNotificationReadMutation,
   useDeleteNotificationMutation,
   useGetNotificationMetaQuery,
+  useSetNotificationUnReadMutation,
 } = apiSlice

--- a/cx-portal/src/features/notification/apiSlice.ts
+++ b/cx-portal/src/features/notification/apiSlice.ts
@@ -31,6 +31,11 @@ export interface NotificationArgsProps {
   notificationTopic: string
 }
 
+export interface NotificationReadType {
+  id: string
+  flag: boolean
+}
+
 export const apiSlice = createApi({
   reducerPath: 'info/notifications',
   baseQuery: fetchBaseQuery(apiBaseQuery()),
@@ -64,15 +69,9 @@ export const apiSlice = createApi({
       // configuration for an individual endpoint, overriding the api setting
       keepUnusedDataFor: 10,
     }),
-    setNotificationRead: builder.mutation<void, string>({
-      query: (id) => ({
-        url: `/api/notification/${id}/read?isRead=true`,
-        method: 'PUT',
-      }),
-    }),
-    setNotificationUnRead: builder.mutation<void, string>({
-      query: (id) => ({
-        url: `/api/notification/${id}/read?isRead=false`,
+    setNotificationRead: builder.mutation<void, NotificationReadType>({
+      query: (obj) => ({
+        url: `/api/notification/${obj.id}/read?isRead=${obj.flag}`,
         method: 'PUT',
       }),
     }),
@@ -91,5 +90,4 @@ export const {
   useSetNotificationReadMutation,
   useDeleteNotificationMutation,
   useGetNotificationMetaQuery,
-  useSetNotificationUnReadMutation,
 } = apiSlice

--- a/cx-portal/src/features/notification/types.ts
+++ b/cx-portal/src/features/notification/types.ts
@@ -124,6 +124,7 @@ export interface CXNotificationContent {
   notificationTopic?: string
   type?: string
   done?: boolean
+  userRead: boolean
 }
 
 export type CXNotificationMeta = {

--- a/cx-portal/src/features/notification/types.ts
+++ b/cx-portal/src/features/notification/types.ts
@@ -123,6 +123,7 @@ export interface CXNotificationContent {
   dueDate?: string
   notificationTopic?: string
   type?: string
+  done?: boolean
 }
 
 export type CXNotificationMeta = {


### PR DESCRIPTION
## Description

Show a tick mark for the notification which are all already addressed or required action taken.
Allow user to mark notification read/unread

## Why

Feature

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
