### PR TITLE
chore(shared-components): add deprecation note

### DIFF
--- a/cx-portal-shared-components/README.md
+++ b/cx-portal-shared-components/README.md
@@ -1,3 +1,10 @@
+# Deprecated!
+
+Note that this version of the library is discontinued and development will continue only in
+* Repository https://github.com/eclipse-tractusx/portal-shared-components
+* NPM Package https://www.npmjs.com/package/@catena-x/portal-shared-components
+
+
 # Catena-X Portal Shared UI Components
 
 Contains the shared UI components that are used to build the Catena-X Portal Frontend.

--- a/cx-portal-shared-components/README.md
+++ b/cx-portal-shared-components/README.md
@@ -1,6 +1,6 @@
 # Deprecated!
 
-Note that this version of the library is discontinued and development will continue only in
+Please note that this library is discontinued and development will continue only in:
 * Repository https://github.com/eclipse-tractusx/portal-shared-components
 * NPM Package https://www.npmjs.com/package/@catena-x/portal-shared-components
 

--- a/cx-portal-shared-components/README.md
+++ b/cx-portal-shared-components/README.md
@@ -10,13 +10,14 @@ Please note that this library is discontinued and development will continue only
 Contains the shared UI components that are used to build the Catena-X Portal Frontend.
 Get an overview about the available components here
 
-https://portal.dev.demo.catena-x.net/_storybook/
+    yarn start:storybook
 
 To use components in your own project follow this guide.
 First create a new react app and add dependencies for the library and Material UI.
 We are using yarn and TypeScript, if you prefer npm/npx or JavaScript use those.
 
     yarn create react-app sample-shared-components --template typescript
+    cd sample-shared-components
     yarn add cx-portal-shared-components @mui/icons-material @mui/material
 
 
@@ -40,28 +41,30 @@ Edit `src/index.tsx` and wrap the `App` with the CX `SharedThemeProvider` contex
 
 Edit `src/index.css` and add this stylings
 
+Note: replace <YOUR_PORTAL_HOSTNAME> with your installation host name.
+
     @font-face {
         font-family: "LibreFranklin-SemiBold";
         font-display: block;
-        src: url("https://portal.dev.demo.catena-x.net/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
+        src: url("https://<YOUR_PORTAL_HOSTNAME>/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
         font-weight: 600;
     }
     @font-face {
         font-family: "LibreFranklin-Medium";
         font-display: block;
-        src: url("https://portal.dev.demo.catena-x.net/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
+        src: url("https://<YOUR_PORTAL_HOSTNAME>/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
         font-weight: 500;
     }
     @font-face {
         font-family: "LibreFranklin";
         font-display: block;
-        src: url("https://portal.dev.demo.catena-x.net/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
+        src: url("https://<YOUR_PORTAL_HOSTNAME>/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
         font-weight: 400;
     }
     @font-face {
         font-family: "LibreFranklin-Light";
         font-display: block;
-        src: url("https://portal.dev.demo.catena-x.net/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
+        src: url("https://<YOUR_PORTAL_HOSTNAME>/assets/fonts/LibreFranklin-VariableFont_wght.ttf") format("truetype");
         font-weight: 300;
     }
 
@@ -78,4 +81,3 @@ Open `App.tsx` and replace the code with this example
     import { Button } from "cx-portal-shared-components";
     const App = () => <Button onClick={() => { alert('clicked') }}>Click me</Button>
     export default App;
-


### PR DESCRIPTION
## Description

Add a note the shared components are deprecated

## Why

The shared components are moving to a new repository location and npm package name. Make sure users are aware of this change and switch to the new version.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)