### PR TITLE
bugfix(service marketplace): clear state on change subscription service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
       * Service details page crash issue
    * App Release Process
       * App lead image load issue fix
+   * Service Marketplace
+      * Subscription Button cross service highlighted
 
 ## 1.5.0-RC1
 

--- a/cx-portal/src/components/pages/ServiceMarketplaceDetail/index.tsx
+++ b/cx-portal/src/components/pages/ServiceMarketplaceDetail/index.tsx
@@ -20,16 +20,20 @@
 import { Button } from 'cx-portal-shared-components'
 import { useNavigate, useParams } from 'react-router-dom'
 import { t } from 'i18next'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useEffect } from 'react'
 import MarketplaceContentDetails from './MarketplaceContentDetails'
 import './Marketplace.scss'
 import { useFetchServiceQuery } from 'features/serviceMarketplace/serviceApiSlice'
-import { currentSuccessType } from 'features/serviceMarketplace/slice'
+import {
+  currentSuccessType,
+  setSuccessType,
+} from 'features/serviceMarketplace/slice'
 
 export default function ServiceMarketplaceDetail() {
   const navigate = useNavigate()
   const { serviceId } = useParams()
+  const dispatch = useDispatch()
 
   const { data, refetch } = useFetchServiceQuery(serviceId ?? '')
 
@@ -44,7 +48,10 @@ export default function ServiceMarketplaceDetail() {
       <Button
         color="secondary"
         size="small"
-        onClick={() => navigate('/servicemarketplace')}
+        onClick={() => {
+          dispatch(setSuccessType(false))
+          navigate('/servicemarketplace')
+        }}
       >
         {t('global.actions.back')}
       </Button>


### PR DESCRIPTION
## Description

Clear already set success state back to false before navigating to another service

## Why

Service Subscription - Subscription Button cross service highlighted

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
