### PR TITLE
bugfix(apps): app details working with new shared components

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -38,7 +38,7 @@ yarn licenses v1.22.19
 │  ├─ @ampproject/remapping@2.2.1
 │  │  ├─ URL: git+https://github.com/ampproject/remapping.git
 │  │  └─ VendorName: Justin Ridgewell
-│  ├─ @catena-x/portal-shared-components@2.0.1
+│  ├─ @catena-x/portal-shared-components@2.0.2
 │  │  ├─ URL: https://github.com/eclipse-tractusx/portal-shared-components.git
 │  │  └─ VendorName: Catena-X Contributors
 │  ├─ @humanwhocodes/config-array@0.11.10
@@ -4698,4 +4698,3 @@ yarn licenses v1.22.19
    │  └─ URL: https://github.com/streamich/fs-monkey.git
    └─ memfs@3.5.3
       └─ URL: https://github.com/streamich/memfs.git
-Done in 0.46s.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^2.0.1",
+    "@catena-x/portal-shared-components": "^2.0.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",

--- a/src/components/overlays/AppMarketplaceRequest/index.tsx
+++ b/src/components/overlays/AppMarketplaceRequest/index.tsx
@@ -25,11 +25,11 @@ import {
   Typography,
   Checkbox,
   OrderStatusButton,
+  paletteDefinitions,
 } from '@catena-x/portal-shared-components'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { useState } from 'react'
-import { useTheme } from '@mui/material'
 import {
   AgreementRequest,
   useAddSubscribeAppMutation,
@@ -43,7 +43,6 @@ import './AppMarketplaceRequest.scss'
 export default function AppMarketplaceRequest({ id }: { id: string }) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
-  const theme = useTheme()
 
   const { data } = useFetchAppDetailsQuery(id ?? '')
   const { data: agreements } = useFetchAgreementsQuery(id ?? '')
@@ -61,19 +60,19 @@ export default function AppMarketplaceRequest({ id }: { id: string }) {
       isIcon: false,
       buttonLabel: t('content.appdetail.buttons.subscribtionInit'),
       zIndex: 4,
-      backgroundColor: theme.palette.buttons.darkGrey ?? '',
+      backgroundColor: paletteDefinitions.buttons.darkGrey ?? '',
     },
     {
       isIcon: false,
       buttonLabel: t('content.appdetail.buttons.appDeployed'),
       zIndex: 3,
-      backgroundColor: theme.palette.buttons.lightGrey ?? '',
+      backgroundColor: paletteDefinitions.buttons.lightGrey ?? '',
     },
     {
       isIcon: false,
       buttonLabel: t('content.appdetail.buttons.activation'),
       zIndex: 2,
-      backgroundColor: theme.palette.buttons.white ?? '',
+      backgroundColor: paletteDefinitions.buttons.white ?? '',
     },
   ]
 

--- a/src/components/pages/AppDetail/components/AppDetailHeader/index.tsx
+++ b/src/components/pages/AppDetail/components/AppDetailHeader/index.tsx
@@ -22,8 +22,8 @@ import { useSelector, useDispatch } from 'react-redux'
 import {
   Typography,
   OrderStatusButton,
+  paletteDefinitions,
 } from '@catena-x/portal-shared-components'
-import { useTheme } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import { AppDetails } from 'features/apps/details/types'
 import { userSelector } from 'features/user/slice'
@@ -57,7 +57,6 @@ export interface ButtonColorType {
 
 export default function AppDetailHeader({ item }: AppDetailHeaderProps) {
   const { t } = useTranslation()
-  const theme = useTheme()
   const dispatch = useDispatch()
   const { appId } = useParams()
   const user = useSelector(userSelector)
@@ -80,17 +79,17 @@ export default function AppDetailHeader({ item }: AppDetailHeaderProps) {
       case SubscriptionStatus.ACTIVE:
         btnColor = {
           color: 'success',
-          background1: theme.palette.buttons.yellow ?? '',
-          background2: theme.palette.buttons.yellow ?? '',
-          background3: theme.palette.buttons.yellow ?? '',
+          background1: paletteDefinitions.buttons.yellow ?? '',
+          background2: paletteDefinitions.buttons.yellow ?? '',
+          background3: paletteDefinitions.buttons.yellow ?? '',
         }
         break
       case SubscriptionStatus.PENDING:
         btnColor = {
           color: 'warning',
-          background1: theme.palette.buttons.yellow ?? '',
-          background2: theme.palette.buttons.lightGrey ?? '',
-          background3: theme.palette.buttons.white ?? '',
+          background1: paletteDefinitions.buttons.yellow ?? '',
+          background2: paletteDefinitions.buttons.lightGrey ?? '',
+          background3: paletteDefinitions.buttons.white ?? '',
         }
         break
       default:
@@ -100,9 +99,9 @@ export default function AppDetailHeader({ item }: AppDetailHeaderProps) {
             user.roles.indexOf(Roles.SUBSCRIBE_SERVICE) !== -1
               ? 'primary'
               : 'secondary',
-          background1: theme.palette.buttons.darkGrey ?? '',
-          background2: theme.palette.buttons.lightGrey ?? '',
-          background3: theme.palette.buttons.white ?? '',
+          background1: paletteDefinitions.buttons.darkGrey ?? '',
+          background2: paletteDefinitions.buttons.lightGrey ?? '',
+          background3: paletteDefinitions.buttons.white ?? '',
         }
     }
     return btnColor

--- a/yarn.lock
+++ b/yarn.lock
@@ -1175,10 +1175,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.0.1.tgz#98858cf567ee3a22bbee39ff33b41c2dad862bcc"
-  integrity sha512-0F8WAA+q7nh/2PBB7fnG/siQgrIMf0iFb2WP7rx1jZ0DwFaAUpgYUyX8HvrM60/XAS118jjn6MDnkvZqkUn8nA==
+"@catena-x/portal-shared-components@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.0.2.tgz#3fcd820b878ed3f0173e67eb399bf0f943cab043"
+  integrity sha512-Qep4qvCEqSZeRsorLce6uIgluwQ9f++UUPnjkTdG8ipnn3Uq28BZNiPcwHBjoDEFwQsjb3Uo/9RztNmaxQvEiQ==
   dependencies:
     "@mui/base" "^5.0.0-beta.3"
     "@mui/system" "^5.13.2"


### PR DESCRIPTION
## Description

App Details page broken after switch to new shared components.

## Why

The Material UI upgrade broke some exports which caused an error on app details page.

## Issue

JIRA: CPLP-2914

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
