### PR TITLE
chore(dependencies): run on push to dev

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -21,7 +21,7 @@ name: Check Dependencies
 
 on:
   push:
-    branches: [ main ]
+    branches: [main, dev]
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
## Description

run dependencies check on push to dev

## Why

missed at https://github.com/eclipse-tractusx/portal-frontend/pull/102

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own changes
