### PR TITLE
chore: don't exit at dependencies file update

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate Dependencies file
-        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true
 
       - name: Check if dependencies were changed
         id: dependencies-changed


### PR DESCRIPTION
## Description

don't exit at dependencies file update

## Why

restricted entries are checked in later step


## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
