### PR TITLE
bugfix(notification): remove onlyDueDate=true

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -55,9 +55,9 @@ npm/npmjs/-/babel-plugin-istanbul/6.1.1, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/babel-plugin-jest-hoist/27.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/babel-plugin-macros/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/babel-plugin-named-asset-import/0.3.8, MIT, approved, clearlydefined
-npm/npmjs/-/babel-plugin-polyfill-corejs2/0.4.3, MIT, approved, clearlydefined
-npm/npmjs/-/babel-plugin-polyfill-corejs3/0.8.1, MIT, approved, clearlydefined
-npm/npmjs/-/babel-plugin-polyfill-regenerator/0.5.0, MIT, approved, clearlydefined
+npm/npmjs/-/babel-plugin-polyfill-corejs2/0.4.3, MIT, approved, #9309
+npm/npmjs/-/babel-plugin-polyfill-corejs3/0.8.1, MIT, approved, #9316
+npm/npmjs/-/babel-plugin-polyfill-regenerator/0.5.0, MIT, approved, #9310
 npm/npmjs/-/babel-plugin-transform-react-remove-prop-types/0.4.24, MIT, approved, clearlydefined
 npm/npmjs/-/babel-preset-current-node-syntax/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/babel-preset-jest/27.5.1, MIT, approved, clearlydefined
@@ -1003,7 +1003,7 @@ npm/npmjs/@babel/helper-builder-binary-assignment-operator-visitor/7.22.5, MIT A
 npm/npmjs/@babel/helper-compilation-targets/7.22.5, MIT, approved, #9037
 npm/npmjs/@babel/helper-create-class-features-plugin/7.22.5, MIT, approved, #8985
 npm/npmjs/@babel/helper-create-regexp-features-plugin/7.22.5, MIT, approved, #8950
-npm/npmjs/@babel/helper-define-polyfill-provider/0.4.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/helper-define-polyfill-provider/0.4.0, MIT, approved, #9314
 npm/npmjs/@babel/helper-environment-visitor/7.22.5, MIT, approved, #8934
 npm/npmjs/@babel/helper-function-name/7.22.5, MIT, approved, #9071
 npm/npmjs/@babel/helper-hoist-variables/7.22.5, MIT, approved, #8957
@@ -1191,7 +1191,7 @@ npm/npmjs/@jest/types/29.5.0, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/gen-mapping/0.3.3, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/resolve-uri/3.1.0, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/set-array/1.1.2, MIT, approved, clearlydefined
-npm/npmjs/@jridgewell/source-map/0.3.3, MIT, approved, clearlydefined
+npm/npmjs/@jridgewell/source-map/0.3.3, MIT, approved, #9304
 npm/npmjs/@jridgewell/sourcemap-codec/1.4.14, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/sourcemap-codec/1.4.15, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/trace-mapping/0.3.18, MIT, approved, clearlydefined

--- a/src/features/notification/apiSlice.ts
+++ b/src/features/notification/apiSlice.ts
@@ -58,12 +58,6 @@ export const apiSlice = createApi({
         ) {
           base += `&notificationTopicId=${fetchArgs.args.notificationTopic}`
         }
-        if (
-          fetchArgs.args.notificationTopic &&
-          fetchArgs.args.notificationTopic === NOTIFICATION_TOPIC.ACTION
-        ) {
-          base += '&onlyDueDate=true'
-        }
         return base
       },
       // configuration for an individual endpoint, overriding the api setting


### PR DESCRIPTION
## Description

remove onlyDueDate=true query parameter from url for action required option

## Why

bugfix

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
