### PR TITLE
bugfix(static page): fix inline scroll height

### DIFF
--- a/src/components/shared/templates/StaticTemplateResponsive/Cards/TitleDescriptionAndSectionlink.tsx
+++ b/src/components/shared/templates/StaticTemplateResponsive/Cards/TitleDescriptionAndSectionlink.tsx
@@ -37,9 +37,9 @@ export default function TitleDescriptionAndSectionlink({
   const navigateTo = (link: { internal: boolean; id: string }) => {
     if (link.internal) {
       const element = document.getElementById(link.id)
-      const top = element?.offsetTop
+      const top = element && element.offsetTop - 200
       window.scrollTo({
-        top: top,
+        top: top || 0,
         behavior: 'smooth',
       })
     } else {

--- a/src/components/shared/templates/StaticTemplateResponsive/Cards/TitleDescriptionAndSectionlink.tsx
+++ b/src/components/shared/templates/StaticTemplateResponsive/Cards/TitleDescriptionAndSectionlink.tsx
@@ -39,7 +39,7 @@ export default function TitleDescriptionAndSectionlink({
       const element = document.getElementById(link.id)
       const top = element && element.offsetTop - 200
       window.scrollTo({
-        top: top || 0,
+        top: top ?? 0,
         behavior: 'smooth',
       })
     } else {


### PR DESCRIPTION
## Description

element placed behind the stage navigation header on scroll to top. subtract the offset value with 200 to stop just before the stage header navigation

## Why

not able to see the section title

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally