### PR TITLE
bugfix(portal): add max width to the portal body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 - Static Pages
   - Data Space
   - Catena-X Participant
+- Portal
+  - Add max width
 
 ## 1.5.0
 

--- a/src/components/styles/main.scss
+++ b/src/components/styles/main.scss
@@ -24,12 +24,13 @@
 @import 'stage';
 
 body {
-  margin: 0;
   min-height: 100vh;
   font-family: 'LibreFranklin', 'Libre Franklin', 'Franklin Gothic Medium',
     'Arial Narrow', Arial, sans-serif !important;
   color: color(text-primary) !important;
   font-weight: 300 !important;
+  max-width: 1800px;
+  margin: auto !important;
 }
 
 #app {


### PR DESCRIPTION
## Description

add max width to the portal body

## Why

contents are getting smaller on zoom out
Positive Example - Microsoft Page

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/127

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally