### PR TITLE
fix(app-release-process): selected values disappears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
   - New Header and Filter UI
 - App Release Process
   - App lead image load issue fix
+  - Fixed issue-upon upload of the conformity certificate, previous selected consents are gone
   - Service Marketplace
     - Subscription Button cross service highlighted
 - BugFix

--- a/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
@@ -587,30 +587,6 @@ export default function AppPage() {
                 }}
                 errorText={t('content.apprelease.appReleaseForm.fileSizeError')}
               />
-              {item === 'uploadDataPrerequisits' &&
-                errors?.uploadDataPrerequisits?.type === ErrorType.REQUIRED && (
-                  <Typography variant="body2" className="file-error-msg">
-                    {t(
-                      'content.apprelease.appReleaseForm.fileUploadIsMandatory'
-                    )}
-                  </Typography>
-                )}
-              {item === 'uploadTechnicalGuide' &&
-                errors?.uploadTechnicalGuide?.type === ErrorType.REQUIRED && (
-                  <Typography variant="body2" className="file-error-msg">
-                    {t(
-                      'content.apprelease.appReleaseForm.fileUploadIsMandatory'
-                    )}
-                  </Typography>
-                )}
-              {item === 'uploadAppContract' &&
-                errors?.uploadAppContract?.type === ErrorType.REQUIRED && (
-                  <Typography variant="body2" className="file-error-msg">
-                    {t(
-                      'content.apprelease.appReleaseForm.fileUploadIsMandatory'
-                    )}
-                  </Typography>
-                )}
             </div>
           </div>
         ))}

--- a/src/components/shared/basic/ReleaseProcess/ContractAndConsent/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/ContractAndConsent/index.tsx
@@ -45,12 +45,9 @@ export default function ContractAndConsent() {
   }).data
   const [updateAgreementConsents] = useUpdateAgreementConsentsMutation()
   const [updateDocumentUpload] = useUpdateDocumentUploadMutation()
-  const { data: fetchAppStatus, isFetching } = useFetchAppStatusQuery(
-    appId ?? '',
-    {
-      refetchOnMountOrArgChange: true,
-    }
-  )
+  const { data: fetchAppStatus } = useFetchAppStatusQuery(appId ?? '', {
+    refetchOnMountOrArgChange: true,
+  })
   const [getDocumentById] = useFetchNewDocumentByIdMutation()
   const [fetchFrameDocumentById] = useFetchFrameDocumentByIdMutation()
 
@@ -60,47 +57,45 @@ export default function ContractAndConsent() {
 
   return (
     <div className="contract-consent">
-      {!isFetching && (
-        <CommonContractAndConsent
-          type={ReleaseProcessTypes.APP_RELEASE}
-          stepperTitle={t('content.apprelease.contractAndConsent.headerTitle')}
-          stepperDescription={t(
-            'content.apprelease.contractAndConsent.headerDescription'
-          )}
-          checkBoxMandatoryText={t(
-            'content.apprelease.appReleaseForm.isMandatory'
-          )}
-          imageFieldLabel={
-            t('content.apprelease.contractAndConsent.uploadImageConformity') +
-            ' *'
-          }
-          pageSnackbarDescription={t(
-            'content.apprelease.appReleaseForm.dataSavedSuccessMessage'
-          )}
-          pageNotificationObject={{
-            title: t('content.apprelease.appReleaseForm.error.title'),
-            description: t('content.apprelease.appReleaseForm.error.message'),
-          }}
-          imageFieldNoDescription={t(
-            'content.apprelease.appReleaseForm.OnlyOneFileAllowed'
-          )}
-          imageFieldNote={t('content.apprelease.appReleaseForm.note')}
-          imageFieldRequiredText={t(
-            'content.apprelease.appReleaseForm.fileUploadIsMandatory'
-          )}
-          id={appId ?? ''}
-          fetchAgreementData={fetchAgreementData || []}
-          fetchConsentData={fetchConsentData}
-          updateAgreementConsents={updateAgreementConsents}
-          updateDocumentUpload={updateDocumentUpload}
-          fetchStatusData={fetchAppStatus || undefined}
-          getDocumentById={getDocumentById}
-          fetchFrameDocumentById={fetchFrameDocumentById}
-          helpUrl={
-            '/documentation/?path=docs%2F04.+App%28s%29%2F02.+App+Release+Process'
-          }
-        />
-      )}
+      <CommonContractAndConsent
+        type={ReleaseProcessTypes.APP_RELEASE}
+        stepperTitle={t('content.apprelease.contractAndConsent.headerTitle')}
+        stepperDescription={t(
+          'content.apprelease.contractAndConsent.headerDescription'
+        )}
+        checkBoxMandatoryText={t(
+          'content.apprelease.appReleaseForm.isMandatory'
+        )}
+        imageFieldLabel={
+          t('content.apprelease.contractAndConsent.uploadImageConformity') +
+          ' *'
+        }
+        pageSnackbarDescription={t(
+          'content.apprelease.appReleaseForm.dataSavedSuccessMessage'
+        )}
+        pageNotificationObject={{
+          title: t('content.apprelease.appReleaseForm.error.title'),
+          description: t('content.apprelease.appReleaseForm.error.message'),
+        }}
+        imageFieldNoDescription={t(
+          'content.apprelease.appReleaseForm.OnlyOneFileAllowed'
+        )}
+        imageFieldNote={t('content.apprelease.appReleaseForm.note')}
+        imageFieldRequiredText={t(
+          'content.apprelease.appReleaseForm.fileUploadIsMandatory'
+        )}
+        id={appId ?? ''}
+        fetchAgreementData={fetchAgreementData || []}
+        fetchConsentData={fetchConsentData}
+        updateAgreementConsents={updateAgreementConsents}
+        updateDocumentUpload={updateDocumentUpload}
+        fetchStatusData={fetchAppStatus || undefined}
+        getDocumentById={getDocumentById}
+        fetchFrameDocumentById={fetchFrameDocumentById}
+        helpUrl={
+          '/documentation/?path=docs%2F04.+App%28s%29%2F02.+App+Release+Process'
+        }
+      />
     </div>
   )
 }

--- a/src/components/shared/basic/ReleaseProcess/components/CommonContractAndConsent.tsx
+++ b/src/components/shared/basic/ReleaseProcess/components/CommonContractAndConsent.tsx
@@ -133,6 +133,12 @@ export default function CommonContractAndConsent({
 
   useEffect(() => {
     deleteResponse.isSuccess && setDeleteSuccess(true)
+    if (deleteResponse.isError) {
+      resetField('uploadImageConformity', {
+        defaultValue:
+          fetchStatusData?.documents?.CONFORMITY_APPROVAL_BUSINESS_APPS ?? null,
+      })
+    }
   }, [deleteResponse])
 
   const deleteDocument = async (documentId: string) => {
@@ -171,6 +177,7 @@ export default function CommonContractAndConsent({
     reset,
     getValues,
     setValue,
+    resetField,
   } = useForm({
     defaultValues: defaultValues,
     mode: 'onChange',


### PR DESCRIPTION
## Description

Fixed issue - upon upload of the conformity certificate, previous selected consents are gone

## Why

Previously selected checkbox values are changed on conformity document change

## Issue

Ref: CPLP-2885

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
