### PR TITLE
bugfix(connector): technicalUserId stays empty

### DIFF
--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -154,7 +154,7 @@ const EdcConnector = () => {
     } else if (selectedService.type === ConnectType.MANAGED_CONNECTOR) {
       // body.append('providerBpn', data.ConnectorBPN)
       body.append('subscriptionId', data.ConnectorSubscription.subscriptionId)
-      body.append('technicalUserId', data.ConnectorSubscription.subscriptionId)
+      body.append('technicalUserId', '')
       await createManagedConnector(body)
         .unwrap()
         .then(() => showOverlay(true))


### PR DESCRIPTION
## Description

remove subscriptionId from technicalUserId attribute and pass empty

## Why

technicalUserId should not have any value. It stays empty

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally