### PR TITLE
bugfix(config): change app management page role

### DIFF
--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -202,7 +202,7 @@ export const ALL_PAGES: IPage[] = [
   },
   {
     name: PAGES.APP_MANAGEMENT,
-    role: ROLES.SERVICEMANAGEMENT_VIEW,
+    role: ROLES.APPMANAGEMENT_VIEW,
     element: <AppOverview />,
   },
   {


### PR DESCRIPTION
## Description

change app management page role. it should be add_apps

## Why

app management page has add_service_offering as role.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally