### PR TITLE
updates(notification): add credential approval, credential reject and subscription url msgs

### DIFF
--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -87,6 +87,14 @@
     "title": "Assigned User Roles Updated - {{app}}",
     "content": "Hallo {{username}}, \n\nIhre App-Benutzerrollen wurden von Ihrem Unternehmensadministrator aktualisiert. Mit dem Wechsel der Rolle ändern sich Ihre Zugriffsrechte. Weitere Einzelheiten zu den Rollenänderungen finden sie anbei. \n\nHinzugefügte Rollen: {{addedRoles}} \n\nEntfernte Rollen: {{removedRoles}}"
   },
+  "CREDENTIAL_APPROVAL": {
+    "title": "Verified Credential {{credentialType}} angelegt",
+    "content": "Verified Credential {{credentialType}} wurde ihrem Company Wallet hinzugefügt."
+  },
+  "CREDENTIAL_REJECTED": {
+    "title": "Verified Credential {{credentialType}} abgelehnt",
+    "content": "Verified Credential {{credentialType}} wurde abgelehnt. Sie können jederzeit die Anfrage wiederholen."
+  },
   "link": {
     "appmarketplace": "Zum App Marketplace",
     "technicalsetup": "Zur Connector Registrierung",

--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -95,6 +95,10 @@
     "title": "Verified Credential {{credentialType}} abgelehnt",
     "content": "Verified Credential {{credentialType}} wurde abgelehnt. Sie können jederzeit die Anfrage wiederholen."
   },
+  "SUBSCRIPTION_URL_UPDATE": {
+    "title": "App URL {{appName}} updated",
+    "content": "Der App Provider hat die hinterlegte App Instance URL für ihre abonnierte App {{appName}} geändert. Neue URL: {{newUrl}}"
+  },
   "link": {
     "appmarketplace": "Zum App Marketplace",
     "technicalsetup": "Zur Connector Registrierung",

--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -96,8 +96,8 @@
     "content": "Verified Credential {{credentialType}} wurde abgelehnt. Sie können jederzeit die Anfrage wiederholen."
   },
   "SUBSCRIPTION_URL_UPDATE": {
-    "title": "App URL {{appName}} updated",
-    "content": "Der App Provider hat die hinterlegte App Instance URL für ihre abonnierte App {{appName}} geändert.\n\nNeue URL: {{newUrl}}"
+    "title": "App URL {{app}} updated",
+    "content": "Der App Provider hat die hinterlegte App Instance URL für ihre abonnierte App {{app}} geändert.\n\nNeue URL: {{newUrl}}"
   },
   "link": {
     "appmarketplace": "Zum App Marketplace",

--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -97,7 +97,7 @@
   },
   "SUBSCRIPTION_URL_UPDATE": {
     "title": "App URL {{appName}} updated",
-    "content": "Der App Provider hat die hinterlegte App Instance URL für ihre abonnierte App {{appName}} geändert. Neue URL: {{newUrl}}"
+    "content": "Der App Provider hat die hinterlegte App Instance URL für ihre abonnierte App {{appName}} geändert.\n\nNeue URL: {{newUrl}}"
   },
   "link": {
     "appmarketplace": "Zum App Marketplace",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -92,8 +92,8 @@
     "content": "Verified Credential {{credentialType}} got declined. You can start a new request immediately."
   },
   "SUBSCRIPTION_URL_UPDATE": {
-    "title": "App URL {{appName}} updated",
-    "content": "The app provider has changed the stored App Instance URL for your subscribed app {{appName}}.\n\nNew URL: {{newUrl}}"
+    "title": "App URL {{app}} updated",
+    "content": "The app provider has changed the stored App Instance URL for your subscribed app {{app}}.\n\nNew URL: {{newUrl}}"
   },
   "link": {
     "appmarketplace": "Go to app marketplace",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -83,6 +83,14 @@
     "title": "Assigned User Roles Updated - {{app}}",
     "content": "Hallo {{username}}, \n\nyour app user roles got updated by your company administrator. With the change of the role assignment your access rights have changed. You can find all details regarding the role change below. \n\nNew Roles: {{addedRoles}} \n\nRemoved Roles: {{removedRoles}}"
   },
+  "CREDENTIAL_APPROVAL": {
+    "title": "Verified Credential {{credentialType}} assigned",
+    "content": "Verified Credential {{credentialType}} got assigned to your company wallet."
+  },
+  "CREDENTIAL_REJECTED": {
+    "title": "Verified Credential {{credentialType}} declined",
+    "content": "Verified Credential {{credentialType}} got declined. You can start a new request immediately."
+  },
   "link": {
     "appmarketplace": "Go to app marketplace",
     "technicalsetup": "Go to connector configuration",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -93,7 +93,7 @@
   },
   "SUBSCRIPTION_URL_UPDATE": {
     "title": "App URL {{appName}} updated",
-    "content": "The app provider has changed the stored App Instance URL for your subscribed app {{appName}}. New URL: {{newUrl}}"
+    "content": "The app provider has changed the stored App Instance URL for your subscribed app {{appName}}.\n\nNew URL: {{newUrl}}"
   },
   "link": {
     "appmarketplace": "Go to app marketplace",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -91,6 +91,10 @@
     "title": "Verified Credential {{credentialType}} declined",
     "content": "Verified Credential {{credentialType}} got declined. You can start a new request immediately."
   },
+  "SUBSCRIPTION_URL_UPDATE": {
+    "title": "App URL {{appName}} updated",
+    "content": "The app provider has changed the stored App Instance URL for your subscribed app {{appName}}. New URL: {{newUrl}}"
+  },
   "link": {
     "appmarketplace": "Go to app marketplace",
     "technicalsetup": "Go to connector configuration",

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -88,6 +88,7 @@ const NotificationContent = ({
   const coreOfferName = item.contentParsed?.coreOfferName
   const removedRoles = item.contentParsed?.removedRoles
   const addedRoles = item.contentParsed?.addedRoles
+  const credentialType = item.contentParsed?.type
 
   return (
     <>
@@ -104,6 +105,7 @@ const NotificationContent = ({
             coreOfferName: coreOfferName,
             removedRoles: removedRoles ? removedRoles : '-',
             addedRoles: addedRoles ? addedRoles : '-',
+            credentialType: credentialType,
           }}
         >
           <NameLink
@@ -197,6 +199,10 @@ const NotificationConfig = ({ item }: { item: CXNotificationContent }) => {
       return <NotificationContent item={item} />
     case NotificationType.ROLE_UPDATE_CORE_OFFER:
       return <NotificationContent item={item} navlinks={[PAGES.ROLE_DETAILS]} />
+    case NotificationType.CREDENTIAL_APPROVAL:
+      return <NotificationContent item={item} />
+    case NotificationType.CREDENTIAL_REJECTED:
+      return <NotificationContent item={item} />
     default:
       return <pre>{JSON.stringify(item, null, 2)}</pre>
   }
@@ -317,6 +323,7 @@ export default function NotificationItem({
               {t(`${item.typeId}.title`, {
                 app: item.contentParsed?.AppName ?? item.contentParsed?.appName,
                 offer: item.contentParsed?.OfferName,
+                credentialType: item.contentParsed?.type,
               })}
             </Typography>
             {open && (

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -81,7 +81,7 @@ const NotificationContent = ({
   const userId = item.contentParsed?.userId
   const appId = item.contentParsed?.appId
   const you = UserService.getName()
-  const appName = item.contentParsed?.AppName
+  const appName = item.contentParsed?.AppName ?? item.contentParsed?.appName
   const companyName = item.contentParsed?.RequestorCompanyName
   const offerName = item.contentParsed?.OfferName
   const userName = item.contentParsed?.username
@@ -89,6 +89,7 @@ const NotificationContent = ({
   const removedRoles = item.contentParsed?.removedRoles
   const addedRoles = item.contentParsed?.addedRoles
   const credentialType = item.contentParsed?.type
+  const newUrl = item.contentParsed?.newUrl
 
   return (
     <>
@@ -106,6 +107,7 @@ const NotificationContent = ({
             removedRoles: removedRoles ? removedRoles : '-',
             addedRoles: addedRoles ? addedRoles : '-',
             credentialType: credentialType,
+            newUrl: newUrl,
           }}
         >
           <NameLink
@@ -202,6 +204,8 @@ const NotificationConfig = ({ item }: { item: CXNotificationContent }) => {
     case NotificationType.CREDENTIAL_APPROVAL:
       return <NotificationContent item={item} />
     case NotificationType.CREDENTIAL_REJECTED:
+      return <NotificationContent item={item} />
+    case NotificationType.SUBSCRIPTION_URL_UPDATE:
       return <NotificationContent item={item} />
     default:
       return <pre>{JSON.stringify(item, null, 2)}</pre>

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -96,6 +96,8 @@ export enum NotificationType {
   SERVICE_RELEASE_REQUEST = 'SERVICE_RELEASE_REQUEST',
   ROLE_UPDATE_APP_OFFER = 'ROLE_UPDATE_APP_OFFER',
   ROLE_UPDATE_CORE_OFFER = 'ROLE_UPDATE_CORE_OFFER',
+  CREDENTIAL_REJECTED = 'CREDENTIAL_REJECTED',
+  CREDENTIAL_APPROVAL = 'CREDENTIAL_APPROVAL',
 }
 
 export interface NotificationContent {
@@ -110,6 +112,7 @@ export interface NotificationContent {
   appName?: string
   removedRoles?: string
   addedRoles?: string
+  type?: string | number
 }
 
 export interface CXNotificationContent {

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -98,6 +98,7 @@ export enum NotificationType {
   ROLE_UPDATE_CORE_OFFER = 'ROLE_UPDATE_CORE_OFFER',
   CREDENTIAL_REJECTED = 'CREDENTIAL_REJECTED',
   CREDENTIAL_APPROVAL = 'CREDENTIAL_APPROVAL',
+  SUBSCRIPTION_URL_UPDATE = 'SUBSCRIPTION_URL_UPDATE',
 }
 
 export interface NotificationContent {
@@ -113,6 +114,7 @@ export interface NotificationContent {
   removedRoles?: string
   addedRoles?: string
   type?: string | number
+  newUrl?: string
 }
 
 export interface CXNotificationContent {


### PR DESCRIPTION
## Description

create new json text for CREDENTIAL_APPROVAL, CREDENTIAL_REJECTED and SUBSCRIPTION_URL_UPDATE in notification page.
Show credentailType , appName and newUrl in both title and description

## Why

CREDENTIAL_APPROVAL & CREDENTIAL_REJECTED shows raw json

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally