### PR TITLE
fix(sub menu-description): fixed page break

### DIFF
--- a/src/components/pages/AppOverview/ChangeDescription.tsx
+++ b/src/components/pages/AppOverview/ChangeDescription.tsx
@@ -55,10 +55,10 @@ export default function ChangeDescription() {
 
   const defaultValues = useMemo(() => {
     return {
-      longDescriptionEN: description?.[0].longDescription ?? '',
-      longDescriptionDE: description?.[1].longDescription ?? '',
-      shortDescriptionEN: description?.[0].shortDescription ?? '',
-      shortDescriptionDE: description?.[1].shortDescription ?? '',
+      longDescriptionEN: description?.[0]?.longDescription ?? '',
+      longDescriptionDE: description?.[1]?.longDescription ?? '',
+      shortDescriptionEN: description?.[0]?.shortDescription ?? '',
+      shortDescriptionDE: description?.[1]?.shortDescription ?? '',
     }
   }, [description])
 
@@ -247,7 +247,7 @@ export default function ChangeDescription() {
           <TabPanel value={activeTab} index={1}>
             <div className="form-field">
               {['shortDescriptionEN', 'shortDescriptionDE'].map(
-                (item: string, i) => (
+                (item: string) => (
                   <div key={item}>
                     <ConnectorFormInputFieldShortAndLongDescription
                       {...{


### PR DESCRIPTION

## Description

Fixed page break issue when api response don't have value for each language

## Why

To fix page break

## Issue

Ref: CPLP-1558

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally