### PR TITLE
bugfix(notification): fix go to use case link issue

### DIFF
--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -93,7 +93,7 @@
     "home": "Zur Startseite",
     "app": "Zur App",
     "user": "Zum Benutzer",
-    "usecases": "Zu den Use Cases",
+    "usecase": "Zu den Use Case",
     "serviceprovider": "Go to service provider",
     "appmanagementboard": "App Management Board öffnen",
     "servicemanagementboard": "Service Management Board öffnen",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -89,7 +89,7 @@
     "home": "Go to home page",
     "app": "Go to app",
     "user": "Go to user",
-    "usecases": "Go to use cases",
+    "usecase": "Go to Use Case",
     "serviceprovider": "Go to service provider",
     "appmanagementboard": "Get there",
     "servicemanagementboard": "Get there",

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -155,7 +155,7 @@ const NotificationConfig = ({ item }: { item: CXNotificationContent }) => {
     case NotificationType.WELCOME_CONNECTOR_REGISTRATION:
       return <NotificationContent item={item} navlinks={['technicalsetup']} />
     case NotificationType.WELCOME_USE_CASES:
-      return <NotificationContent item={item} navlinks={['usecases']} />
+      return <NotificationContent item={item} navlinks={['usecase']} />
     case NotificationType.WELCOME_SERVICE_PROVIDER:
       return (
         <NotificationContent


### PR DESCRIPTION
## Description

fix typo -> use usecase instead of usecases

## Why

"Nofications" page: link "go to use cases" doesn't work

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally