### PR TITLE
bugfix(connectors): do not allow confirm without customer link

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -539,9 +539,10 @@
             "tooltipMsg": "Laden Sie das Zertifikat hoch, das die öffentlichen Schlüsselinformationen Ihres Connectors enthält."
           },
           "subscription": {
-            "label": "Customer Link",
+            "label": "Customer Link*",
             "placeholder": "Select the related subscription",
-            "tooltipMsg": "Select the related subscription"
+            "tooltipMsg": "Select the related subscription",
+            "error": "Customer link is mandatory"
           }
         },
         "create": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -538,9 +538,10 @@
             "tooltipMsg": "Upload the certificate that contains your connector's public key information."
           },
           "subscription": {
-            "label": "Customer Link",
+            "label": "Customer Link*",
             "placeholder": "Select the related subscription",
-            "tooltipMsg": "Select the related subscription"
+            "tooltipMsg": "Select the related subscription",
+            "error": "Customer link is mandatory"
           }
         },
         "create": {

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -348,7 +348,6 @@ const ConnectorInsertForm = ({
                       name: 'ConnectorSubscriptionId',
                       rules: {
                         required: true,
-                        pattern: Patterns.connectors.CUSTOMER_LINK,
                       },
                       label: t(
                         'content.edcconnector.modal.insertform.subscription.label'

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -162,7 +162,7 @@ const ConnectorFormInput = ({
               variant="h2"
               sx={{
                 fontSize: '14px',
-                color: !!errors[name] ? '#d32f2f' : '#111111',
+                color: errors[name] ? '#d32f2f' : '#111111',
                 fontWeight: '400',
                 paddingRight: '10px',
               }}

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -162,7 +162,7 @@ const ConnectorFormInput = ({
               variant="h2"
               sx={{
                 fontSize: '14px',
-                color: '#111111',
+                color: !!errors[name] ? '#d32f2f' : '#111111',
                 fontWeight: '400',
                 paddingRight: '10px',
               }}
@@ -191,12 +191,14 @@ const ConnectorFormInput = ({
             render={({ field: { onChange, value } }) => {
               return (
                 <SelectList
+                  error={!!errors[name]}
+                  helperText={helperText}
                   defaultValue={defaultSelectValue}
                   items={items}
                   label={''}
                   placeholder={placeholder}
                   onChangeItem={(e) => {
-                    onChange(e)
+                    onChange(e ? e.subscriptionId : '')
                   }}
                   keyTitle={keyTitle}
                 />
@@ -343,7 +345,11 @@ const ConnectorInsertForm = ({
                       trigger,
                       errors,
                       type: 'select',
-                      name: 'ConnectorSubscription',
+                      name: 'ConnectorSubscriptionId',
+                      rules: {
+                        required: true,
+                        pattern: Patterns.connectors.CUSTOMER_LINK,
+                      },
                       label: t(
                         'content.edcconnector.modal.insertform.subscription.label'
                       ),
@@ -352,6 +358,9 @@ const ConnectorInsertForm = ({
                       ),
                       tooltipMsg: t(
                         'content.edcconnector.modal.insertform.subscription.tooltipMsg'
+                      ),
+                      helperText: t(
+                        'content.edcconnector.modal.insertform.subscription.error'
                       ),
                       items: subscriptions,
                       defaultSelectValue: {},

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Dialog,
@@ -33,7 +33,6 @@ import ConnectorInsertForm from './components/ConnectorInsertForm'
 import { useForm } from 'react-hook-form'
 import {
   ConnectorType,
-  EdcSubscriptionsType,
   useFetchOfferSubscriptionsQuery,
 } from 'features/connector/connectorApiSlice'
 import Box from '@mui/material/Box'
@@ -52,7 +51,7 @@ interface AddCollectorOverlayProps {
 export type FormFieldsType = {
   ConnectorName: string
   ConnectorURL: string
-  ConnectorSubscription: EdcSubscriptionsType
+  ConnectorSubscriptionId: string
   ConnectorLocation: string
   // ConnectorDoc: any TO-DO: Enable when DAPS enabled
 }
@@ -61,6 +60,7 @@ const formFields = {
   ConnectorName: '',
   ConnectorURL: '',
   ConnectorLocation: '',
+  ConnectorSubscriptionId: '',
   // ConnectorDoc: '', TO-DO: Enable when DAPS enabled
 }
 
@@ -99,6 +99,7 @@ const AddConnectorOverlay = ({
       'ConnectorName',
       'ConnectorURL',
       'ConnectorLocation',
+      'ConnectorSubscriptionId',
       // 'ConnectorDoc', TO-DO: Enable when DAPS enabled
     ])
     if (validateFields) {

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -158,7 +158,7 @@ const EdcConnector = () => {
         .catch(() => showOverlay(false))
     } else if (selectedService.type === ConnectType.MANAGED_CONNECTOR) {
       // body.append('providerBpn', data.ConnectorBPN)
-      body.append('subscriptionId', data.ConnectorSubscription.subscriptionId)
+      body.append('subscriptionId', data.ConnectorSubscriptionId)
       body.append('technicalUserId', '')
       await createManagedConnector(body)
         .unwrap()

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -82,6 +82,7 @@ export const Patterns = {
   connectors: {
     NAME: /^[^-\s()'"#@.&](?!.*[%&?,';:!\s-]{2}).{1,19}$/,
     COUNTRY: /^[A-Z]{2}$/,
+    CUSTOMER_LINK: /^.*$/,
   },
   CANCEL_INPUT: /^[a-z0-9 ?*%$#@!-](?=)/i,
 }

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -82,7 +82,6 @@ export const Patterns = {
   connectors: {
     NAME: /^[^-\s()'"#@.&](?!.*[%&?,';:!\s-]{2}).{1,19}$/,
     COUNTRY: /^[A-Z]{2}$/,
-    CUSTOMER_LINK: /^.*$/,
   },
   CANCEL_INPUT: /^[a-z0-9 ?*%$#@!-](?=)/i,
 }


### PR DESCRIPTION
## Description

handle empty customer link section in managed connectors

## Why

make sure that the connector registration can not get triggered, if the Customer Link is not selected

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
