### PR TITLE
bugfix(service card): do not allow to erase

### DIFF
--- a/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -301,7 +301,7 @@ export default function OfferCard() {
       serviceTypeIds: data.serviceTypeIds,
       title: data.title,
       leadPictureUri:
-        data.uploadImage && data.uploadImage.leadPictureUri
+        data.uploadImage?.leadPictureUri
           ? data.uploadImage.leadPictureUri !== null &&
             Object.keys(data.uploadImage.leadPictureUri).length > 0 &&
             Object.values(data.uploadImage.leadPictureUri)[0]

--- a/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -136,7 +136,7 @@ export default function OfferCard() {
         alt: fetchServiceStatus?.leadPictureUri || '',
       },
     }
-  }, [fetchServiceStatus, imageData])
+  }, [fetchServiceStatus])
 
   const {
     handleSubmit,
@@ -234,16 +234,19 @@ export default function OfferCard() {
     apiBody: CreateServiceStep1Item,
     buttonLabel: string
   ) => {
-    const uploadImageValue = getValues().uploadImage
-      .leadPictureUri as unknown as DropzoneFile
+    const uploadImageValue =
+      getValues().uploadImage &&
+      (getValues().uploadImage.leadPictureUri as unknown as DropzoneFile)
     await saveService({
       id: serviceId,
       body: apiBody,
     })
       .unwrap()
       .then(() => {
-        !uploadImageValue.id &&
-          handleUploadDocument(serviceId, uploadImageValue)
+        if (uploadImageValue) {
+          !uploadImageValue.id &&
+            handleUploadDocument(serviceId, uploadImageValue)
+        }
         dispatch(setServiceId(serviceId))
         buttonLabel === ButtonLabelTypes.SAVE_AND_PROCEED &&
           dispatch(serviceReleaseStepIncrement())
@@ -261,8 +264,9 @@ export default function OfferCard() {
     apiBody: CreateServiceStep1Item,
     buttonLabel: string
   ) => {
-    const uploadImageValue = getValues().uploadImage
-      .leadPictureUri as unknown as DropzoneFile
+    const uploadImageValue =
+      getValues().uploadImage &&
+      (getValues().uploadImage.leadPictureUri as unknown as DropzoneFile)
     await createService({
       id: '',
       body: apiBody,
@@ -270,7 +274,10 @@ export default function OfferCard() {
       .unwrap()
       .then((result) => {
         if (isString(result)) {
-          !uploadImageValue.id && handleUploadDocument(result, uploadImageValue)
+          if (uploadImageValue) {
+            !uploadImageValue.id &&
+              handleUploadDocument(result, uploadImageValue)
+          }
           dispatch(setServiceId(result))
           buttonLabel === ButtonLabelTypes.SAVE_AND_PROCEED &&
             dispatch(serviceReleaseStepIncrement())
@@ -294,9 +301,11 @@ export default function OfferCard() {
       serviceTypeIds: data.serviceTypeIds,
       title: data.title,
       leadPictureUri:
-        data.uploadImage.leadPictureUri !== null &&
-        Object.keys(data.uploadImage.leadPictureUri).length > 0 &&
-        Object.values(data.uploadImage.leadPictureUri)[0],
+        data.uploadImage && data.uploadImage.leadPictureUri
+          ? data.uploadImage.leadPictureUri !== null &&
+            Object.keys(data.uploadImage.leadPictureUri).length > 0 &&
+            Object.values(data.uploadImage.leadPictureUri)[0]
+          : '',
       descriptions: [
         {
           languageCode: 'de',

--- a/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -300,12 +300,11 @@ export default function OfferCard() {
     const apiBody = {
       serviceTypeIds: data.serviceTypeIds,
       title: data.title,
-      leadPictureUri:
-        data.uploadImage?.leadPictureUri
-          ? data.uploadImage.leadPictureUri !== null &&
-            Object.keys(data.uploadImage.leadPictureUri).length > 0 &&
-            Object.values(data.uploadImage.leadPictureUri)[0]
-          : '',
+      leadPictureUri: data.uploadImage?.leadPictureUri
+        ? data.uploadImage.leadPictureUri !== null &&
+          Object.keys(data.uploadImage.leadPictureUri).length > 0 &&
+          Object.values(data.uploadImage.leadPictureUri)[0]
+        : '',
       descriptions: [
         {
           languageCode: 'de',


### PR DESCRIPTION
## Description

do not erase data which are already added to the form on deleting uploaded image

## Why

ServiceCard Deletion of Image deletes all Entries

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally