### PR TITLE
chore: attribute logos in notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -34,11 +34,18 @@ The project maintains the following source code repositories in the GitHub organ
 
 This project leverages the following third party content:
 
+See DEPENDENCIES file.
+
+This project uses the following font:
+
 - License: Open Font License 1.1
 - Licence Path: https://github.com/impallari/Libre-Franklin/blob/master/OFL.txt
 - Source URL: https://github.com/impallari/Libre-Franklin
 
-See DEPENDENCIES file.
+This project uses the following image content:
+
+- Image: Catena-X Logo
+- Source URL: https://catena-x.net
 
 ## Cryptography
 

--- a/public/cx-logo-gray.svg.license
+++ b/public/cx-logo-gray.svg.license
@@ -1,5 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-frontend

--- a/public/cx-logo-text.svg.license
+++ b/public/cx-logo-text.svg.license
@@ -1,5 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-frontend

--- a/public/cx-logo.svg.license
+++ b/public/cx-logo.svg.license
@@ -1,5 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-frontend

--- a/public/orange-background-full.svg.license
+++ b/public/orange-background-full.svg.license
@@ -2,4 +2,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-frontend
+- Source URL: https://github.com/eclipse-tractusx/portal-assets

--- a/public/orange-background-head.svg.license
+++ b/public/orange-background-head.svg.license
@@ -2,4 +2,4 @@ This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses
 
 - SPDX-License-Identifier: CC-BY-4.0
 - SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-frontend
+- Source URL: https://github.com/eclipse-tractusx/portal-assets

--- a/src/assets/logo/cx-logo-short.svg.license
+++ b/src/assets/logo/cx-logo-short.svg.license
@@ -1,5 +1,0 @@
-This work is licensed under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
-
-- SPDX-License-Identifier: CC-BY-4.0
-- SPDX-FileCopyrightText: Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
-- Source URL: https://github.com/eclipse-tractusx/portal-frontend


### PR DESCRIPTION
## Description

- attribute logos in notice
- change source in some license notice files

## Why

[third-party-content](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07#third-party-content)

## Issue

n/a

## Checklist

- [x] I have performed a self-review of my own code
