### PR TITLE
feat(service overview): add sub menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Active Subscription
   - Switch endpoint used to display "App Subscriptions"
+- Serview Overview
+  - Added Sub menu for active services in service overview
 
 ## 1.6.0
 

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -116,7 +116,11 @@
     },
     "headerTitle": "Service Overview - Own managed service offers",
     "inputPlaceholder": "Suchen Sie nach Services",
-    "addbtn": "Registrieren Sie Ihre Services"
+    "addbtn": "Registrieren Sie Ihre Services",
+    "submenuNotAvailable": "Sub-Menu is not available for not active apps.",
+    "sortOptions": {
+      "deactivate": "Deactivate"
+    }
   },
   "servicedetails": {
     "headerTitle": "Service Details"

--- a/src/assets/locales/en/servicerelease.json
+++ b/src/assets/locales/en/servicerelease.json
@@ -116,7 +116,11 @@
       "inactive": "Inactive",
       "wip": "WIP"
     },
-    "addbtn": "Register your Service"
+    "addbtn": "Register your Service",
+    "submenuNotAvailable": "Sub-Menu is not available for not active apps.",
+    "sortOptions": {
+      "deactivate": "Deactivate"
+    }
   },
   "servicedetails": {
     "headerTitle": "Service Details"

--- a/src/components/pages/ServiceReleaseProcess/components/ServiceListOverview.tsx
+++ b/src/components/pages/ServiceReleaseProcess/components/ServiceListOverview.tsx
@@ -46,6 +46,11 @@ import debounce from 'lodash.debounce'
 import { setServiceId } from 'features/serviceManagement/actions'
 import { useDispatch } from 'react-redux'
 import { setServiceReleaseActiveStep } from 'features/serviceManagement/slice'
+
+enum ServiceSubMenuItems {
+  DEACTIVATE = 'deactivate',
+}
+
 export default function ServiceListOverview() {
   const { t } = useTranslation('servicerelease')
   const [items, setItems] = useState<any>([])
@@ -62,6 +67,14 @@ export default function ServiceListOverview() {
   })
   const { data } = useFetchProvidedServicesQuery(argsData)
   const dispatch = useDispatch()
+
+  const submenuOptions = [
+    {
+      label: t('serviceoverview.sortOptions.deactivate'),
+      value: ServiceSubMenuItems.DEACTIVATE,
+      url: '',
+    },
+  ]
 
   useEffect(() => {
     dispatch(setServiceReleaseActiveStep())
@@ -209,7 +222,16 @@ export default function ServiceListOverview() {
                   navigate(`/${PAGES.SERVICE_DETAIL}/${item.id}`)
                 }
               }}
-              subMenu={false}
+              subMenu={true}
+              submenuOptions={submenuOptions}
+              submenuClick={(sortMenu: string, id: string | undefined) => {
+                sortMenu === ServiceSubMenuItems.DEACTIVATE &&
+                  navigate(`/${PAGES.DEACTIVATE}/${id}`, {
+                    state: items,
+                  })
+                return undefined
+              }}
+              tooltipText={t('serviceoverview.submenuNotAvailable')}
             />
           </div>
         ) : (


### PR DESCRIPTION
## Description

Added Sub menu for active services in service overview

## Why

To enhance service overview

## Issue

Link to Github issue.

Ref: CPLP-3181

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally