### PR TITLE
feat(appoverview): add change documents sub menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,9 @@
   - Enable credential reset
   - Enable search & filter
 - Serview Overview
-
   - Added Sub menu for active services in service overview
 - App management
   - Fixed page break
-
 - App Overview
   - Enhance Sub Menu by adding 'Change Documents' for active apps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Serview Overview
   - Added Sub menu for active services in service overview
 
+- App Overview
+  - Enhance Sub Menu by adding 'Change Documents' for active apps
+
 ## 1.6.0
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Technical User
   - Enable search & filter
 - Serview Overview
+
   - Added Sub menu for active services in service overview
 
 - App Overview

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -842,7 +842,7 @@ npm/npmjs/-/string-length/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/string-natural-compare/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/string-width/4.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/string.prototype.matchall/4.0.8, MIT, approved, #4571
-npm/npmjs/-/string.prototype.trim/1.2.7, MIT, approved, clearlydefined
+npm/npmjs/-/string.prototype.trim/1.2.7, MIT, approved, #10361
 npm/npmjs/-/string.prototype.trimend/1.0.6, MIT, approved, #4564
 npm/npmjs/-/string.prototype.trimstart/1.0.6, MIT, approved, #4647
 npm/npmjs/-/string_decoder/1.1.1, MIT, approved, clearlydefined

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -451,6 +451,13 @@
       "successMsg": "Successfully added roles",
       "errorMsg": "Unable to add roles"
     },
+    "changeDocuments": {
+      "headerTitle": "Update Contract Documents",
+      "description": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard .Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard .",
+      "saveTooltipMsg": "The save button will be active after a document was changed",
+      "successMsg": "Documents changed successfully",
+      "errorMsg": "Error! Something went wrong"
+    },
     "appreleaseprocess": {
       "message": "App Release Process Message"
     },

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -395,7 +395,8 @@
         "deactivate": "Deactivate",
         "changeImage": "Change Image",
         "changeDescription": "Change Description",
-        "addRoles": "Add Roles"
+        "addRoles": "Add Roles",
+        "changeDocuments": "Change Document(s)"
       },
       "addbtn": "Registrieren Sie Ihre App",
       "confirmModal": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -450,6 +450,13 @@
       "successMsg": "Successfully added roles",
       "errorMsg": "Unable to add roles"
     },
+    "changeDocuments": {
+      "headerTitle": "Update Contract Documents",
+      "description": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard .Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard .",
+      "saveTooltipMsg": "The save button will be active after a document was changed",
+      "successMsg": "Documents changed successfully",
+      "errorMsg": "Error! Something went wrong"
+    },
     "appreleaseprocess": {
       "message": "App Release Process Message"
     },

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -394,7 +394,8 @@
         "deactivate": "Deactivate",
         "changeImage": "Change Image",
         "changeDescription": "Change Description",
-        "addRoles": "Add Roles"
+        "addRoles": "Add Roles",
+        "changeDocuments": "Change Document(s)"
       },
       "addbtn": "Register your App",
       "confirmModal": {

--- a/src/components/pages/AppOverview/AppOverviewList.tsx
+++ b/src/components/pages/AppOverview/AppOverviewList.tsx
@@ -30,7 +30,7 @@ enum AppSubMenuItems {
   CHANGE_IMAGE = 'changeImage',
   CHANGE_DESCRIPTION = 'changeDescription',
   ADD_ROLES = 'addRoles',
-  CHANGE_DOCUMENTS = 'changedocuments',
+  CHANGE_DOCUMENTS = 'changeDocuments',
 }
 
 export const AppOverviewList = ({

--- a/src/components/pages/AppOverview/AppOverviewList.tsx
+++ b/src/components/pages/AppOverview/AppOverviewList.tsx
@@ -30,6 +30,7 @@ enum AppSubMenuItems {
   CHANGE_IMAGE = 'changeImage',
   CHANGE_DESCRIPTION = 'changeDescription',
   ADD_ROLES = 'addRoles',
+  CHANGE_DOCUMENTS = 'changedocuments',
 }
 
 export const AppOverviewList = ({
@@ -61,6 +62,11 @@ export const AppOverviewList = ({
     {
       label: t('content.appoverview.sortOptions.addRoles'),
       value: AppSubMenuItems.ADD_ROLES,
+      url: '',
+    },
+    {
+      label: t('content.appoverview.sortOptions.changeDocuments'),
+      value: AppSubMenuItems.CHANGE_DOCUMENTS,
       url: '',
     },
   ]
@@ -98,6 +104,10 @@ export const AppOverviewList = ({
             })
           sortMenu === AppSubMenuItems.ADD_ROLES &&
             navigate(`/${PAGES.ADD_ROLES}/${id}`, {
+              state: filterItem,
+            })
+          sortMenu === AppSubMenuItems.CHANGE_DOCUMENTS &&
+            navigate(`/${PAGES.CHANGE_DOCUMENTS}/${id}`, {
               state: filterItem,
             })
           return undefined

--- a/src/components/pages/AppOverview/ChangeDocuments.tsx
+++ b/src/components/pages/AppOverview/ChangeDocuments.tsx
@@ -17,6 +17,91 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { PageBreadcrumb } from 'components/shared/frame/PageBreadcrumb/PageBreadcrumb'
+import {
+  Typography,
+  PageHeader,
+  Button,
+  Tooltips,
+  LoadingButton,
+} from '@catena-x/portal-shared-components'
+import { useTranslation } from 'react-i18next'
+import { useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Box } from '@mui/material'
+import { useState } from 'react'
+
 export default function ChangeDocuments() {
-  return <>In Progress</>
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const appId = useParams().appId
+  const [isLoading, setIsLoading] = useState(false)
+  const { state } = useLocation()
+  const items: any = state
+  const app = items?.filter((item: any) => item.id === appId)
+  const [imageChanged, setImageChanged] = useState(false)
+
+  const handleSaveClick = async () => {
+    setIsLoading(true)
+    setImageChanged(true)
+  }
+
+  return (
+    <main className="deactivate-main">
+      <PageHeader title={app?.[0]?.title} topPage={true} headerHeight={200}>
+        <PageBreadcrumb backButtonVariant="contained" />
+      </PageHeader>
+      <section>
+        <Typography variant="body2" mb={3} align="center">
+          {app?.[0]?.title}
+        </Typography>
+        <Typography variant="h2" mb={3} align="center">
+          {t('content.changeDocuments.headerTitle')}
+        </Typography>
+        <Typography variant="body2" align="center">
+          {t('content.changeDocuments.description')}
+        </Typography>
+      </section>
+      <section>
+        <hr style={{ border: 0, borderTop: '1px solid #DCDCDC' }} />
+        <Box sx={{ position: 'relative', marginTop: '30px' }}>
+          <Button
+            color="secondary"
+            size="small"
+            onClick={() => navigate('/appoverview')}
+          >
+            {t('global.actions.cancel')}
+          </Button>
+          <Tooltips
+            tooltipPlacement="bottom-start"
+            tooltipText={
+              !imageChanged ? t('content.changeDocuments.saveTooltipMsg') : ''
+            }
+            children={
+              <span style={{ position: 'absolute', right: '10px' }}>
+                {isLoading ? (
+                  <LoadingButton
+                    size="small"
+                    loading={isLoading}
+                    variant="contained"
+                    onButtonClick={() => {}}
+                    loadIndicator="Loading..."
+                    label={`${t('global.actions.confirm')}`}
+                  />
+                ) : (
+                  <Button
+                    size="small"
+                    variant="contained"
+                    disabled={!imageChanged}
+                    onClick={handleSaveClick}
+                  >
+                    {t('global.actions.save')}
+                  </Button>
+                )}
+              </span>
+            }
+          />
+        </Box>
+      </section>
+    </main>
+  )
 }

--- a/src/components/pages/AppOverview/ChangeDocuments.tsx
+++ b/src/components/pages/AppOverview/ChangeDocuments.tsx
@@ -50,13 +50,16 @@ export default function ChangeDocuments() {
       <PageHeader title={app?.[0]?.title} topPage={true} headerHeight={200}>
         <PageBreadcrumb backButtonVariant="contained" />
       </PageHeader>
+
       <section>
-        <Typography variant="body2" mb={3} align="center">
+        <Typography mb={3} align="center" variant="body2">
           {app?.[0]?.title}
         </Typography>
-        <Typography variant="h2" mb={3} align="center">
+
+        <Typography align="center" mb={3} variant="h2">
           {t('content.changeDocuments.headerTitle')}
         </Typography>
+
         <Typography variant="body2" align="center">
           {t('content.changeDocuments.description')}
         </Typography>

--- a/src/components/pages/AppOverview/ChangeDocuments.tsx
+++ b/src/components/pages/AppOverview/ChangeDocuments.tsx
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export default function ChangeDocuments() {
+  return <>In Progress</>
+}

--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -80,6 +80,7 @@ import ChangeDescription from 'components/pages/AppOverview/ChangeDescription'
 import DataSpace from 'components/pages/DataSpace'
 import AdminCredential from 'components/pages/AdminCredential'
 import AddRoles from 'components/pages/AppOverview/AddRoles'
+import ChangeDocuments from 'components/pages/AppOverview/ChangeDocuments'
 
 /**
  * ALL_PAGES
@@ -451,7 +452,6 @@ export const ALL_PAGES: IPage[] = [
       </Route>
     ),
   },
-
   {
     name: PAGES.ADD_ROLES,
     isRoute: true,
@@ -462,6 +462,19 @@ export const ALL_PAGES: IPage[] = [
         element={<AddRoles />}
       >
         <Route path=":appId" element={<AddRoles />} />
+      </Route>
+    ),
+  },
+  {
+    name: PAGES.CHANGE_DOCUMENTS,
+    isRoute: true,
+    element: (
+      <Route
+        key={PAGES.CHANGE_DOCUMENTS}
+        path={PAGES.CHANGE_DOCUMENTS}
+        element={<ChangeDocuments />}
+      >
+        <Route path=":appId" element={<ChangeDocuments />} />
       </Route>
     ),
   },

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -74,6 +74,7 @@ export enum PAGES {
   CHANGE_IMAGE = 'changeimage',
   CHANGE_DESCRIPTION = 'changedescription',
   ADD_ROLES = 'addroles',
+  CHANGE_DOCUMENTS = 'changedocuments',
   APPRELEASEPROCESS = 'appreleaseprocess',
   APP_RELEASE_PROCESS_FORM = 'appreleaseprocess_form',
   INTRODUCTION = 'companyroles',


### PR DESCRIPTION
## Description

Added sub-menu for change documents for active apps

## Why

To enhance active apps

## Issue

Ref: CPLP-3084

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally