### PR TITLE
bugfix(sub navigation header): align label to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   - Enable search & filter
 - Serview Overview
   - Added Sub menu for active services in service overview
+- Sub Navigation Header
+  - Align label to the left
 
 ## 1.6.0
 

--- a/src/components/shared/templates/Templates.scss
+++ b/src/components/shared/templates/Templates.scss
@@ -33,6 +33,7 @@
 
 .subNavigationContainer button {
   margin-right: 20px;
+  text-align: left;
 }
 
 .customHeight {
@@ -90,8 +91,4 @@
     border: none;
     box-shadow: 0px 0px 0px 1px rgb(15 113 203 / 40%);
   }
-}
-
-.subNavigationContainer button {
-  text-align: left;
 }

--- a/src/components/shared/templates/Templates.scss
+++ b/src/components/shared/templates/Templates.scss
@@ -32,7 +32,6 @@
 }
 
 .subNavigationContainer button {
-  padding-right: 80px;
   margin-right: 20px;
 }
 
@@ -91,4 +90,8 @@
     border: none;
     box-shadow: 0px 0px 0px 1px rgb(15 113 203 / 40%);
   }
+}
+
+.subNavigationContainer button {
+  text-align: left;
 }


### PR DESCRIPTION
## Description

sub navigation header label should be aligned to left instead of centre

## Why

label is left aligned

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally