### PR TITLE
build(arch): build images for arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -81,6 +84,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-release_candidate.yml
+++ b/.github/workflows/release-release_candidate.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -100,6 +103,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -101,6 +104,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Unit Tests
         run: yarn test:ci
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
@@ -81,6 +84,7 @@ jobs:
         with:
           context: .
           file: .conf/Dockerfile.prebuilt
+          platforms: linux/amd64, linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description

build images also for arm64, in addition to amd64

## Why

enable localdev umbrella chart: arm64 images needed for usage on Mac

## Issue

[localdev](https://github.com/eclipse-tractusx/portal-cd/pull/90)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
