### PR TITLE
bugfix(app page): double image load fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+- App Release Process
+  - Fixed double loading of images for app page
+
 ## 1.7.0-alpha
 
 ### Change

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -752,7 +752,7 @@ npm/npmjs/-/recursive-readdir/2.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/redent/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/redux-thunk/2.4.2, MIT, approved, clearlydefined
 npm/npmjs/-/redux/4.2.1, CC0-1.0 AND MIT, approved, #7046
-npm/npmjs/-/regenerate-unicode-properties/10.1.0, MIT, approved, clearlydefined
+npm/npmjs/-/regenerate-unicode-properties/10.1.0, MIT, approved, #10903
 npm/npmjs/-/regenerate/1.4.2, MIT, approved, clearlydefined
 npm/npmjs/-/regenerator-runtime/0.13.11, MIT, approved, #4978
 npm/npmjs/-/regenerator-transform/0.15.1, MIT, approved, #5001

--- a/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
@@ -541,7 +541,7 @@ export default function AppPage() {
                   onChange={(files, addedFiles) => {
                     reactHookFormOnChange(files)
                     trigger('images')
-                    addedFiles && uploadImages(files)
+                    addedFiles && uploadImages(addedFiles)
                   }}
                   acceptFormat={{
                     'image/png': [],


### PR DESCRIPTION
## Description

Fixed double loading of images for app page

## Why

On upload of second image, previously uploaded image was also uploading

## Issue

Ref: CPLP-3303

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally