### PR TITLE
fix(component): fix key value view for undefined attributes

### DIFF
--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -65,14 +65,15 @@ export const KeyValueView = ({ cols, title, items }: KeyValueViewProps) => {
           },
         }}
         onClick={async () => {
-          await navigator.clipboard.writeText(item.value.toString())
-          setCopied(item.value.toString())
+          const value = item.value?.toString() ?? ''
+          await navigator.clipboard.writeText(value)
+          setCopied(value)
           setTimeout(() => {
             setCopied('')
           }, 1000)
         }}
       >
-        {renderValue(item.value.toString())}
+        {renderValue(item.value?.toString() ?? '')}
         <ContentCopyIcon
           sx={{
             marginLeft: '10px',


### PR DESCRIPTION
## Description

Fix broken KeyValueView for undefined object attributes

## Why

The KeyValueView had a bug which led to a white screen in case it tries to access undefined attributes.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally