### PR TITLE
bugfix(notification): change navigation link to service marketplace

### DIFF
--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -117,7 +117,8 @@
     "usermanagement": "Get there",
     "servicesubscription": "Get there",
     "serviceadminboard": "Get there",
-    "role-details": "Open Role Matrix"
+    "role-details": "Open Role Matrix",
+    "servicemarketplace": "Get there"
   },
   "due": "fällig",
   "search": "...suchen",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -113,7 +113,8 @@
     "usermanagement": "Get there",
     "servicesubscription": "Get there",
     "serviceadminboard": "Get there",
-    "role-details": "Open Role Matrix"
+    "role-details": "Open Role Matrix",
+    "servicemarketplace": "Get there"
   },
   "due": "due",
   "search": "Enter your search value",

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -174,10 +174,7 @@ const NotificationConfig = ({ item }: { item: CXNotificationContent }) => {
       return <NotificationContent item={item} navlinks={['usecase']} />
     case NotificationType.WELCOME_SERVICE_PROVIDER:
       return (
-        <NotificationContent
-          item={item}
-          navlinks={['companyrolesserviceprovider']}
-        />
+        <NotificationContent item={item} navlinks={['servicemarketplace']} />
       )
     case NotificationType.APP_SUBSCRIPTION_REQUEST:
       return (


### PR DESCRIPTION
## Description

change navigation from  Company Role Service Provider  to service marketplace

## Why

Link should lead to Service Provider Marketplace as described in notification. https://portal.int.demo.catena-x.net/servicemarketplace

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally