### PR TITLE
bugfix(tech user): fix duplicate entry issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Company Role
   - Updated OSP translations
+- Technical User
+  - Fix - After adding / creating new technical users, list view at bottom "randomly" shows duplicates. Applies to all the views (ALL, MANAGED, OWNED)
 
 ## 1.7.0-RC2
 

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -56,6 +56,10 @@ export const TechnicalUserTable = () => {
   }
 
   useEffect(() => {
+    setRefresh(Date.now())
+  }, [update])
+
+  useEffect(() => {
     setFetchHookArgs({
       statusFilter: group,
       expr,
@@ -93,7 +97,7 @@ export const TechnicalUserTable = () => {
         loadLabel={t('global.actions.more')}
         searchPlaceholder={t('content.usermanagement.technicalUser.searchText')}
         fetchHook={useFetchServiceAccountListQuery}
-        fetchHookRefresh={update || refresh}
+        fetchHookRefresh={refresh}
         getRowId={(row: { [key: string]: string }) => row.serviceAccountId}
         filterViews={filterButtons}
         fetchHookArgs={fetchHookArgs}

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -31,6 +31,10 @@ export enum ServiceAccountType {
   SECRET = 'SECRET',
 }
 
+export enum Tags {
+  SERVICEACCOUNTS = 'SERVICEACCOUNTS',
+}
+
 export interface ServiceAccountRole {
   roleId: string
   roleDescription: string
@@ -82,6 +86,7 @@ export enum ServiceAccountStatusFilter {
 export const apiSlice = createApi({
   reducerPath: 'rtk/admin/service',
   baseQuery: fetchBaseQuery(apiBaseQuery()),
+  tagTypes: [Tags.SERVICEACCOUNTS],
   endpoints: (builder) => ({
     addServiceAccount: builder.mutation<
       ServiceAccountDetail,
@@ -92,6 +97,7 @@ export const apiSlice = createApi({
         method: 'POST',
         body,
       }),
+      invalidatesTags: [Tags.SERVICEACCOUNTS],
     }),
     removeServiceAccount: builder.mutation<void, string>({
       query: (id: string) => ({
@@ -136,6 +142,7 @@ export const apiSlice = createApi({
           return url
         }
       },
+      providesTags: [Tags.SERVICEACCOUNTS],
     }),
     fetchServiceAccountDetail: builder.query<ServiceAccountDetail, string>({
       query: (id: string) =>


### PR DESCRIPTION
## Description

Fix - After adding / creating new technical users, list view at bottom "randomly" shows duplicates. Applies to all the views (ALL, MANAGED, OWNED)

## Why

duplicate entry issue

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally