### PR TITLE
fix(vulnerability): upgrade axios dependency

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -50,7 +50,6 @@ npm/npmjs/-/autoprefixer/10.4.16, MIT, approved, #7494
 npm/npmjs/-/autosuggest-highlight/3.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/available-typed-arrays/1.0.5, MIT, approved, clearlydefined
 npm/npmjs/-/axe-core/4.8.2, MPL-2.0 AND MIT AND (Apache-2.0 AND OFL-1.1), approved, #10969
-npm/npmjs/-/axios/1.5.1, MIT, approved, #10504
 npm/npmjs/-/axios/1.6.1, MIT, approved, #11338
 npm/npmjs/-/axobject-query/3.2.1, Apache-2.0, approved, #9144
 npm/npmjs/-/babel-jest/27.5.1, MIT, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@react-hook/cache": "^1.1.1",
     "@reduxjs/toolkit": "^1.9.5",
     "@types/papaparse": "^5.3.7",
-    "axios": "^1.4.0",
+    "axios": "^1.6.1",
     "buffer": "^6.0.3",
     "dayjs": "^1.11.8",
     "i18next": "^22.5.1",
@@ -92,8 +92,7 @@
   },
   "resolutions": {
     "**/nth-check": "^2.1.1",
-    "**/@babel/traverse": "^7.23.2",
-    "**/axios": "^1.6.1"
+    "**/@babel/traverse": "^7.23.2"
   },
   "scripts": {
     "prepare": "husky install",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3231,15 +3231,6 @@ axe-core@^4.6.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.8.2.tgz#2f6f3cde40935825cf4465e3c1c9e77b240ff6ae"
   integrity sha512-/dlp0fxyM3R8YW7MFzaHWXrf4zzbr0vaYb23VBFCl83R7nWNPg/yaQw2Dc8jzCMmDVLhSdzH8MjrsuIUuvX+6g==
 
-axios@^1.4.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.5.1.tgz#11fbaa11fc35f431193a9564109c88c1f27b585f"
-  integrity sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 axios@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.1.tgz#76550d644bf0a2d469a01f9244db6753208397d7"


### PR DESCRIPTION
## Description

 upgrade axios dependency to v1.6.1

## Why

due to vulnerability in previous version
https://github.com/eclipse-tractusx/portal-frontend/pull/352 didn't solve the issue

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
