### PR TITLE
bugfix(invite): add new invited company gets right away in to the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## unreleased
 
-- ...
--
+- Invite Business Partner
+  - Add the new invited company gets right away in to the table
 
 ## 1.7.0-RC2
 

--- a/src/components/pages/InviteBusinessPartner/components/InviteList/index.tsx
+++ b/src/components/pages/InviteBusinessPartner/components/InviteList/index.tsx
@@ -28,7 +28,7 @@ import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import type { CompanyInvite } from 'features/admin/inviteApiSlice'
 import { useTranslation } from 'react-i18next'
 import './style.scss'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import dayjs from 'dayjs'
 import { setSearchInput } from 'features/appManagement/actions'
 import { updateInviteSelector } from 'features/control/updates'
@@ -42,6 +42,7 @@ export const InviteList = ({
   fetchHookArgs,
   onSearch,
   searchExpr,
+  refetch,
 }: {
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
@@ -49,6 +50,7 @@ export const InviteList = ({
   fetchHookArgs?: FetchHookArgsType
   onSearch?: (search: string) => void
   searchExpr?: string
+  refetch?: number
 }) => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -60,6 +62,10 @@ export const InviteList = ({
     if (validateExpr) dispatch(setSearchInput({ open: true, text: expr }))
     return validateExpr
   }
+
+  useEffect(() => {
+    setRefresh(Date.now())
+  }, [refetch])
 
   return (
     <section id="identity-management-id">

--- a/src/features/admin/inviteApiSlice.ts
+++ b/src/features/admin/inviteApiSlice.ts
@@ -25,6 +25,7 @@ import type {
 } from '@catena-x/portal-shared-components'
 import { PAGE_SIZE } from 'types/Constants'
 import { apiBaseQuery } from 'utils/rtkUtil'
+import { type InviteData } from './registration/types'
 
 export enum CompanyInviteStatus {
   PENDING = 'PENDING',
@@ -54,7 +55,14 @@ export const apiSlice = createApi({
           fetchArgs.page
         }&size=${PAGE_SIZE}&companyName=${fetchArgs.args!.expr}`,
     }),
+    sendInvite: builder.mutation<void, InviteData>({
+      query: (data: InviteData) => ({
+        url: '/api/administration/invitation',
+        method: 'POST',
+        body: data,
+      }),
+    }),
   }),
 })
 
-export const { useFetchInviteSearchQuery } = apiSlice
+export const { useFetchInviteSearchQuery, useSendInviteMutation } = apiSlice


### PR DESCRIPTION
## Description

its expected that the new invited company gets right away updated in the table (see below)

## Why

when inviting via the invite overlay a new company, the company gets only displayed as new invited company, if the user refreshes the page.

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
