### PR TITLE
fix(trivy): don't fail on high findings

### DIFF
--- a/.github/workflows/trivy-dev.yml
+++ b/.github/workflows/trivy-dev.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@@0.14.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           scan-type: "config"
           hide-progress: false
@@ -86,7 +86,7 @@ jobs:
       # For public images, no ENV vars must be set.
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@@0.14.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           # Path to Docker image
           image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:dev"

--- a/.github/workflows/trivy-dev.yml
+++ b/.github/workflows/trivy-dev.yml
@@ -54,15 +54,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@@0.14.0
         with:
           scan-type: "config"
-          # ignore-unfixed: true
-          exit-code: "1"
           hide-progress: false
           format: "sarif"
           output: "trivy-results1.sarif"
-          severity: "CRITICAL,HIGH"
+          vuln-type: "os,library"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
@@ -88,14 +86,13 @@ jobs:
       # For public images, no ENV vars must be set.
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@@0.14.0
         with:
           # Path to Docker image
           image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:dev"
           format: "sarif"
           output: "trivy-results2.sarif"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
+          vuln-type: "os,library"
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@@0.14.0
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           scan-type: "config"
           hide-progress: false

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@@0.14.0
         with:
           scan-type: "config"
           hide-progress: false
@@ -86,7 +86,7 @@ jobs:
       # For public images, no ENV vars must be set.
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@0.14.0‚
+        uses: aquasecurity/trivy-action@0.14.0
         with:
           # Path to Docker image
           image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -57,12 +57,10 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           scan-type: "config"
-          # ignore-unfixed: true
-          exit-code: "1"
           hide-progress: false
           format: "sarif"
           output: "trivy-results1.sarif"
-          severity: "CRITICAL,HIGH"
+          vuln-type: "os,library"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
@@ -88,14 +86,13 @@ jobs:
       # For public images, no ENV vars must be set.
       - name: Run Trivy vulnerability scanner
         if: always()
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.14.0‚
         with:
           # Path to Docker image
           image-ref: "${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:latest"
           format: "sarif"
           output: "trivy-results2.sarif"
-          exit-code: "1"
-          severity: "CRITICAL,HIGH"
+          vuln-type: "os,library"
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()


### PR DESCRIPTION
## Description

fix trivy: don't fail on high findings

## Why

action should only fail if there is an error/misconfiguration

## Issue

relates to https://github.com/eclipse-tractusx/portal-frontend/pull/353

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes
