### PR TITLE
bugfix(contract and consent): consent check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## 1.7.0-RC4
 
 - App release process
+
   - Fixed error message deletion upon deleting of csv file in technical integration
+  - Fixed consent check removal issue on save
+
+- Service release process
+  - Fixed consent check removal issue on save
 
 ## 1.7.0-RC3
 

--- a/src/components/shared/basic/ReleaseProcess/components/CommonContractAndConsent.tsx
+++ b/src/components/shared/basic/ReleaseProcess/components/CommonContractAndConsent.tsx
@@ -368,7 +368,6 @@ export default function CommonContractAndConsent({
             type === ReleaseProcessTypes.SERVICE_RELEASE &&
               dispatch(serviceReleaseStepIncrement())
           }
-          setAgreementData([])
         })
         .catch(() => {
           setContractNotification(true)


### PR DESCRIPTION
## Description

Fixed consent check removal issue on save in app release process and service release process

## Why

Upon save, checked consent should remain unchanged

## Issue

Ref: TEST-1519

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally