### PR TITLE
feat(overlay): change from cancel to close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   - Document Hover Effect
 - Tech User Details
   - Fix crash issue
+- Overlays
+  - Change Overlay Button from "Cancel" to "Close"
 
 ## 1.7.0-RC3
 

--- a/src/components/overlays/NotFound/index.tsx
+++ b/src/components/overlays/NotFound/index.tsx
@@ -49,9 +49,6 @@ export default function NotFound() {
       </DialogContent>
 
       <DialogActions>
-        <Button variant="outlined" onClick={close}>
-          {`${t('global.actions.cancel')}`}
-        </Button>
         <Button variant="contained" onClick={close}>
           {`${t('global.actions.close')}`}
         </Button>

--- a/src/components/overlays/TechnicalUserInfo/index.tsx
+++ b/src/components/overlays/TechnicalUserInfo/index.tsx
@@ -52,9 +52,6 @@ export default function TechnicalUserInfo({ id }: { id: string }) {
       </DialogContent>
 
       <DialogActions>
-        <Button variant="outlined" onClick={() => dispatch(closeOverlay())}>
-          {`${t('global.actions.cancel')}`}
-        </Button>
         <Button variant="contained" onClick={() => dispatch(closeOverlay())}>
           {`${t('global.actions.close')}`}
         </Button>

--- a/src/components/overlays/UpdateCertificate/index.tsx
+++ b/src/components/overlays/UpdateCertificate/index.tsx
@@ -211,7 +211,7 @@ export default function UpdateCertificate({ id }: { id: string }) {
           </DialogContent>
           <DialogActions>
             <Button variant="outlined" onClick={() => dispatch(closeOverlay())}>
-              {t('global.actions.cancel')}
+              {t('global.actions.close')}
             </Button>
           </DialogActions>
         </Dialog>
@@ -294,7 +294,7 @@ export default function UpdateCertificate({ id }: { id: string }) {
           </DialogContent>
           <DialogActions>
             <Button variant="outlined" onClick={() => dispatch(closeOverlay())}>
-              {t('global.actions.cancel')}
+              {t('global.actions.close')}
             </Button>
 
             {loading ? (


### PR DESCRIPTION
## Description

Change Overlay Button from "Cancel" to "Close"

## Why

The action button on the overlay bottom is called "Cancel" which needs to get renamed to "Close". "Cancel" should only get used if the user can actually cancel a process; means the transaction to the backend is not yet done.

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
