### PR TITLE
fix(usecase): document icon link issue

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -879,7 +879,7 @@ npm/npmjs/-/strip-comments/2.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/strip-final-newline/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/strip-indent/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/strip-json-comments/3.1.1, MIT, approved, clearlydefined
-npm/npmjs/-/style-loader/3.3.3, MIT, approved, clearlydefined
+npm/npmjs/-/style-loader/3.3.3, MIT, approved, #12669
 npm/npmjs/-/stylehacks/5.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/stylis/4.2.0, MIT, approved, #8409
 npm/npmjs/-/sucrase/3.34.0, MIT, approved, clearlydefined

--- a/src/components/pages/UsecaseParticipation/index.tsx
+++ b/src/components/pages/UsecaseParticipation/index.tsx
@@ -191,8 +191,8 @@ export default function UsecaseParticipation() {
                                 }
                                 children={
                                   <Link
-                                    to={credential.externalDetailData.template}
-                                    target="_blank"
+                                    to={credential.externalDetailData.template && credential.externalDetailData.template}
+                                    target={credential.externalDetailData.template && '_blank'}
                                     className={`thirdSection ${
                                       !credential.externalDetailData.template &&
                                       'documentDisabled'

--- a/src/components/pages/UsecaseParticipation/index.tsx
+++ b/src/components/pages/UsecaseParticipation/index.tsx
@@ -192,7 +192,6 @@ export default function UsecaseParticipation() {
                                 children={
                                   <Link
                                     to={
-                                      credential.externalDetailData.template &&
                                       credential.externalDetailData.template
                                     }
                                     target={

--- a/src/components/pages/UsecaseParticipation/index.tsx
+++ b/src/components/pages/UsecaseParticipation/index.tsx
@@ -191,9 +191,7 @@ export default function UsecaseParticipation() {
                                 }
                                 children={
                                   <Link
-                                    to={
-                                      credential.externalDetailData.template
-                                    }
+                                    to={credential.externalDetailData.template}
                                     target={
                                       credential.externalDetailData.template &&
                                       '_blank'

--- a/src/components/pages/UsecaseParticipation/index.tsx
+++ b/src/components/pages/UsecaseParticipation/index.tsx
@@ -191,8 +191,14 @@ export default function UsecaseParticipation() {
                                 }
                                 children={
                                   <Link
-                                    to={credential.externalDetailData.template && credential.externalDetailData.template}
-                                    target={credential.externalDetailData.template && '_blank'}
+                                    to={
+                                      credential.externalDetailData.template &&
+                                      credential.externalDetailData.template
+                                    }
+                                    target={
+                                      credential.externalDetailData.template &&
+                                      '_blank'
+                                    }
                                     className={`thirdSection ${
                                       !credential.externalDetailData.template &&
                                       'documentDisabled'


### PR DESCRIPTION
## Description

Document Icon handling

## Why

Enhance the element handling, if no document template url is provided by the backend, then link will be disabled

## Issue

n/a

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
