### PR TITLE
fix(idp): show only two steps when managed idp selected

### DIFF
--- a/src/assets/locales/de/idp.json
+++ b/src/assets/locales/de/idp.json
@@ -181,7 +181,7 @@
       "name": "Alias",
       "hint": "The IdP alias is a generated value and cannot be changed"
     },
-    "type": {
+    "authType": {
       "name": "Authentication type",
       "hint": "Select the authentication type of the new Identity Provider (currently only OIDC is supported)"
     },

--- a/src/assets/locales/en/idp.json
+++ b/src/assets/locales/en/idp.json
@@ -183,7 +183,7 @@
       "name": "Alias",
       "hint": "The IdP alias is a generated value and cannot be changed"
     },
-    "type": {
+    "authType": {
       "name": "Authentication type",
       "hint": "Select the authentication type of the new Identity Provider (currently only OIDC is supported)"
     },

--- a/src/features/admin/idpApiSlice.ts
+++ b/src/features/admin/idpApiSlice.ts
@@ -18,7 +18,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { type PayloadAction, createSlice } from '@reduxjs/toolkit'
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { type RootState } from 'features/store'
 import { apiBaseQuery } from 'utils/rtkUtil'
 
 export enum IDPCategory {
@@ -28,7 +30,6 @@ export enum IDPCategory {
 }
 
 export enum IDPProviderType {
-  NONE = 'NONE',
   OWN = 'OWN',
   MANAGED = 'MANAGED',
 }
@@ -146,12 +147,55 @@ export interface IdentityProvider {
   saml?: OIDCType
 }
 
+export type AddIDPStep1Type = {
+  name: string
+  authType: IDPAuthType
+  providerType: IDPProviderType
+}
+
+const initialState: AddIDPStep1Type = {
+  name: '',
+  authType: IDPAuthType.OIDC,
+  providerType: IDPProviderType.OWN,
+}
+
 enum TAGS {
   IDP = 'idp',
 }
 
+export const slice = createSlice({
+  name: 'admin/idp/control',
+  initialState,
+  reducers: {
+    setName: (state, action: PayloadAction<string>) => ({
+      ...state,
+      name: action.payload,
+    }),
+    setAuthType: (state, action: PayloadAction<IDPAuthType>) => ({
+      ...state,
+      authType: action.payload,
+    }),
+    setProviderType: (state, action: PayloadAction<IDPProviderType>) => ({
+      ...state,
+      providerType: action.payload,
+    }),
+  },
+})
+
+export const idpAddSelector = (state: RootState): AddIDPStep1Type =>
+  state.admin.idp
+
+export const idpAddNameSelector = (state: RootState): string =>
+  state.admin.idp.name
+
+export const idpAddAuthTypeSelector = (state: RootState): IDPAuthType =>
+  state.admin.idp.authType
+
+export const idpAddProviderTypeSelector = (state: RootState): IDPProviderType =>
+  state.admin.idp.providerType
+
 export const apiSlice = createApi({
-  reducerPath: 'rtk/admin/idp',
+  reducerPath: 'admin/idp/api',
   baseQuery: fetchBaseQuery(apiBaseQuery()),
   tagTypes: [TAGS.IDP],
   endpoints: (builder) => ({
@@ -217,6 +261,8 @@ export const apiSlice = createApi({
   }),
 })
 
+export const { setName, setAuthType, setProviderType } = slice.actions
+
 export const {
   useFetchIDPListQuery,
   useFetchIDPDetailQuery,
@@ -228,3 +274,5 @@ export const {
   useEnableIDPMutation,
   useUpdateUserIDPMutation,
 } = apiSlice
+
+export default slice

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -22,8 +22,10 @@ import { combineReducers } from 'redux'
 import { slice as registration } from './registration/slice'
 import { slice as user } from './userDeprecated/slice'
 import { slice as userOwn } from './userOwn/slice'
+import { slice as idp } from './idpApiSlice'
 
 export default combineReducers({
+  idp: idp.reducer,
   user: user.reducer,
   registration: registration.reducer,
   userOwn: userOwn.reducer,

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -37,7 +37,7 @@ import appSubscriptionSlice from './appSubscription/slice'
 import adminBoardSlice from './adminBoard/slice'
 import modelsSlice from './semanticModels/slice'
 import updateCompanyRoleSlice from './companyRoles/slice'
-import { apiSlice as idpSlice } from './admin/idpApiSlice'
+import { apiSlice as idpApiSlice } from './admin/idpApiSlice'
 import userAddSlice, { apiSlice as userSlice } from './admin/userApiSlice'
 import { apiSlice as serviceSlice } from './admin/serviceApiSlice'
 import { apiSlice as notificationSlice } from './notification/apiSlice'
@@ -91,7 +91,7 @@ export const reducers = {
   notification: notificationSliceDep.reducer,
   error: ErrorSlice.reducer,
   languageSlice: languageSlice.reducer,
-  [idpSlice.reducerPath]: idpSlice.reducer,
+  [idpApiSlice.reducerPath]: idpApiSlice.reducer,
   [userSlice.reducerPath]: userSlice.reducer,
   [serviceSlice.reducerPath]: serviceSlice.reducer,
   [notificationSlice.reducerPath]: notificationSlice.reducer,
@@ -125,7 +125,7 @@ export const store = configureStore({
   reducer: combineReducers(reducers),
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ serializableCheck: false })
-      .concat(idpSlice.middleware)
+      .concat(idpApiSlice.middleware)
       .concat(userSlice.middleware)
       .concat(serviceSlice.middleware)
       .concat(notificationSlice.middleware)

--- a/src/services/NotifyService.ts
+++ b/src/services/NotifyService.ts
@@ -27,9 +27,9 @@ const NOTIFY_TIME = 7000
 const NotifyService = {
   notify: (item: Notify) => {
     if (item.severity === SeverityType.ERROR) {
-      log.error(`${item.title}, ${item.msg}`, item.data)
+      log.error(`${item.title}, ${item.msg ?? ''}`, item.data ?? '')
     } else {
-      log.info(`${item.title}, ${item.msg}`, item.data)
+      log.info(`${item.title}, ${item.msg ?? ''}`, item.data ?? '')
     }
     store.dispatch(enq(item))
     setTimeout(() => store.dispatch(deq()), NOTIFY_TIME)


### PR DESCRIPTION
## Description

Show only two steps in IDP add stepper when provider type MANAGED is selected.

## Why

This type only requires two steps, however three were displayed under certain circumstances.
Note: this is a minor UI glitch, therefore no changelog update.

## Issue

ref. Jira CPLP-3684

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally