### PR TITLE
fix(test): remove dev env from image urls

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -358,7 +358,7 @@ npm/npmjs/-/has-flag/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/has-property-descriptors/1.0.0, MIT, approved, #11098
 npm/npmjs/-/has-proto/1.0.1, MIT, approved, #6175
 npm/npmjs/-/has-symbols/1.0.3, MIT, approved, clearlydefined
-npm/npmjs/-/has-tostringtag/1.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/has-tostringtag/1.0.0, MIT, approved, #13161
 npm/npmjs/-/has/1.0.4, MIT, approved, #10930
 npm/npmjs/-/he/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/hoist-non-react-statics/3.3.2, BSD-3-Clause, approved, clearlydefined

--- a/src/components/pages/Test/index.image.tsx
+++ b/src/components/pages/Test/index.image.tsx
@@ -1,6 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/components/pages/Test/index.image.tsx
+++ b/src/components/pages/Test/index.image.tsx
@@ -24,7 +24,7 @@ import {
   TransparentPixel,
 } from '@catena-x/portal-shared-components'
 import { useEffect, useState } from 'react'
-import { getApiBase } from 'services/EnvironmentService'
+import { getApiBase, getAssetBase } from 'services/EnvironmentService'
 import { fetchImageWithToken } from 'services/ImageService'
 
 export default function ImageTest() {
@@ -33,9 +33,7 @@ export default function ImageTest() {
   const [data, setData] = useState<string>(TransparentPixel)
 
   useEffect(() => {
-    fetchImageWithToken(
-      'https://portal.dev.demo.catena-x.net/assets/images/frame/Home.png'
-    )
+    fetchImageWithToken(`${getAssetBase()}/images/frame/Home.png`)
       .then((buffer) => {
         setData(URL.createObjectURL(new Blob([buffer], { type: 'image/png' })))
       })
@@ -61,16 +59,9 @@ export default function ImageTest() {
           }
           style={style}
         />
+        <Image src={'/assets/images/icons/book.svg'} style={style} />
         <Image
-          src={
-            'https://portal.dev.demo.catena-x.net/assets/images/icons/book.svg'
-          }
-          style={style}
-        />
-        <Image
-          src={
-            'https://portal.dev.demo.catena-x.net/assets/images/frame/Home.jpg'
-          }
+          src={`${getAssetBase()}/assets/images/frame/Home.jpg`}
           style={style}
         />
         <Image src={data} style={style} />
@@ -92,9 +83,7 @@ export default function ImageTest() {
           />
           <Image src={'data:image/svg+xml;base64,ertiouiertui'} style={style} />
           <Image
-            src={
-              'https://portal-backend.dev.demo.catena-x.net/api/apps/d245d2fe-e567-44e4-9c15-5a0e4a733b9a/appDocuments/id_not_existing'
-            }
+            src={`${getApiBase()}/api/apps/d245d2fe-e567-44e4-9c15-5a0e4a733b9a/appDocuments/id_not_existing`}
             style={style}
           />
           <Image

--- a/src/services/EnvironmentService.ts
+++ b/src/services/EnvironmentService.ts
@@ -1,6 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021, 2023 BMW Group AG
- * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,9 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-// Add an ESLint exception until there is a solution
-// eslint-disable-next-line
-declare const ENV: any
+declare const ENV: Record<string, string>
 
 export const getApiBase = () =>
   typeof ENV === 'undefined' ? '' : ENV.PORTAL_BACKEND_URL


### PR DESCRIPTION
## Description

Removed references to dev env in test code URLs

## Why

Code should not contain URLs of existing environments.

## Issue

#453 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
