### PR TITLE
fix(company role): show company role specific standard library info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.8.0-RC4
+
+- Company roles
+  - Show standard library infomration based on the selected company role
+
 ## 1.8.0-RC3
 
 ### Change

--- a/src/components/pages/CompanyRoles/index.tsx
+++ b/src/components/pages/CompanyRoles/index.tsx
@@ -34,6 +34,13 @@ import {
   useFetchStandardLibraryQuery,
 } from 'features/staticContent/staticContentApiSlice'
 
+enum URLs {
+  companyrolesappprovider = 'companyrolesappprovider',
+  companyrolesserviceprovider = 'companyrolesserviceprovider',
+  companyrolesconformitybody = 'companyrolesconformitybody',
+  companyrolesonboardingserviceprovider = 'companyrolesonboardingserviceprovider',
+}
+
 export default function CompanyRoles() {
   const [companyRoles, setCompanyRoles] = useState<CompanyType>()
   const [stdJson, setStdJson] = useState<StandardLibraryType>()
@@ -43,65 +50,44 @@ export default function CompanyRoles() {
   const [topReached, setTopReached] = useState<boolean>(false)
   const { data: companyRolesResponse } = useFetchCompanyRolesQuery()
   const { data: standardLibraryResponse } = useFetchStandardLibraryQuery()
-  let filterd: StandardLibraryType = {
-    rows: [],
-    useCases: [],
-    capabilities: [],
-    roles: [],
-    status: [],
-    typesOfDocuments: [],
-  }
 
   useEffect(() => {
+    const roles = []
     if (companyRolesResponse && standardLibraryResponse) {
-      if (url.indexOf('companyrolesappprovider') > 1) {
+      if (url.includes(URLs.companyrolesappprovider)) {
         setCompanyRoles(companyRolesResponse.appProvider)
         setLinkArray(companyRolesResponse.appProvider.subNavigation)
-        filterd = {
-          ...standardLibraryResponse,
-          rows: getFiltered(standardLibraryResponse, [3]),
-        }
-      } else if (url.indexOf('companyrolesserviceprovider') > 1) {
+        roles.push(3)
+      } else if (url.includes(URLs.companyrolesserviceprovider)) {
         setCompanyRoles(companyRolesResponse.serviceProvider)
         setLinkArray(companyRolesResponse.serviceProvider.subNavigation)
-        filterd = {
-          ...standardLibraryResponse,
-          rows: getFiltered(standardLibraryResponse, [2]),
-        }
-      } else if (url.indexOf('companyrolesconformitybody') > 1) {
+        roles.push(2)
+      } else if (url.includes(URLs.companyrolesconformitybody)) {
         setCompanyRoles(companyRolesResponse.conformity)
         setLinkArray(companyRolesResponse.conformity.subNavigation)
-        filterd = {
-          ...standardLibraryResponse,
-          rows: getFiltered(standardLibraryResponse, []),
-        }
-      } else if (url.indexOf('companyrolesonboardingserviceprovider') > 1) {
+      } else if (url.includes(URLs.companyrolesonboardingserviceprovider)) {
         setCompanyRoles(companyRolesResponse.ospProvider)
         setLinkArray(companyRolesResponse.ospProvider.subNavigation)
-        filterd = {
-          ...standardLibraryResponse,
-          rows: getFiltered(standardLibraryResponse, [15]),
-        }
+        roles.push(15)
       } else {
         setCompanyRoles(companyRolesResponse.participant)
         setLinkArray(companyRolesResponse.participant.subNavigation)
-        filterd = {
-          ...standardLibraryResponse,
-          rows: getFiltered(standardLibraryResponse, [6]),
-        }
+        roles.push(6)
       }
-      setStdJson(filterd)
+      setStdJson({
+        ...standardLibraryResponse,
+        rows: getFiltered(standardLibraryResponse, roles),
+      })
     }
   }, [url, language, companyRolesResponse, standardLibraryResponse])
 
   const intersect = (a: number[], b: number[]) =>
     a.filter((value: number) => b.includes(value))
 
-  const getFiltered = (std: StandardLibraryType, cr: number[]) => {
-    return std.rows.filter(
+  const getFiltered = (std: StandardLibraryType, cr: number[]) =>
+    std.rows.filter(
       (row: { roles: number[] }) => intersect(row.roles, cr).length > 0
     )
-  }
 
   const scrollStarted = () => {
     setTopReached(window.scrollY > 500)

--- a/src/components/pages/CompanyRoles/index.tsx
+++ b/src/components/pages/CompanyRoles/index.tsx
@@ -43,31 +43,65 @@ export default function CompanyRoles() {
   const [topReached, setTopReached] = useState<boolean>(false)
   const { data: companyRolesResponse } = useFetchCompanyRolesQuery()
   const { data: standardLibraryResponse } = useFetchStandardLibraryQuery()
+  let filterd: StandardLibraryType = {
+    rows: [],
+    useCases: [],
+    capabilities: [],
+    roles: [],
+    status: [],
+    typesOfDocuments: [],
+  }
 
   useEffect(() => {
-    if (companyRolesResponse) {
+    if (companyRolesResponse && standardLibraryResponse) {
       if (url.indexOf('companyrolesappprovider') > 1) {
         setCompanyRoles(companyRolesResponse.appProvider)
         setLinkArray(companyRolesResponse.appProvider.subNavigation)
+        filterd = {
+          ...standardLibraryResponse,
+          rows: getFiltered(standardLibraryResponse, [3]),
+        }
       } else if (url.indexOf('companyrolesserviceprovider') > 1) {
         setCompanyRoles(companyRolesResponse.serviceProvider)
         setLinkArray(companyRolesResponse.serviceProvider.subNavigation)
+        filterd = {
+          ...standardLibraryResponse,
+          rows: getFiltered(standardLibraryResponse, [2]),
+        }
       } else if (url.indexOf('companyrolesconformitybody') > 1) {
         setCompanyRoles(companyRolesResponse.conformity)
         setLinkArray(companyRolesResponse.conformity.subNavigation)
+        filterd = {
+          ...standardLibraryResponse,
+          rows: getFiltered(standardLibraryResponse, []),
+        }
       } else if (url.indexOf('companyrolesonboardingserviceprovider') > 1) {
         setCompanyRoles(companyRolesResponse.ospProvider)
         setLinkArray(companyRolesResponse.ospProvider.subNavigation)
+        filterd = {
+          ...standardLibraryResponse,
+          rows: getFiltered(standardLibraryResponse, [15]),
+        }
       } else {
         setCompanyRoles(companyRolesResponse.participant)
         setLinkArray(companyRolesResponse.participant.subNavigation)
+        filterd = {
+          ...standardLibraryResponse,
+          rows: getFiltered(standardLibraryResponse, [6]),
+        }
       }
+      setStdJson(filterd)
     }
-  }, [url, language, companyRolesResponse])
+  }, [url, language, companyRolesResponse, standardLibraryResponse])
 
-  useEffect(() => {
-    setStdJson(standardLibraryResponse)
-  }, [language, standardLibraryResponse])
+  const intersect = (a: number[], b: number[]) =>
+    a.filter((value: number) => b.includes(value))
+
+  const getFiltered = (std: StandardLibraryType, cr: number[]) => {
+    return std.rows.filter(
+      (row: { roles: number[] }) => intersect(row.roles, cr).length > 0
+    )
+  }
 
   const scrollStarted = () => {
     setTopReached(window.scrollY > 500)

--- a/src/components/shared/templates/Templates.scss
+++ b/src/components/shared/templates/Templates.scss
@@ -28,7 +28,7 @@
   width: 100%;
   justify-content: flex-start;
   padding-left: 160px;
-  padding-right: 80px;
+  padding-right: 160px;
 
   h4 {
     font-size: 16px;
@@ -37,8 +37,9 @@
 }
 
 .subNavigationContainer button {
-  margin-right: 20px;
-  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .customHeight {


### PR DESCRIPTION
## Description

Show company role specific standard library info in the table instead of all.

## Why

do not show all std library info in the company role page

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
