### PR TITLE
feat(portal navigation): handle navigation as per status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.6.0-RC4 (unreleased)
+
+### Change
+
+- handle portal login navigation as per applicationType and applicationStatus
+
 ## 1.8.0-RC3
 
 ### Change

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -146,6 +146,10 @@
       "helpText": "If you have any questions regarding your registration please contact our helpdesk:",
       "email": "help@catena-x.com"
     },
+    "registrationDeclined": {
+      "title": "Registration Status",
+      "description": "<strong>After careful consideration, we regret to inform you that we are unable to approve your registration at this time.</strong><br /><br />Details/reasons for the cancellation have been provided via email.Your account will get disabled soon."
+    },
     "admin": {
       "registration-requests": {
         "columns": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -145,6 +145,10 @@
       "helpText": "If you have any questions regarding your registration please contact our helpdesk:",
       "email": "help@catena-x.com"
     },
+    "registrationDeclined": {
+      "title": "Registration Status",
+      "description": "<strong style='color: red'>After careful consideration, we regret to inform you that we are unable to approve your registration at this time.</strong><br /><br />Details/reasons for the cancellation have been provided via email.Your account will get disabled soon."
+    },
     "admin": {
       "registration-requests": {
         "columns": {

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from 'react-i18next'
 import AccessService from '../services/AccessService'
 import MainOverlay from './MainOverlay'
 import { show } from 'features/control/overlay'
-import type { OVERLAYS } from 'types/Constants'
+import { OVERLAYS } from 'types/Constants'
 import MainNotify from './MainNotify'
 import MainSearchOverlay from './shared/frame/SearchOverlay'
 import { MenuInfo } from './pages/Home/components/MenuInfo'
@@ -57,11 +57,14 @@ export default function Main() {
   if (
     companyData &&
     [
-      ApplicationStatus.SUBMITTED,
-      ApplicationStatus.DECLINED,
-      ApplicationStatus.APPROVED,
-    ].indexOf(companyData.applicationStatus) === -1 &&
-    Object.values(ApplicationStatus).includes(companyData.applicationStatus)
+      ApplicationStatus.CREATED,
+      ApplicationStatus.ADD_COMPANY_DATA,
+      ApplicationStatus.INVITE_USER,
+      ApplicationStatus.SELECT_COMPANY_ROLE,
+      ApplicationStatus.UPLOAD_DOCUMENTS,
+      ApplicationStatus.VERIFY,
+    ].includes(companyData.applicationStatus) &&
+    !location.search.includes('overlay=consent_osp')
   ) {
     if (companyData.applicationType === ApplicationType.INTERNAL) {
       return (
@@ -77,7 +80,7 @@ export default function Main() {
           <MenuInfo main={[]} />
         </>
       )
-    } else window.location.replace('/?overlay=consent_osp')
+    } else dispatch(show(OVERLAYS.CONSENT_OSP))
   }
 
   return (

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -34,6 +34,7 @@ import MainSearchOverlay from './shared/frame/SearchOverlay'
 import { MenuInfo } from './pages/Home/components/MenuInfo'
 import {
   ApplicationStatus,
+  ApplicationType,
   useFetchApplicationsQuery,
 } from 'features/registration/registrationApiSlice'
 import './styles/main.scss'
@@ -55,22 +56,28 @@ export default function Main() {
 
   if (
     companyData &&
-    companyData.applicationStatus !== ApplicationStatus.SUBMITTED &&
+    [
+      ApplicationStatus.SUBMITTED,
+      ApplicationStatus.DECLINED,
+      ApplicationStatus.APPROVED,
+    ].indexOf(companyData.applicationStatus) === -1 &&
     Object.values(ApplicationStatus).includes(companyData.applicationStatus)
   ) {
-    return (
-      <>
-        <Header main={[]} user={AccessService.userMenuReg()} />
-        <MainSearchOverlay />
-        {window.location.pathname === '/logout' ? (
-          <Logout />
-        ) : (
-          <RegistrationStatus />
-        )}
-        <Footer pages={AccessService.footerMenu()} />
-        <MenuInfo main={[]} />
-      </>
-    )
+    if (companyData.applicationType === ApplicationType.INTERNAL) {
+      return (
+        <>
+          <Header main={[]} user={AccessService.userMenuReg()} />
+          <MainSearchOverlay />
+          {window.location.pathname === '/logout' ? (
+            <Logout />
+          ) : (
+            <RegistrationStatus />
+          )}
+          <Footer pages={AccessService.footerMenu()} />
+          <MenuInfo main={[]} />
+        </>
+      )
+    } else window.location.replace('/?overlay=consent_osp')
   }
 
   return (

--- a/src/components/shared/frame/Header/RegistrationDeclinedOverlay/index.tsx
+++ b/src/components/shared/frame/Header/RegistrationDeclinedOverlay/index.tsx
@@ -18,68 +18,56 @@
  ********************************************************************************/
 
 import { Trans, useTranslation } from 'react-i18next'
-import { useMediaQuery, useTheme } from '@mui/material'
 import {
-  Button,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogActions,
   Typography,
 } from '@catena-x/portal-shared-components'
-import RegistrationReviewContent from './RegistrationReviewContent'
-import './RegistrationReview.scss'
 
 export type StatusTagIcon = {
   type?: 'confirmed' | 'pending' | 'declined' | 'label'
 }
 
-export type RegistrationReviewProps = {
+export type RegistrationDeclinedProps = {
   openDialog: boolean
   handleOverlayClose: React.MouseEventHandler
 }
 
-const RegistrationReviewOverlay = ({
+const RegistrationDeclinedOverlay = ({
   openDialog,
   handleOverlayClose,
-}: RegistrationReviewProps) => {
+}: RegistrationDeclinedProps) => {
   const { t } = useTranslation()
-  const theme = useTheme()
-
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'), {
-    defaultMatches: true,
-  })
 
   return (
     <Dialog
       open={openDialog}
       additionalModalRootStyles={{
-        width: isMobile ? '80%' : '50%',
+        width: '50%',
       }}
     >
-      <DialogHeader title={t('content.registrationInreview.title')} />
+      <DialogHeader title={t('content.registrationDeclined.title')} />
       <DialogContent
         sx={{
-          padding: isMobile ? '0 30px' : '0 120px',
+          padding: '0 120px',
           marginBottom: 5,
         }}
       >
         <div className="registration-review">
           <Trans>
-            <Typography variant="body1" className="description">
-              {t('content.registrationInreview.description')}
+            <Typography variant="body2">
+              {t('content.registrationDeclined.description')}
             </Typography>
           </Trans>
-          <RegistrationReviewContent />
         </div>
       </DialogContent>
-      <DialogActions helperText={t('content.registrationInreview.helperText')}>
-        <Button variant="contained" size="small" onClick={handleOverlayClose}>
-          {t('global.actions.close')}
-        </Button>
-      </DialogActions>
+      <DialogActions
+        helperText={t('content.registrationInreview.helperText')}
+      ></DialogActions>
     </Dialog>
   )
 }
 
-export default RegistrationReviewOverlay
+export default RegistrationDeclinedOverlay

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -48,6 +48,7 @@ import { Logo } from '../Logo'
 import RegistrationReviewOverlay from './RegistrationReviewOverlay'
 import './Header.scss'
 import RegistrationReviewContent from './RegistrationReviewOverlay/RegistrationReviewContent'
+import RegistrationDeclinedOverlay from './RegistrationDeclinedOverlay'
 
 export const Header = ({ main, user }: { main: Tree[]; user: string[] }) => {
   const { t } = useTranslation()
@@ -63,8 +64,11 @@ export const Header = ({ main, user }: { main: Tree[]; user: string[] }) => {
   const { data } = useFetchApplicationsQuery()
   const companyData = data?.[0]
 
-  const [overlayOpen, setOverlayOpen] = useState(
+  const [submittedOverlayOpen, setSubmittedOverlayOpen] = useState(
     companyData?.applicationStatus === ApplicationStatus.SUBMITTED
+  )
+  const [declinedOverlayOpen, setDeclinedOverlayOpen] = useState(
+    companyData?.applicationStatus === ApplicationStatus.DECLINED
   )
   const [headerNote, setHeaderNote] = useState(false)
 
@@ -209,9 +213,16 @@ export const Header = ({ main, user }: { main: Tree[]; user: string[] }) => {
       </div>
       {headerNote && renderRegistrationNoteSection()}
       <RegistrationReviewOverlay
-        openDialog={overlayOpen}
+        openDialog={submittedOverlayOpen}
         handleOverlayClose={() => {
-          setOverlayOpen(false)
+          setSubmittedOverlayOpen(false)
+          setHeaderNote(true)
+        }}
+      />
+      <RegistrationDeclinedOverlay
+        openDialog={declinedOverlayOpen}
+        handleOverlayClose={() => {
+          setDeclinedOverlayOpen(false)
           setHeaderNote(true)
         }}
       />

--- a/src/features/registration/registrationApiSlice.ts
+++ b/src/features/registration/registrationApiSlice.ts
@@ -28,6 +28,13 @@ export enum ApplicationStatus {
   UPLOAD_DOCUMENTS = 'UPLOAD_DOCUMENTS',
   VERIFY = 'VERIFY',
   SUBMITTED = 'SUBMITTED',
+  DECLINED = 'DECLINED',
+  APPROVED = 'APPROVED',
+}
+
+export enum ApplicationType {
+  INTERNAL = 'INTERNAL',
+  EXTERNAL = 'EXTERNAL',
 }
 
 export type ApplicationChecklist = {
@@ -39,6 +46,7 @@ export type ApplicationResponse = {
   applicationId: string
   applicationStatus: ApplicationStatus
   applicationChecklist: ApplicationChecklist[]
+  applicationType: ApplicationType
 }
 
 export const apiSlice = createApi({


### PR DESCRIPTION
## Description

Handle portal login navigation as per applicationStatus and applicationType

## Why

Portal login navigation handling

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/468

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
