### PR TITLE
fix(invite bpn): fix loading btn issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Add missing translations, fix duplicate error
 - Service Release Process
   - fixed conformity document deletion issue after uploading document
+- Invite Business Partner
+  - fix loading button issue to invite multiple companies in succession
 
 ## 1.8.0-RC3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## unreleased 1.8.0-RC4
 
-
 - Service overview
   - Add missing translations, fix duplicate error
 - Service Release Process

--- a/src/components/pages/InviteBusinessPartner/index.tsx
+++ b/src/components/pages/InviteBusinessPartner/index.tsx
@@ -78,6 +78,7 @@ export default function InviteBusinessPartner() {
         setFailureOverlayOpen(true)
         setInviteOverlayOpen(false)
       })
+    setProcessing(ProcessingType.INPUT)
   }
 
   return (


### PR DESCRIPTION
## Description

Please include a summary of the change.

## Why

Not possible to invite multiple companies in succession as loading button still appears

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/428

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
