### PR TITLE
fix(notifications): handle set read correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased 1.8.0-RC5
+
+- Notifications
+  - handle set read/unread correctly
+
 ## 1.8.0-RC4
 
 ### Change

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -256,7 +256,7 @@ export default function NotificationItem({
 
   const toggleOpen = () => {
     const nextState = !open
-    if (nextState && !item.isRead) {
+    if (nextState && !userRead) {
       void setRead(true)
     }
     setOpen(nextState)

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -28,12 +28,8 @@ import {
 import {
   type CXNotificationContent,
   NotificationType,
-  PAGE,
-  PAGE_SIZE,
-  SORT_OPTION,
-  NOTIFICATION_TOPIC,
 } from 'features/notification/types'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { NavLink } from 'react-router-dom'
 import UserService from 'services/UserService'
@@ -45,8 +41,6 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import CloseIcon from '@mui/icons-material/Close'
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
 import DeleteNotificationConfirmOverlay from './DeleteNotificationConfirmOverlay'
-import { useDispatch } from 'react-redux'
-import { resetInitialNotificationState } from 'features/notification/actions'
 import { PAGES } from 'types/Constants'
 import DoneIcon from '@mui/icons-material/Done'
 import EmailIcon from '@mui/icons-material/Email'
@@ -243,31 +237,27 @@ export default function NotificationItem({
   const [deleteNotification] = useDeleteNotificationMutation()
   const [showDeleteModal, setShowDeleteModal] = useState<boolean>(false)
   const [loading, setLoading] = useState<boolean>(false)
-  const dispatch = useDispatch()
-  const [userRead, setUserRead] = useState<boolean>(false)
+  const [userRead, setUserRead] = useState<boolean>(item.isRead ?? false)
 
   item = {
     ...item,
     contentParsed: JSON.parse(item.content ?? '{}'),
   }
 
-  const setRead = async (id: string, flag: boolean) => {
+  const setRead = async (flag: boolean) => {
     try {
-      await setNotificationRead({ id, flag })
+      await setNotificationRead({ id: item.id, flag }).unwrap()
+      item.isRead = flag
+      setUserRead(flag)
     } catch (error: unknown) {
       console.log(error)
     }
   }
 
-  useEffect(() => {
-    setUserRead(item.userRead)
-  }, [item.userRead])
-
-  const toggle = () => {
+  const toggleOpen = () => {
     const nextState = !open
-    if (nextState && !userRead) {
-      setUserRead(true)
-      void setRead(item.id, true)
+    if (nextState && !item.isRead) {
+      void setRead(true)
     }
     setOpen(nextState)
   }
@@ -275,18 +265,6 @@ export default function NotificationItem({
   const onDelete = async () => {
     setLoading(true)
     await deleteNotification(item.id).unwrap()
-    dispatch(
-      resetInitialNotificationState({
-        page: PAGE,
-        size: PAGE_SIZE,
-        args: {
-          searchQuery: '',
-          searchTypeIds: [],
-          notificationTopic: NOTIFICATION_TOPIC.ALL,
-          sorting: SORT_OPTION,
-        },
-      })
-    )
     setShowDeleteModal(false)
   }
 
@@ -305,7 +283,9 @@ export default function NotificationItem({
         />
       )}
       <li
-        onClick={toggle}
+        onClick={() => {
+          toggleOpen()
+        }}
         onKeyDown={() => {
           // do nothing
         }}
@@ -388,9 +368,8 @@ export default function NotificationItem({
             <div
               className="padding-r-10"
               onClick={(e) => {
-                setUserRead(!userRead)
-                setRead(item.id, !userRead)
                 e.stopPropagation()
+                setRead(!userRead)
               }}
               onKeyDown={() => {
                 // do nothing

--- a/src/features/notification/apiSlice.ts
+++ b/src/features/notification/apiSlice.ts
@@ -40,15 +40,23 @@ export interface NotificationReadType {
   flag: boolean
 }
 
+enum TAG {
+  ITEMS = 'ITEMS',
+  META = 'META',
+}
+
 export const apiSlice = createApi({
   reducerPath: `${name}/api`,
   baseQuery: fetchBaseQuery(apiBaseQuery()),
+  tagTypes: [TAG.ITEMS, TAG.META],
   endpoints: (builder) => ({
     getNotificationCount: builder.query<number, boolean>({
       query: (read) => `/api/notification/count?isRead=${read}`,
+      providesTags: [TAG.ITEMS],
     }),
     getNotificationMeta: builder.query<CXNotificationMeta, null>({
       query: () => '/api/notification/count-details',
+      providesTags: [TAG.META],
     }),
     getNotifications: builder.query<CXNotification, NotificationFetchType>({
       query: (fetchArgs) =>
@@ -68,18 +76,21 @@ export const apiSlice = createApi({
         }&sorting=${
           fetchArgs?.args?.sorting ?? NotificationSortingType.DateDesc
         }`,
+      providesTags: [TAG.ITEMS],
     }),
     setNotificationRead: builder.mutation<void, NotificationReadType>({
       query: (obj) => ({
         url: `/api/notification/${obj.id}/read?isRead=${obj.flag}`,
         method: 'PUT',
       }),
+      invalidatesTags: [TAG.META],
     }),
     deleteNotification: builder.mutation<void, string>({
       query: (id) => ({
         url: `/api/notification/${id}`,
         method: 'DELETE',
       }),
+      invalidatesTags: [TAG.ITEMS, TAG.META],
     }),
   }),
 })


### PR DESCRIPTION
## Description

Handle set read/unread correctly

## Why

Notifications were not shown correcty as read or unread and the count of new items was wrong.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally