### PR TITLE
fix(IDP management): allow extend range for extID field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## unreleased 1.8.0-RC5
+
+### Bugfix
+
+- IDP Management
+  - Allow 6-36 alphanumeric characters for IDP extID
+
 ## 1.8.0-RC4
 
 ### Change

--- a/src/components/overlays/OSPRegister/OSPRegisterContent.tsx
+++ b/src/components/overlays/OSPRegister/OSPRegisterContent.tsx
@@ -25,6 +25,7 @@ import {
   isCityName,
   isCompanyName,
   isCountryCode,
+  isExtID,
   isFirstName,
   isID,
   isLastName,
@@ -33,7 +34,6 @@ import {
   isRegionNameOrEmpty,
   isStreetName,
   isStreetNumberOrEmpty,
-  isUUID,
   isZipCodeOrEmpty,
 } from 'types/Patterns'
 import { useTranslation } from 'react-i18next'
@@ -103,7 +103,7 @@ const OSPRegisterForm = ({
         name={'extid'}
         label={t('field.extid.name')}
         hint={t('field.extid.hint')}
-        validate={isUUID}
+        validate={isExtID}
         onInvalid={invalidate}
         onValid={(_key, value: string) => {
           updateData({

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -34,6 +34,7 @@ export const Patterns = {
     'i'
   ),
   UUID: /^[a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8}$/i,
+  EXTID: /^[a-z0-9]{6,36}$/i,
   COMPANY_NAME:
     /^\d*?[a-zÀ-ÿ]\d?([a-z0-9À-ÿ!?@&_£$€¥\-.,:;'()*+#%=]\s?){2,40}$/i,
   name: /^([A-Za-zÀ-ÿ-,.'](?!.*[-,.]{2})[A-Za-zÀ-ÿ-,.']{1,40} ?)[^ –]{1,40}$/,
@@ -102,6 +103,8 @@ export const isURL = (expr: string) => Patterns.URL.test(expr)
 export const isKeycloakURL = (expr: string) =>
   isURL(expr) && !expr.includes('#')
 export const isUUID = (expr: string) => Patterns.UUID.test(expr)
+export const isExtID = (expr: string) =>
+  Patterns.EXTID.test(expr) || isUUID(expr)
 export const isCompanyName = (expr: string) => Patterns.COMPANY_NAME.test(expr)
 export const isName = (expr: string) => Patterns.name.test(expr)
 export const isCityName = isName


### PR DESCRIPTION
## Description

Allow 6-36 alphanumeric characters for IDP extId

## Why

Existing check for UUIDs is too restrictive.

## Issue

#477 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally