### PR TITLE
fix(company wallet): update status text and sub navigation link

### DIFF
--- a/src/components/pages/CompanyWallet/ComapnyWalletSubNavigationHeader.tsx
+++ b/src/components/pages/CompanyWallet/ComapnyWalletSubNavigationHeader.tsx
@@ -34,7 +34,7 @@ export default function ComapnyWalletSubNavigationHeader(): JSX.Element {
     },
     {
       title: t('content.companyWallet.subnavigation.button2'),
-      link: '/company-role',
+      link: '/certificate-credential',
     },
     {
       title: t('content.companyWallet.subnavigation.button3'),

--- a/src/components/pages/CompanyWallet/RuleCard.tsx
+++ b/src/components/pages/CompanyWallet/RuleCard.tsx
@@ -69,7 +69,7 @@ export default function RuleCard({
               >
                 <div key={item.id} className="rule-card-container">
                   <Typography className="text" variant="body2">
-                    {item?.credentialSubject[0].status ?? 'Inactive'}
+                    {item?.credentialSubject[0].status ?? 'Unknown'}
                   </Typography>
                   <Typography className="text" variant="h4">
                     {item?.credentialSubject[0].type}


### PR DESCRIPTION
## Description

display unknown if status is not present instead of inactive. update sub navigation link to credential certificate page

## Why

wrong text and link configured

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
