### PR TITLE
fix(idp users): user invite logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - handle navigation as per applicationType and applicationStatus
 - App Management
   - Template file encoding updated for 'technical integration' and 'add roles overlay' and deleted previos template
+- User Invite IdP
+  - Blocked user invite if multiple SHARED/OWN identityProviderTypeId
 
 ## 1.8.0-RC4
 

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -46,10 +46,12 @@ const MenuItemOpenOverlay = ({
   overlay,
   id,
   label,
+  idps,
 }: {
   overlay: OVERLAYS
   id: string
   label: string
+  idps?: IdentityProvider[]
 }) => {
   const dispatch = useDispatch()
 
@@ -60,7 +62,7 @@ const MenuItemOpenOverlay = ({
   ) => {
     try {
       e.stopPropagation()
-      dispatch(show(overlay, id))
+      dispatch(show(overlay, id, '', false, '', [], idps))
     } catch (error) {
       console.log(error)
     }
@@ -138,6 +140,12 @@ export const IDPList = () => {
   }
 
   const renderMenu = (idp: IdentityProvider) => {
+    const isMultipleSharedOwn = idpsData?.filter(
+      (idp) =>
+        idp.identityProviderTypeId === IDPCategory.SHARED ||
+        idp.identityProviderTypeId === IDPCategory.OWN
+    ).length
+
     const menuItems = {
       configure: (
         <MenuItemOpenOverlay
@@ -146,11 +154,16 @@ export const IDPList = () => {
           label={ti('action.configure')}
         />
       ),
-      addUsers: (
+      addUsers: isMultipleSharedOwn && (
         <MenuItemOpenOverlay
-          overlay={OVERLAYS.ADDUSERS_IDP}
+          overlay={
+            isMultipleSharedOwn > 1
+              ? OVERLAYS.DENYUSERS_IDP
+              : OVERLAYS.ADDUSERS_IDP
+          }
           id={idp.identityProviderId}
           label={ti('action.users')}
+          idps={isMultipleSharedOwn > 1 ? idpsData : []}
         />
       ),
       delete: (

--- a/src/features/control/overlay.ts
+++ b/src/features/control/overlay.ts
@@ -21,6 +21,7 @@
 import { createAction, createSlice } from '@reduxjs/toolkit'
 import { OVERLAYS } from 'types/Constants'
 import type { RootState } from 'features/store'
+import { type IdentityProvider } from 'features/admin/idpApiSlice'
 
 export const name = 'control/overlay'
 
@@ -31,6 +32,7 @@ export type OverlayState = {
   status?: boolean
   subTitle?: string
   roles?: string[]
+  idps?: IdentityProvider[]
 }
 
 const initialState = {
@@ -40,6 +42,7 @@ const initialState = {
   displayName: '',
   subTitle: '',
   roles: [],
+  idps: [],
 }
 
 const closeOverlay = createAction(`${name}/closeOverlay`, () => ({
@@ -57,7 +60,8 @@ const show = createAction(
     title?: string,
     status?: boolean,
     subTitle?: string,
-    roles?: string[]
+    roles?: string[],
+    idps?: IdentityProvider[]
   ) => ({
     payload: {
       type,
@@ -66,6 +70,7 @@ const show = createAction(
       status,
       subTitle,
       roles,
+      idps,
     },
   })
 )

--- a/src/services/AccessService.tsx
+++ b/src/services/AccessService.tsx
@@ -74,6 +74,7 @@ import { OSPConsent } from 'components/overlays/OSPConsent'
 import { OSPRegisterNext } from 'components/overlays/OSPRegister/OSPRegisterNext'
 import CompanyCertificateDetails from 'components/overlays/CompanyCertificateDetails'
 import DeleteCompanyCertificateConfirmationOverlay from 'components/overlays/CompanyCertificateDetails/DeleteCompanyCertificateConfirmationOverlay'
+import { AddUserDeny } from 'components/overlays/AddUser/AddUserDeny'
 
 let pageMap: { [page: string]: IPage }
 let actionMap: { [action: string]: IAction }
@@ -180,6 +181,8 @@ export const getOverlay = (overlay: OverlayState) => {
       return <DisableIDP id={overlay.id} />
     case OVERLAYS.ADDUSERS_IDP:
       return <AddusersIDP id={overlay.id} />
+    case OVERLAYS.DENYUSERS_IDP:
+      return <AddUserDeny idps={overlay.idps ?? []} />
     case OVERLAYS.DELETE_IDP:
       return <DeleteIDP id={overlay.id} />
     case OVERLAYS.IDP_TEST_RUN:

--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -646,6 +646,10 @@ export const ALL_OVERLAYS: IOverlay[] = [
     role: ROLES.IDP_SETUP,
   },
   {
+    name: OVERLAYS.DENYUSERS_IDP,
+    role: ROLES.IDP_SETUP,
+  },
+  {
     name: OVERLAYS.IDP_TEST_RUN,
     role: ROLES.IDP_ADD,
   },

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -132,6 +132,7 @@ export enum OVERLAYS {
   DISABLE_IDP = 'disable_idp',
   DELETE_IDP = 'delete_idp',
   ADDUSERS_IDP = 'addusers_idp',
+  DENYUSERS_IDP = 'denyusers_idp',
   IDP_DETAILS = 'idp_details',
   IDP_CONFIRM = 'idp_confirm',
   IDP_STATUS = 'idp_status',


### PR DESCRIPTION
## Description

Blocked user invite if multiple SHARED/OWN identityProviderTypeId

## Why

The "add user not possible" should only get displayed if multiple SHARED/OWN "identityProviderTypeId"  and ignore MANAGED idps for the screen navigation

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/507

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
