### PR TITLE
fix(user management): remove quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased 1.8.0-RC6
+
+- User Management
+  - Removed quotation marks from technical user details
+
 ## 1.8.0-RC5
 
 ### Bugfix

--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -20,7 +20,7 @@
 
 import { Box } from '@mui/material'
 import { Typography } from '@catena-x/portal-shared-components'
-import { isValidElement, useState } from 'react'
+import { useState } from 'react'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 
 type DataValue = string | number | JSX.Element
@@ -46,7 +46,7 @@ const renderValue = (value: DataValue) => (
       wordBreak: 'break-all',
     }}
   >
-    {isValidElement(value) ? value : JSON.stringify(value)}
+    {value}
   </Typography>
 )
 
@@ -73,7 +73,7 @@ export const KeyValueView = ({ cols, title, items }: KeyValueViewProps) => {
           }, 1000)
         }}
       >
-        {renderValue(JSON.stringify(item.value) ?? '')}
+        {renderValue(item.value ?? '')}
         <ContentCopyIcon
           sx={{
             marginLeft: '10px',


### PR DESCRIPTION
## Description

Removed quotation marks from technical user details

## Why

As quotation marks are not needed, it should be removed

## Issue

Ref: [Issues-492](https://github.com/eclipse-tractusx/portal-frontend/issues/492)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally