### PR TITLE
fix(idp invite): add user filter idps on shared and own type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - handle navigation as per applicationType and applicationStatus
 - App Management
   - Template file encoding updated for 'technical integration' and 'add roles overlay' and deleted previos template
+- Idp User Invite Logic
+  - fix add user overlay issue
 
 ## 1.8.0-RC4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## unreleased 1.8.0-RC6
+
+### Bugfix
+
+- Idp User Invite Logic
+  - fix add user overlay issue
+
 ## 1.8.0-RC5
 
 ### Bugfix
@@ -17,8 +24,6 @@
   - handle navigation as per applicationType and applicationStatus
 - App Management
   - Template file encoding updated for 'technical integration' and 'add roles overlay' and deleted previos template
-- Idp User Invite Logic
-  - fix add user overlay issue
 - App Release Process - app role template file encoding updated
 
 ## 1.8.0-RC4

--- a/src/components/overlays/AddUser/index.tsx
+++ b/src/components/overlays/AddUser/index.tsx
@@ -26,6 +26,7 @@ import {
 import {
   useFetchIDPListQuery,
   type IdentityProvider,
+  IDPCategory,
 } from 'features/admin/idpApiSlice'
 import { AddUserContent } from './AddUserContent'
 import { AddUserDeny } from './AddUserDeny'
@@ -73,7 +74,13 @@ export const AddUser = () => {
   }
 
   const renderAdduserMainContent = () => {
-    return idps && idps.length === 1 ? (
+    return idps &&
+      idps.filter(
+        (idp) =>
+          (idp.identityProviderTypeId === IDPCategory.SHARED ||
+            idp.identityProviderTypeId === IDPCategory.OWN) &&
+          idp.enabled
+      ).length === 1 ? (
       <AddUserContent idp={idps[0]} />
     ) : (
       <AddUserDeny idps={idps} />


### PR DESCRIPTION
## Description

Blocked user invite if multiple SHARED/OWN identityProviderTypeId

## Why

The "add user not possible" should only get displayed if multiple SHARED/OWN "identityProviderTypeId"  and ignore MANAGED idps for the screen navigation

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/507

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
