### PR TITLE
fix(certificate): change certificate response type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Idp User Invite Logic
   - fix add user overlay issue
+- Certificate Crendentials
+  - fix certificate ui as per backend response
 
 ## 1.8.0-RC5
 

--- a/src/components/pages/CertificateCredentials/CertificateElements.tsx
+++ b/src/components/pages/CertificateCredentials/CertificateElements.tsx
@@ -41,21 +41,23 @@ export default function CertificateElements({
 
   return (
     <Grid container spacing={2} className="certificate-section">
-      {data?.map((item: CertificateResponse) => (
-        <Grid
-          item
-          xs={12}
-          sm={6}
-          md={6}
-          className="certificate-card"
-          key={item.credentialType}
-        >
-          <CertificateCard
-            credentialType={item.credentialType}
-            ssiDetailData={item.ssiDetailData}
-          />
-        </Grid>
-      ))}
+      {data?.map((item: CertificateResponse) =>
+        item.ssiDetailData?.map((certificate) => (
+          <Grid
+            item
+            xs={12}
+            sm={6}
+            md={6}
+            className="certificate-card"
+            key={item.credentialType}
+          >
+            <CertificateCard
+              credentialType={item.credentialType}
+              ssiDetailData={certificate}
+            />
+          </Grid>
+        ))
+      )}
     </Grid>
   )
 }

--- a/src/components/shared/basic/CertificateCard/index.tsx
+++ b/src/components/shared/basic/CertificateCard/index.tsx
@@ -29,7 +29,6 @@ import PendingOutlinedIcon from '@mui/icons-material/PendingOutlined'
 import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
 import { Typography } from '@catena-x/portal-shared-components'
 import {
-  type CertificateResponse,
   type SSIDetailData,
   StatusEnum,
 } from 'features/certification/certificationApiSlice'
@@ -52,7 +51,7 @@ export interface CertificateData {
 export const CertificateCard = ({
   credentialType,
   ssiDetailData,
-}: CertificateResponse) => {
+}: CertificateData) => {
   const { t } = useTranslation()
   const boxRef = useRef<HTMLDivElement>(null)
 

--- a/src/features/certification/certificationApiSlice.tsx
+++ b/src/features/certification/certificationApiSlice.tsx
@@ -41,7 +41,7 @@ export type SSIDetailData = {
 
 export type CertificateResponse = {
   credentialType: string
-  ssiDetailData: SSIDetailData | null
+  ssiDetailData: SSIDetailData[] | null
 }
 
 export type CertificateRequest = {


### PR DESCRIPTION
## Description

Changed certificate credential response as per backend

## Why

UI enhancement as per backend response

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/515

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
