### PR TITLE
chore: upgrade shared-components package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Idp user upload
   - fix blank page issue while uploading json file
 
+### Technical Support
+
+- upgraded portal-shared-components package due to CVE-2023-42282 in node-ip package
+
 ## 1.8.0-RC5
 
 - Application Requests

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1156,7 +1156,7 @@ npm/npmjs/@babel/traverse/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD
 npm/npmjs/@babel/types/7.23.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@babel/types/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/2.1.25, Apache-2.0 AND CC-BY-4.0, approved, #10502
+npm/npmjs/@catena-x/portal-shared-components/2.1.28, Apache-2.0 AND CC-BY-4.0, approved, #10502
 npm/npmjs/@csstools/normalize.css/12.0.0, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-cascade-layers/1.1.1, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-color-function/1.1.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3022

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1156,7 +1156,7 @@ npm/npmjs/@babel/traverse/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD
 npm/npmjs/@babel/types/7.23.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@babel/types/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/2.1.28, Apache-2.0 AND CC-BY-4.0, approved, #10502
+npm/npmjs/@catena-x/portal-shared-components/2.1.30, Apache-2.0 AND CC-BY-4.0, approved, #10502
 npm/npmjs/@csstools/normalize.css/12.0.0, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-cascade-layers/1.1.1, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-color-function/1.1.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3022

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^2.1.25",
+    "@catena-x/portal-shared-components": "^2.1.28",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^2.1.28",
+    "@catena-x/portal-shared-components": "^2.1.30",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^2.1.28":
-  version "2.1.28"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.28.tgz#e7b85ada90d8c1c613b29dc7b51d375006b4fd27"
-  integrity sha512-6Zdqi4t8n9KfQIfIuZ8OXYuzCqDtjeGRr0IufiMfRPenNtJaZePIQUn+xUbYJ3pAPUV5rLEgOcwcxH5tL3Wmnw==
+"@catena-x/portal-shared-components@^2.1.30":
+  version "2.1.30"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.30.tgz#0c9082a576d5c1cb5fabf1e731f81f5ca7f10c80"
+  integrity sha512-BHO/2OOUihdOAA/Uql+s/VUBfl9ToHVQRL8mFMXhb9DuYPi213+LDXP3422sGLNQrlzIdCdD2U6yRHh8CVMlEQ==
   dependencies:
     "@mui/base" "^5.0.0-beta.3"
     "@mui/system" "^5.13.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^2.1.25":
-  version "2.1.25"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.25.tgz#61e60d871f16adeb413b87a1da4b23847aa55b93"
-  integrity sha512-UKtYlgwXQUYocZZvIKqeZtRzuX1CoPvwl2eZ3+W++Rdwnxl/TvFcFaafoOizYIYlXYqEqSQJpDvPgahnok2IuQ==
+"@catena-x/portal-shared-components@^2.1.28":
+  version "2.1.28"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.28.tgz#e7b85ada90d8c1c613b29dc7b51d375006b4fd27"
+  integrity sha512-6Zdqi4t8n9KfQIfIuZ8OXYuzCqDtjeGRr0IufiMfRPenNtJaZePIQUn+xUbYJ3pAPUV5rLEgOcwcxH5tL3Wmnw==
   dependencies:
     "@mui/base" "^5.0.0-beta.3"
     "@mui/system" "^5.13.2"


### PR DESCRIPTION
## Description

upgrade shared-components package due to CVE-2023-42282 in node-ip package (transitive dependency over @storybook/core-server)

## Why

https://github.com/eclipse-tractusx/portal-shared-components/pull/97

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
