### PR TITLE
fix(delete user): fix logout redirect uri issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - User Management
   - Removed quotation marks from technical user details
+- Delete ownuser Redirect URL
+  - fixed logout redirect url issue
 
 ### Bugfix
 

--- a/src/components/overlays/ConfirmUserAction/index.tsx
+++ b/src/components/overlays/ConfirmUserAction/index.tsx
@@ -28,11 +28,12 @@ import {
   useDeleteMyUserMutation,
 } from 'features/admin/userApiSlice'
 import { Typography } from '@catena-x/portal-shared-components'
-import { closeOverlay } from 'features/control/overlay'
+import { closeOverlay, exec } from 'features/control/overlay'
 import { useNavigate } from 'react-router-dom'
 import UserService from 'services/UserService'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import { ServerResponseOverlay } from '../ServerResponse'
+import { ACTIONS } from 'types/Constants'
 
 export const ConfirmUserAction = ({
   id,
@@ -185,7 +186,7 @@ export const ConfirmUserAction = ({
     showLoading(false)
     if (title === 'ownUser') {
       setTimeout(() => {
-        UserService.doLogout({ redirectUri: `${document.location.origin} /` })
+        dispatch(exec(ACTIONS.SIGNOUT))
       }, 5000)
     }
   }


### PR DESCRIPTION
## Description

Fix logout Redirect URL issue

## Why

Logout Redirect URL was wrongly configured

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/505

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally