### PR TITLE
feat(decline login): add button to logout user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - User Management
   - Removed quotation marks from technical user details
+- Decline Status
+  - added button in overlay to logout deom portal
 
 ### Bugfix
 

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -152,7 +152,8 @@
     },
     "registrationDeclined": {
       "title": "Registration Status",
-      "description": "<strong>After careful consideration, we regret to inform you that we are unable to approve your registration at this time.</strong><br /><br />Details/reasons for the cancellation have been provided via email.Your account will get disabled soon."
+      "description": "<strong>After careful consideration, we regret to inform you that we are unable to approve your registration at this time.</strong><br /><br />Details/reasons for the cancellation have been provided via email.Your account will get disabled soon.",
+      "close": "Close the Page"
     },
     "admin": {
       "registration-requests": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -151,7 +151,8 @@
     },
     "registrationDeclined": {
       "title": "Registration Status",
-      "description": "<strong style='color: red'>After careful consideration, we regret to inform you that we are unable to approve your registration at this time.</strong><br /><br />Details/reasons for the cancellation have been provided via email.Your account will get disabled soon."
+      "description": "<strong style='color: red'>After careful consideration, we regret to inform you that we are unable to approve your registration at this time.</strong><br /><br />Details/reasons for the cancellation have been provided via email.Your account will get disabled soon.",
+      "close": "Close the Page"
     },
     "admin": {
       "registration-requests": {

--- a/src/components/shared/frame/Header/RegistrationDeclinedOverlay/index.tsx
+++ b/src/components/shared/frame/Header/RegistrationDeclinedOverlay/index.tsx
@@ -24,22 +24,23 @@ import {
   DialogHeader,
   DialogActions,
   Typography,
+  Button,
 } from '@catena-x/portal-shared-components'
+import { useDispatch } from 'react-redux'
+import { exec } from 'features/control/overlay'
+import { ACTIONS } from 'types/Constants'
 
 export type StatusTagIcon = {
   type?: 'confirmed' | 'pending' | 'declined' | 'label'
 }
 
-export type RegistrationDeclinedProps = {
-  openDialog: boolean
-  handleOverlayClose: React.MouseEventHandler
-}
-
 const RegistrationDeclinedOverlay = ({
   openDialog,
-  handleOverlayClose,
-}: RegistrationDeclinedProps) => {
+}: {
+  openDialog: boolean
+}) => {
   const { t } = useTranslation()
+  const dispatch = useDispatch()
 
   return (
     <Dialog
@@ -65,7 +66,14 @@ const RegistrationDeclinedOverlay = ({
       </DialogContent>
       <DialogActions
         helperText={t('content.registrationInreview.helperText')}
-      ></DialogActions>
+      >
+        <Button
+          variant="contained"
+          onClick={() => dispatch(exec(ACTIONS.SIGNOUT))}
+        >
+          {t('content.registrationDeclined.close')}
+        </Button>
+      </DialogActions>
     </Dialog>
   )
 }

--- a/src/components/shared/frame/Header/RegistrationDeclinedOverlay/index.tsx
+++ b/src/components/shared/frame/Header/RegistrationDeclinedOverlay/index.tsx
@@ -64,9 +64,7 @@ const RegistrationDeclinedOverlay = ({
           </Trans>
         </div>
       </DialogContent>
-      <DialogActions
-        helperText={t('content.registrationInreview.helperText')}
-      >
+      <DialogActions helperText={t('content.registrationInreview.helperText')}>
         <Button
           variant="contained"
           onClick={() => dispatch(exec(ACTIONS.SIGNOUT))}

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -67,9 +67,6 @@ export const Header = ({ main, user }: { main: Tree[]; user: string[] }) => {
   const [submittedOverlayOpen, setSubmittedOverlayOpen] = useState(
     companyData?.applicationStatus === ApplicationStatus.SUBMITTED
   )
-  const [declinedOverlayOpen, setDeclinedOverlayOpen] = useState(
-    companyData?.applicationStatus === ApplicationStatus.DECLINED
-  )
   const [headerNote, setHeaderNote] = useState(false)
 
   const addTitle = (items: Tree[] | undefined) =>
@@ -220,11 +217,7 @@ export const Header = ({ main, user }: { main: Tree[]; user: string[] }) => {
         }}
       />
       <RegistrationDeclinedOverlay
-        openDialog={declinedOverlayOpen}
-        handleOverlayClose={() => {
-          setDeclinedOverlayOpen(false)
-          setHeaderNote(true)
-        }}
+        openDialog={companyData?.applicationStatus === ApplicationStatus.DECLINED}
       />
     </>
   )

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -217,7 +217,9 @@ export const Header = ({ main, user }: { main: Tree[]; user: string[] }) => {
         }}
       />
       <RegistrationDeclinedOverlay
-        openDialog={companyData?.applicationStatus === ApplicationStatus.DECLINED}
+        openDialog={
+          companyData?.applicationStatus === ApplicationStatus.DECLINED
+        }
       />
     </>
   )


### PR DESCRIPTION
## Description

Add button to logout from decline overlay

## Why

There was no other way to logout from declined user

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/514

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
