### PR TITLE
fix(technical user): remove quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - User Management
   - Removed quotation marks from technical user details
+  - Removed quotation marks when technical user details is copied
 - Decline Status
   - added button in overlay to logout deom portal
 - Dataspace

--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -65,9 +65,9 @@ export const KeyValueView = ({ cols, title, items }: KeyValueViewProps) => {
           },
         }}
         onClick={async () => {
-          const value = JSON.stringify(item.value) ?? ''
-          await navigator.clipboard.writeText(value)
-          setCopied(value)
+          const value = item.value ?? ''
+          await navigator.clipboard.writeText(value as string)
+          setCopied(value as string)
           setTimeout(() => {
             setCopied('')
           }, 1000)


### PR DESCRIPTION
## Description

Removed quotation marks when technical user details is copied

## Why

Quotes are not required

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/492

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally