### PR TITLE
fix(app subscription): fix help links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   - fixed logout redirect url issue
 - Consent Pop-Up after registration
   - fix reappear overlay on every page even after consent updated
+- App Subscription
+  - fixed help links in configuration overlay
 
 ### Bugfix
 

--- a/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
@@ -48,9 +48,9 @@ import { Link } from 'react-router-dom'
 import { closeOverlay } from 'features/control/overlay'
 
 const TentantHelpURL =
-  '/documentation/?path=user%2F04.App%28s%29%2F05.+App-Subscription%2F04.+Subscription+Activation%28App+Provider%29.md'
+  '/documentation/?path=user%2F04.+App%28s%29%2F05.+App+Subscription%2F04.+Subscription+Activation+%28App+Provider%29.md'
 const ProfileHelpURL =
-  '/documentation/?path=user%2F04.App%28s%29%2F05.+App-Subscription%2F04.+Subscription+Activation%28App+Provider%29.md'
+  '/documentation/?path=user%2F04.+App%28s%29%2F05.+App+Subscription%2F04.+Subscription+Activation+%28App+Provider%29.md'
 
 interface ActivateSubscriptionProps {
   openDialog: boolean


### PR DESCRIPTION
## Description

fixed help links in configuration overlay

## Why

To redirect to valid documentation

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/493

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally