### PR TITLE
fix(service subscription): change header name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - fix reappear overlay on every page even after consent updated
 - OSP IDP
   - add disable, enable & delete sub-menu's to managed IdPs
+- Service subscription
+  - Changed 'Active Service Subscription' overlay section header for 'Technical User Details'
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## unreleased
+
+### Bugfix
+
+- Service subscription
+  - Changed 'Active Service Subscription' overlay section header for 'Technical User Details'
+
 ## 1.8.0-RC6
 
 ### Change

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -177,6 +177,7 @@
       "subtitle": "for ",
       "description": "In order to activate the subscription of {{company}}, follow these steps below, <br /><br />1. Activate the service subscription request.<br />2. Customer will be informed about the successfully activation<br />",
       "descriptionWithTechUser": "In order to activate the subscription of {{company}}, follow these steps below, <br /><br />1. Activate the service subscription request.<br />2. System - technical user (if needed) will get generated and credentials getting shared.<br />3. Configure your service with the specific technical user to ensure that the service is fully usable",
+      "technicalUserDetails": "Technische Benutzerdetails",
       "sectionHeader": "Technischer User Profil",
       "sectionDescription": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard .Lorem Ipsu",
       "close": "Close",

--- a/src/assets/locales/en/servicerelease.json
+++ b/src/assets/locales/en/servicerelease.json
@@ -177,6 +177,7 @@
       "subtitle": "for ",
       "description": "In order to activate the subscription of {{company}}, follow these steps below, <br /> <br />1. Activate the service subscription request.<br />2. Customer will be informed about the successfully activation<br />",
       "descriptionWithTechUser": "In order to activate the subscription of {{company}}, follow these steps below, <br /> <br />1. Activate the service subscription request.<br />2. System - technical user (if needed) will get generated and credentials getting shared.<br />3. Configure your service with the specific technical user to ensure that the service is fully usable",
+      "technicalUserDetails": "Technical User Details",
       "sectionHeader": "Technical User Profile",
       "sectionDescription": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard .Lorem Ipsu",
       "close": "Close",

--- a/src/components/overlays/ActivateServiceSubscription/index.tsx
+++ b/src/components/overlays/ActivateServiceSubscription/index.tsx
@@ -229,7 +229,7 @@ export default function ActivateserviceSubscription({
                     }}
                   >
                     <Typography variant="h4" sx={{ marginBottom: '20px' }}>
-                      {t('serviceSubscription.register.sectionHeader')}
+                      {t('serviceSubscription.register.technicalUserDetails')}
                     </Typography>
 
                     <Typography variant="body2">


### PR DESCRIPTION
## Description

Changed 'Active Service Subscription' overlay section header for 'Technical User Details'

## Why

Header name was duplicated

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/494

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally