### PR TITLE
chore(metafile): update .tractusx because of leading repo rename

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -17,4 +17,4 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-leadingRepository: "https://github.com/eclipse-tractusx/portal-cd"
+leadingRepository: "https://github.com/eclipse-tractusx/portal"


### PR DESCRIPTION
## Description

- adjust the metafile for leading repo renaming to https://github.com/eclipse-tractusx/portal

## Issue

fixes https://github.com/eclipse-tractusx/portal-frontend/issues/568

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code