### PR TITLE
fix(certificate elements): fixed code smell error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Business Partner Details
   - Show certificate information which are associated with the bpn number.
   - Activate on hover and click action to download the corresponding certificate
+- Certificate Elements
+  - fixed code smell error
 
 ## 1.8.0-RC6
 

--- a/src/components/pages/CertificateCredentials/index.tsx
+++ b/src/components/pages/CertificateCredentials/index.tsx
@@ -240,7 +240,7 @@ export default function CertificateCredentials() {
                 <Tooltips
                   additionalStyles={{
                     cursor: 'pointer',
-                    display: certificateTypes.length >= 0 ? 'none' : 'block',
+                    display: certificateTypes.length ? 'none' : 'block',
                   }}
                   tooltipPlacement="top-start"
                   tooltipText={t('content.certificates.noUploadMessage')}


### PR DESCRIPTION
## Description

Fixed code smell error

## Why

Fix this expression; length of "certificateTypes" is always greater or equal to zero.

## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
