### PR TITLE
fix(repo-renaming): merge change of references also into dev branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
             --data '{"ref":"dev", "inputs": { "new-image":"${{ github.sha }}" }}' \

--- a/.github/workflows/release-release_candidate.yml
+++ b/.github/workflows/release-release_candidate.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
             --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ env.REF_NAME }}" }}' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           fi
         if: steps.hf-check.outputs.hf == 'false'
 
-      - name: Determine branch to update in portal-cd
+      - name: Determine branch to update in portal repository
         id: cd-branch
         run: |
           if [[ ${{ steps.rc-check.outputs.rc }} == 'true' ]]; then
@@ -191,7 +191,7 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
             --data '{"ref":"${{ steps.cd-branch.outputs.branch }}", "inputs": { "new-image":"${{ env.REF_NAME }}" }}' \

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           curl -v \
             --request POST \
-            --url https://api.github.com/repos/eclipse-tractusx/portal-cd/actions/workflows/portal-image-update.yml/dispatches \
+            --url https://api.github.com/repos/eclipse-tractusx/portal/actions/workflows/portal-image-update.yml/dispatches \
             --header "authorization: Bearer $TOKEN" \
             --header "Accept: application/vnd.github.v3+json" \
             --data '{"ref":"release-candidate", "inputs": { "new-image":"${{ github.sha }}" }}' \

--- a/.tractusx
+++ b/.tractusx
@@ -17,4 +17,4 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-leadingRepository: "https://github.com/eclipse-tractusx/portal-cd"
+leadingRepository: "https://github.com/eclipse-tractusx/portal"

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -22,12 +22,12 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories in the GitHub organization https://github.com/eclipse-tractusx:
 
-- https://github.com/eclipse-tractusx/portal-frontend-registration
+- https://github.com/eclipse-tractusx/portal
 - https://github.com/eclipse-tractusx/portal-frontend
+- https://github.com/eclipse-tractusx/portal-frontend-registration
 - https://github.com/eclipse-tractusx/portal-shared-components
 - https://github.com/eclipse-tractusx/portal-backend
 - https://github.com/eclipse-tractusx/portal-assets
-- https://github.com/eclipse-tractusx/portal-cd
 - https://github.com/eclipse-tractusx/portal-iam
 
 ## Third-party Content

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Catena-X Portal application consists of
 - [portal-assets](https://github.com/eclipse-tractusx/portal-assets) and
 - [portal-backend](https://github.com/eclipse-tractusx/portal-backend).
 
-![Tag](https://img.shields.io/static/v1?label=&message=LeadingRepository&color=green&style=flat) The helm chart for installing the Catena-X Portal is available in [portal-cd](https://github.com/eclipse-tractusx/portal-cd).
+![Tag](https://img.shields.io/static/v1?label=&message=LeadingRepository&color=green&style=flat) The helm chart for installing the Catena-X Portal is available in the [portal](https://github.com/eclipse-tractusx/portal) repository.
 
 The Catena-X Portal is designed to work with the [Catena-X IAM](https://github.com/eclipse-tractusx/portal-iam).
 


### PR DESCRIPTION
## Description

change portal-cd references to portal in dev branch via cherry-pick from release branch

## Why

Auto-Image-Update to portal (ex. portal-cd) not working as the GH API does apparently not support repository renamings

## Issue

Ref: https://github.com/eclipse-tractusx/portal-cd/issues/131

## Checklist

- [x] I have performed a self-review of my changes