### PR TITLE
fix: change link to right and roles matrix to images/content

### DIFF
--- a/src/components/pages/RoleDetails/index.tsx
+++ b/src/components/pages/RoleDetails/index.tsx
@@ -131,13 +131,13 @@ export default function RoleDetails() {
           </TabPanel>
           <TabPanel value={activeTab} index={1}>
             <Image
-              src={`${getAssetBase()}/images/docs/PortalRoleAndPermissionMatrix.png`}
+              src={`${getAssetBase()}/images/content/PortalRoleAndPermissionMatrix.png`}
               style={{
                 width: '100%',
               }}
             />
             <Image
-              src={`${getAssetBase()}/images/docs/RegistrationRoleAndPermissionMatrix.png`}
+              src={`${getAssetBase()}/images/content/RegistrationRoleAndPermissionMatrix.png`}
               style={{
                 width: '100%',
               }}


### PR DESCRIPTION
## Description

change link to right and roles matrix

## Why

the two images `PortalRoleAndPermissionMatrix.png` and `RegistrationRoleAndPermissionMatrix.png` were moved from /public/assets/images/docs to docs/static as part of https://github.com/eclipse-tractusx/portal-assets/pull/238/commits/caef999ddd6f9be3b0c75d957365d1c7e6b05c40
but apparently those two images aren't used by the documentation app but by the portal app, therefore I move those two images to images/content to avoid further with images used by the documentation app 
those two images are the only affected images by this move, as all other moved images are only referenced in the documentation app.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/576

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
