### PR TITLE
chore: upgrade keycloak-js dependency to v23.0.7

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -498,7 +498,7 @@ npm/npmjs/-/jest/27.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/jiti/1.20.0, MIT, approved, clearlydefined
 npm/npmjs/-/jquery/3.7.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-sdsl/4.4.2, MIT, approved, #7722
-npm/npmjs/-/js-sha256/0.9.0, MIT, approved, clearlydefined
+npm/npmjs/-/js-sha256/0.10.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
 npm/npmjs/-/js-yaml/3.14.1, MIT, approved, clearlydefined
 npm/npmjs/-/js-yaml/4.1.0, MIT, approved, clearlydefined
@@ -518,7 +518,8 @@ npm/npmjs/-/jsonfile/6.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/jsonpath/1.1.1, BSD-2-Clause AND MIT AND MIT, approved, #10974
 npm/npmjs/-/jsonpointer/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/jsx-ast-utils/3.3.5, MIT, approved, #9209
-npm/npmjs/-/keycloak-js/21.1.2, Apache-2.0 AND MIT, approved, #9145
+npm/npmjs/-/jwt-decode/4.0.0, MIT, approved, clearlydefined
+npm/npmjs/-/keycloak-js/23.0.7, Apache-2.0 AND MIT AND EPL-1.0 AND LicenseRef-scancode-oasis-ws-security-spec AND W3C AND LicenseRef-scancode-ws-policy-specification AND W3C AND W3C-19980720 AND (AFL-2.1 OR LGPL-2.0-only) AND (Apache-2.0 AND MIT) AND (Apache-2.0 AND MIT), approved, #11737
 npm/npmjs/-/keyv/4.5.4, MIT, approved, #4674
 npm/npmjs/-/kind-of/6.0.3, MIT, approved, clearlydefined
 npm/npmjs/-/kleur/3.0.3, MIT, approved, clearlydefined
@@ -1156,7 +1157,7 @@ npm/npmjs/@babel/traverse/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD
 npm/npmjs/@babel/types/7.23.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@babel/types/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/2.1.39, Apache-2.0 AND CC-BY-4.0, approved, #10502
+npm/npmjs/@catena-x/portal-shared-components/2.1.40, Apache-2.0 AND CC-BY-4.0, approved, #10502
 npm/npmjs/@csstools/normalize.css/12.0.0, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-cascade-layers/1.1.1, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-color-function/1.1.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3022

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dayjs": "^1.11.8",
     "i18next": "^22.5.1",
     "i18next-browser-languagedetector": "^7.0.2",
-    "keycloak-js": "^21.1.1",
+    "keycloak-js": "^23.0.7",
     "lodash.debounce": "^4.0.8",
     "lodash.uniq": "^4.5.0",
     "nanoid": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^2.1.38":
-  version "2.1.39"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.39.tgz#f968e59b418eae4347086bfd768e73ebe70448a4"
-  integrity sha512-UOE0HiFFw+kth6roaX/uYRBLLHxMyMjIyhp2qmb3Xg3Hf6VvgQ2+dl9qmurE47RskuANA7WC4N6A8VhiXwlMGw==
+"@catena-x/portal-shared-components@^2.1.39":
+  version "2.1.40"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.40.tgz#67694255bb57cd2c64457f25612c7d2f3e1b638c"
+  integrity sha512-Zlw/sobpzF96fI4A0DcLoibIP4M7sIY1AY4eEgnJ2+i6Ux0ZsSzYHt/9HVrUKNpI7SpVPDHaiXjn0JHUc/k8cg==
   dependencies:
     "@mui/base" "^5.0.0-beta.3"
     "@mui/system" "^5.13.2"
@@ -6813,10 +6813,10 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.4.2.tgz#2e3c031b1f47d3aca8b775532e3ebb0818e7f847"
   integrity sha512-dwXFwByc/ajSV6m5bcKAPwe4yDDF6D614pxmIi5odytzxRlwqF6nwoiCek80Ixc7Cvma5awClxrzFtxCQvcM8w==
 
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
+js-sha256@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.10.1.tgz#b40104ba1368e823fdd5f41b66b104b15a0da60d"
+  integrity sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6963,13 +6963,19 @@ jsonpointer@^5.0.0:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
-keycloak-js@^21.1.1:
-  version "21.1.2"
-  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-21.1.2.tgz#949889848c024c2a585c177875e012f0163a1d6a"
-  integrity sha512-+6r1BvmutWGJBtibo7bcFbHWIlA7XoXRCwcA4vopeJh59Nv2Js0ju2u+t8AYth+C6Cg7/BNfO3eCTbsl/dTBHw==
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
+
+keycloak-js@^23.0.7:
+  version "23.0.7"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-23.0.7.tgz#9d2fad3253e087a49573bd9ee0569e327531135c"
+  integrity sha512-OmszsKzBhhm5yP4W1q/tMd+nNnKpOAdeVYcoGhphlv8Fj1bNk4wRTYzp7pn5BkvueLz7fhvKHz7uOc33524YrA==
   dependencies:
     base64-js "^1.5.1"
-    js-sha256 "^0.9.0"
+    js-sha256 "^0.10.1"
+    jwt-decode "^4.0.0"
 
 keyv@^4.5.3:
   version "4.5.4"


### PR DESCRIPTION
## Description

align keycloak version with centralidp keycloak instance

## Why

https://github.com/eclipse-tractusx/portal-iam/issues/62

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own changes
