### PR TITLE
fix(console): remove logging and warning outputs

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1156,7 +1156,7 @@ npm/npmjs/@babel/traverse/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD
 npm/npmjs/@babel/types/7.23.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@babel/types/7.23.3, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/2.1.39, Apache-2.0 AND CC-BY-4.0, approved, #10502
+npm/npmjs/@catena-x/portal-shared-components/2.1.40, Apache-2.0 AND CC-BY-4.0, approved, #10502
 npm/npmjs/@csstools/normalize.css/12.0.0, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-cascade-layers/1.1.1, CC0-1.0, approved, clearlydefined
 npm/npmjs/@csstools/postcss-color-function/1.1.1, CC0-1.0 AND (MIT AND W3C-20150513) AND W3C-20150513 AND MIT, approved, #3022

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^2.1.39",
+    "@catena-x/portal-shared-components": "^2.1.40",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",

--- a/src/components/pages/CompanyCertificates/UploadCompanyCerificate.tsx
+++ b/src/components/pages/CompanyCertificates/UploadCompanyCerificate.tsx
@@ -199,7 +199,7 @@ export default function UploadCompanyCertificate({
               placeholder={t(
                 'content.companyCertificate.upload.dateplaceholder'
               )}
-              locale={i18n.language as ('en' | 'de')}
+              locale={i18n.language as 'en' | 'de'}
               error={dateError}
               helperText={
                 dateError

--- a/src/components/pages/Home/components/BusinessApplicationsSection/index.tsx
+++ b/src/components/pages/Home/components/BusinessApplicationsSection/index.tsx
@@ -20,7 +20,12 @@
 
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Typography, Carousel, Card } from '@catena-x/portal-shared-components'
+import {
+  Typography,
+  Carousel,
+  Card,
+  Button,
+} from '@catena-x/portal-shared-components'
 import Box from '@mui/material/Box'
 import uniqueId from 'lodash/uniqueId'
 import PageService from 'services/PageService'
@@ -61,6 +66,18 @@ export default function BusinessApplicationsSection() {
   const { data } = useFetchBusinessAppsQuery()
   const reference = PageService.registerReference(label, useRef(null))
 
+  const placeholder: AppMarketplaceApp[] = [
+    {
+      id: '...',
+      title: '...',
+      provider: '',
+      leadPictureUri: '',
+      shortDescription: '...',
+      useCases: [],
+      price: '',
+    },
+  ]
+
   return (
     <div ref={reference} className="orange-background-home">
       <section className="business-applications-section">
@@ -76,25 +93,20 @@ export default function BusinessApplicationsSection() {
         </Typography>
 
         <Carousel gapToDots={5}>
-          {data
-            ?.map((app: AppMarketplaceApp) => {
-              const card = appToCard(app)
-              return card
-            })
-            .map((item) => (
-              <Card
-                {...item}
-                key={uniqueId(item.title)}
-                buttonText="Details"
-                imageSize="small"
-                imageShape="round"
-                variant="minimal"
-                expandOnHover={false}
-                filledBackground={true}
-                onClick={item.onClick}
-                imageLoader={fetchImageWithToken}
-              />
-            ))}
+          {(data ?? placeholder).map(appToCard).map((item) => (
+            <Card
+              {...item}
+              key={uniqueId(item.title)}
+              buttonText="Details"
+              imageSize="small"
+              imageShape="round"
+              variant="minimal"
+              expandOnHover={false}
+              filledBackground={true}
+              onClick={item.onClick}
+              imageLoader={fetchImageWithToken}
+            />
+          ))}
           {data &&
             data.length < 4 &&
             new Array(4 - data.length)

--- a/src/components/pages/Home/components/BusinessApplicationsSection/index.tsx
+++ b/src/components/pages/Home/components/BusinessApplicationsSection/index.tsx
@@ -24,7 +24,6 @@ import {
   Typography,
   Carousel,
   Card,
-  Button,
 } from '@catena-x/portal-shared-components'
 import Box from '@mui/material/Box'
 import uniqueId from 'lodash/uniqueId'

--- a/src/components/pages/Home/components/BusinessApplicationsSection/index.tsx
+++ b/src/components/pages/Home/components/BusinessApplicationsSection/index.tsx
@@ -20,11 +20,7 @@
 
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import {
-  Typography,
-  Carousel,
-  Card,
-} from '@catena-x/portal-shared-components'
+import { Typography, Carousel, Card } from '@catena-x/portal-shared-components'
 import Box from '@mui/material/Box'
 import uniqueId from 'lodash/uniqueId'
 import PageService from 'services/PageService'

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -70,7 +70,6 @@ const init = (onAuthenticatedCallback: (loggedUser: IUser) => void) => {
   KC.init({
     onLoad: 'login-required',
     pkceMethod: 'S256',
-    enableLogging: true,
   })
     .then((authenticated: boolean) => {
       if (authenticated) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,10 +1193,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^2.1.38":
-  version "2.1.39"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.39.tgz#f968e59b418eae4347086bfd768e73ebe70448a4"
-  integrity sha512-UOE0HiFFw+kth6roaX/uYRBLLHxMyMjIyhp2qmb3Xg3Hf6VvgQ2+dl9qmurE47RskuANA7WC4N6A8VhiXwlMGw==
+"@catena-x/portal-shared-components@^2.1.40":
+  version "2.1.40"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.40.tgz#67694255bb57cd2c64457f25612c7d2f3e1b638c"
+  integrity sha512-Zlw/sobpzF96fI4A0DcLoibIP4M7sIY1AY4eEgnJ2+i6Ux0ZsSzYHt/9HVrUKNpI7SpVPDHaiXjn0JHUc/k8cg==
   dependencies:
     "@mui/base" "^5.0.0-beta.3"
     "@mui/system" "^5.13.2"


### PR DESCRIPTION
## Description

Disable some console logs and remove home page warning

## Why

The console output was showing some keycloak logs not meant for the portal user and one css warning.

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally