### PR TITLE
fix(app marketplace): change fav icon add/remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   - Card style updates for Active, Inactive and Unknown status
 - App Change Description
   - fixed display of the description correctly
+- App Marketplace
+  - Change fav icon on add/remove item from favourite list
 
 ### Feature
 

--- a/src/components/pages/AppMarketplace/components/AppListSection/index.tsx
+++ b/src/components/pages/AppMarketplace/components/AppListSection/index.tsx
@@ -42,14 +42,14 @@ export default function AppListSection() {
   const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
   const { data } = useFetchActiveAppsQuery()
-  const favoriteItems = useFetchFavoriteAppsQuery().data
+  const { data: favoriteItems, refetch } = useFetchFavoriteAppsQuery()
   const control = useSelector(appsControlSelector)
 
   const checkIsFavorite = (appId: string) => favoriteItems?.includes(appId)
 
   const addOrRemoveFavorite = (event: React.MouseEvent, appId: string) => {
     event?.stopPropagation()
-    dispatch(checkIsFavorite(appId) ? removeItem(appId) : addItem(appId))
+    dispatch(checkIsFavorite(appId) ? removeItem(appId) : addItem(appId)) 
   }
 
   const renderProgress = () => (
@@ -91,6 +91,7 @@ export default function AppListSection() {
             },
             onSecondaryButtonClick: (e: React.MouseEvent) => {
               addOrRemoveFavorite(e, card.id!)
+              refetch()
             },
             addButtonClicked: checkIsFavorite(card.id!),
           }))}

--- a/src/components/pages/AppMarketplace/components/AppListSection/index.tsx
+++ b/src/components/pages/AppMarketplace/components/AppListSection/index.tsx
@@ -49,7 +49,7 @@ export default function AppListSection() {
 
   const addOrRemoveFavorite = (event: React.MouseEvent, appId: string) => {
     event?.stopPropagation()
-    dispatch(checkIsFavorite(appId) ? removeItem(appId) : addItem(appId)) 
+    dispatch(checkIsFavorite(appId) ? removeItem(appId) : addItem(appId))
   }
 
   const renderProgress = () => (


### PR DESCRIPTION
## Description

When a user clicks on the favorite button, the button icon change instantly to indicate successful favoritization.
Similarly, when un-favoriting an app, the button icon will update immediately.

## Why

The old implementation of the favorite button was causing a problem. When a user clicks on the app's favorite button, the button icon does not change immediately. Instead, the change is only visible after reloading the page. The same issue occurs when trying to un-favorite an app

## Issue

#464 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
