### PR TITLE
fix(add roles): fix roles display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
   - Card style updates for Active, Inactive and Unknown status
 - App Change Description
   - fixed display of the description correctly
+- Add Roles
+  - fixed empty chip display for additional roles in app overview active apps
 
 ### Feature
 

--- a/src/components/pages/AppOverview/AddRoles.tsx
+++ b/src/components/pages/AppOverview/AddRoles.tsx
@@ -92,10 +92,13 @@ export default function AddRoles() {
     )
   }, [data])
 
-  const appRolesData = appRoles.map((item, i) => ({
-    establishedRoles: item[0],
-    id: i,
-  }))
+  const appRolesData =
+    data && data.length > 0
+      ? appRoles.map((item, i) => ({
+          establishedRoles: item[0],
+          id: i,
+        }))
+      : []
 
   const columns = [
     {


### PR DESCRIPTION
## Description

fixed empty chip display for additional roles in app overview active apps

## Why

Empty chip is displayed when api response is empty

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/553

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally