### PR TITLE
fix(apis): remove duplicate api end points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   - UI updates as per figma
 - UI Cleanups
   - Removed unused overlays
+- API cleanups
+  - Remove duplicate api end points
 
 ### Bugfix
 

--- a/src/components/overlays/UpdateCompanyRole/index.tsx
+++ b/src/components/overlays/UpdateCompanyRole/index.tsx
@@ -41,7 +41,6 @@ import {
   type CompanyRolesResponse,
   type RoleFeatureData,
   type RolesData,
-  useFetchDocumentByIdMutation,
   useFetchRolesQuery,
   useUpdateCompanyRolesMutation,
 } from 'features/companyRoles/companyRoleApiSlice'
@@ -53,6 +52,7 @@ import {
   setCompanyRoleSuccess,
   setOverlayCancel,
 } from 'features/companyRoles/slice'
+import { useFetchFrameDocumentByIdMutation } from 'features/appManagement/apiSlice'
 
 export enum AgreementStatus {
   ACTIVE = 'ACTIVE',
@@ -71,7 +71,7 @@ export default function UpdateCompanyRole({ roles }: { roles: string[] }) {
   const [agreements, setAgreements] = useState<AgreementsData[]>([])
   const [checkedAgreementsIds, setCheckedAgreementsIds] = useState<string[]>([])
 
-  const [getDocumentById] = useFetchDocumentByIdMutation()
+  const [getDocumentById] = useFetchFrameDocumentByIdMutation()
   const { data } = useFetchRolesQuery()
   const [updateCompanyRoles] = useUpdateCompanyRolesMutation()
 

--- a/src/components/pages/Admin/components/RegistrationRequests/CompanyDetailOverlay/index.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/CompanyDetailOverlay/index.tsx
@@ -39,11 +39,11 @@ import {
   type ApplicationRequest,
   useFetchCheckListDetailsQuery,
   useFetchCompanySearchQuery,
-  useFetchNewDocumentByIdMutation,
 } from 'features/admin/applicationRequestApiSlice'
 import { download } from 'utils/downloadUtils'
 import CheckListFullButtons from '../components/CheckList/CheckListFullButtons'
 import { getTitle } from './CompanyDetailsHelper'
+import { useFetchNewDocumentByIdMutation } from 'features/appManagement/apiSlice'
 
 interface CompanyDetailOverlayProps {
   openDialog?: boolean

--- a/src/components/pages/Admin/components/RegistrationRequests/index.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/index.tsx
@@ -31,7 +31,6 @@ import {
   useApproveRequestMutation,
   useDeclineChecklistMutation,
   useFetchCompanySearchQuery,
-  useFetchNewDocumentByIdMutation,
   useUpdateBPNMutation,
   type ProgressButtonsType,
 } from 'features/admin/applicationRequestApiSlice'
@@ -43,6 +42,7 @@ import AddBpnOveraly from './ConfirmationOverlay/AddBpnOverlay'
 import CheckListStatusOverlay from './components/CheckList/CheckListStatusOverlay'
 import ConfirmCancelOverlay from './ConfirmationOverlay/ConfirmCancelOverlay'
 import type { AppDispatch } from 'features/store'
+import { useFetchNewDocumentByIdMutation } from 'features/appManagement/apiSlice'
 
 export default function RegistrationRequests() {
   const { t } = useTranslation()

--- a/src/components/pages/AppMarketplace/components/FavoriteSection/FavoriteItem.tsx
+++ b/src/components/pages/AppMarketplace/components/FavoriteSection/FavoriteItem.tsx
@@ -24,9 +24,9 @@ import { useNavigate } from 'react-router-dom'
 import { useState, useEffect } from 'react'
 import { removeItem } from 'features/apps/favorites/actions'
 import { useDispatch } from 'react-redux'
-import { useFetchDocumentByIdMutation } from 'features/appManagement/apiSlice'
 import CommonService from 'services/CommonService'
 import type { AppDispatch } from 'features/store'
+import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 interface FavoriteItemProps {
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line

--- a/src/components/pages/AppOverview/AppOverViewDetails.tsx
+++ b/src/components/pages/AppOverview/AppOverViewDetails.tsx
@@ -28,7 +28,6 @@ import { Grid } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 import {
   ConsentStatusEnum,
-  useFetchDocumentByIdMutation,
   useFetchRolesDataQuery,
   useSubmitappMutation,
 } from 'features/appManagement/apiSlice'
@@ -38,6 +37,7 @@ import {
   type AppStatusDataState,
 } from 'features/appManagement/types'
 import CommonValidateAndPublish from 'components/shared/basic/ReleaseProcess/components/CommonValidateAndPublish'
+import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 
 export default function AppOverViewDetails({
   item,

--- a/src/components/pages/AppOverview/ChangeImage.tsx
+++ b/src/components/pages/AppOverview/ChangeImage.tsx
@@ -32,15 +32,13 @@ import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { Box } from '@mui/material'
 import { useCallback, useEffect, useState } from 'react'
-import {
-  useFetchDocumentByIdMutation,
-  useUpdateImageDataMutation,
-} from 'features/appManagement/apiSlice'
+import { useUpdateImageDataMutation } from 'features/appManagement/apiSlice'
 import ConnectorFormInputFieldImage from 'components/shared/basic/ReleaseProcess/components/ConnectorFormInputFieldImage'
 import { useForm } from 'react-hook-form'
 import type { DropzoneFile } from 'components/shared/basic/Dropzone'
 import { error, success } from 'services/NotifyService'
 import type { ItemType } from './AddRoles'
+import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 
 export default function ChangeImage() {
   const { t } = useTranslation()

--- a/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
@@ -37,7 +37,6 @@ import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined'
 import {
   type SubscriptionActivationResponse,
   useAddUserSubscribtionMutation,
-  useFetchTechnicalProfilesQuery,
 } from 'features/appSubscription/appSubscriptionApiSlice'
 import { useState } from 'react'
 import { useDispatch } from 'react-redux'
@@ -46,6 +45,7 @@ import type { store } from 'features/store'
 import { setSuccessType } from 'features/appSubscription/slice'
 import { Link } from 'react-router-dom'
 import { closeOverlay } from 'features/control/overlay'
+import { useFetchTechnicalUserProfilesQuery } from 'features/appManagement/apiSlice'
 
 const TentantHelpURL =
   '/documentation/?path=user%2F04.+App%28s%29%2F05.+App+Subscription%2F04.+Subscription+Activation+%28App+Provider%29.md'
@@ -80,7 +80,7 @@ const ActivateSubscriptionOverlay = ({
     useState<SubscriptionActivationResponse>()
 
   const [addUserSubscribtion] = useAddUserSubscribtionMutation()
-  const { data } = useFetchTechnicalProfilesQuery(appId)
+  const { data } = useFetchTechnicalUserProfilesQuery(appId)
 
   const addInputURL = (value: string) => {
     setInputURL(value)

--- a/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
@@ -43,7 +43,6 @@ import {
   type salesManagerType,
   useSaveAppMutation,
   useFetchAppStatusQuery,
-  useFetchDocumentByIdMutation,
   DocumentTypeId,
   useDeleteAppReleaseDocumentMutation,
   type appLanguagesItem,
@@ -74,6 +73,7 @@ import {
   type LanguageStatusType,
   type UseCaseType,
 } from 'features/appManagement/types'
+import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 
 type FormDataType = {
   title: string

--- a/src/components/shared/basic/ReleaseProcess/OfferContractAndConsent/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferContractAndConsent/index.tsx
@@ -24,16 +24,18 @@ import { useDispatch, useSelector } from 'react-redux'
 import { serviceIdSelector } from 'features/serviceManagement/slice'
 import {
   useUpdateServiceAgreementConsentsMutation,
-  useFetchNewDocumentByIdMutation,
   useFetchServiceStatusQuery,
   useFetchServiceAgreementDataQuery,
   useFetchServiceConsentDataQuery,
   useUpdateServiceDocumentUploadMutation,
   ReleaseProcessTypes,
-  useFetchFrameDocumentByIdMutation,
 } from 'features/serviceManagement/apiSlice'
 import { setServiceStatus } from 'features/serviceManagement/actions'
 import CommonContractAndConsent from '../components/CommonContractAndConsent'
+import {
+  useFetchFrameDocumentByIdMutation,
+  useFetchNewDocumentByIdMutation,
+} from 'features/appManagement/apiSlice'
 
 export default function OfferContractAndConsent() {
   const { t } = useTranslation('servicerelease')

--- a/src/components/shared/basic/ReleaseProcess/ValidateAndPublish/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/ValidateAndPublish/index.tsx
@@ -26,13 +26,13 @@ import { appIdSelector } from 'features/appManagement/slice'
 import {
   ConsentStatusEnum,
   useFetchAppStatusQuery,
-  useFetchDocumentByIdMutation,
   useFetchRolesDataQuery,
   useSubmitappMutation,
 } from 'features/appManagement/apiSlice'
 import { setAppStatus } from 'features/appManagement/actions'
 import CommonValidateAndPublish from '../components/CommonValidateAndPublish'
 import { ReleaseProcessTypes } from 'features/serviceManagement/apiSlice'
+import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 
 export default function ValidateAndPublish({
   showSubmitPage,

--- a/src/features/admin/applicationRequestApiSlice.ts
+++ b/src/features/admin/applicationRequestApiSlice.ts
@@ -229,24 +229,6 @@ export const apiSlice = createApi({
         }
       },
     }),
-    fetchDocumentById: builder.mutation({
-      query: (data: DocumentRequestData) => ({
-        url: `/api/apps/${data.appId}/appDocuments/${data.documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
-    fetchNewDocumentById: builder.mutation({
-      query: (documentId) => ({
-        url: `/api/administration/registration/documents/${documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
     updateBPN: builder.mutation<boolean, UpdateBpnReuestType>({
       query: (args) => ({
         url: `/api/administration/registration/application/${args.applicationId}/${args.bpn}/bpn`,
@@ -284,11 +266,9 @@ export const {
   useApproveRequestMutation,
   useDeclineRequestMutation,
   useFetchCompanySearchQuery,
-  useFetchDocumentByIdMutation,
   useUpdateBPNMutation,
   useFetchCheckListDetailsQuery,
   useApproveChecklistMutation,
   useDeclineChecklistMutation,
   useRetriggerProcessMutation,
-  useFetchNewDocumentByIdMutation,
 } = apiSlice

--- a/src/features/admin/registration/actions.ts
+++ b/src/features/admin/registration/actions.ts
@@ -58,28 +58,6 @@ const fetchPage = createAsyncThunk(
   }
 )
 
-const approveRequest = createAsyncThunk(
-  `${name}/approveRequest`,
-  async (applicationId: string) => {
-    try {
-      await Api.getInstance().approveRegistrationRequest(applicationId)
-    } catch (error: unknown) {
-      throw Error(`${name}/approveRequest error`)
-    }
-  }
-)
-
-const declineRequest = createAsyncThunk(
-  `${name}/declineRequest`,
-  async (applicationId: string) => {
-    try {
-      await Api.getInstance().declineRegistrationRequest(applicationId)
-    } catch (error: unknown) {
-      throw Error(`${name}/declineRequest error`)
-    }
-  }
-)
-
 const refreshApplicationRequest = createAction(
   `${name}/refreshApplicationRequest`,
   (refresh: number) => ({ payload: { refresh } })
@@ -89,7 +67,5 @@ export {
   fetchCompanyDetail,
   fetchRegistrationRequests,
   fetchPage,
-  approveRequest,
-  declineRequest,
   refreshApplicationRequest,
 }

--- a/src/features/admin/registration/api.ts
+++ b/src/features/admin/registration/api.ts
@@ -66,18 +66,4 @@ export class Api extends HttpClient {
       `api/administration/registration/applicationsWithStatus?page=${page}&size=${PAGE_SIZE}`,
       getHeaders()
     )
-
-  public approveRegistrationRequest = (applicationId: string) =>
-    this.instance.put<void>(
-      `/api/administration/registration/application/${applicationId}/approveRequest`,
-      {},
-      getHeaders()
-    )
-
-  public declineRegistrationRequest = (applicationId: string) =>
-    this.instance.put<void>(
-      `/api/administration/registration/application/${applicationId}/declineRequest`,
-      {},
-      getHeaders()
-    )
 }

--- a/src/features/appManagement/apiSlice.ts
+++ b/src/features/appManagement/apiSlice.ts
@@ -296,15 +296,6 @@ export const apiSlice = createApi({
         body: data.body,
       }),
     }),
-    fetchDocumentById: builder.mutation({
-      query: (data: DocumentRequestData) => ({
-        url: `/api/apps/${data.appId}/appDocuments/${data.documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
     deleteAppReleaseDocument: builder.mutation<void, string>({
       query: (documentId) => ({
         url: `/api/apps/appreleaseprocess/documents/${documentId}`,
@@ -455,7 +446,6 @@ export const {
   useUpdateAgreementConsentsMutation,
   useFetchSalesManagerDataQuery,
   useSaveAppMutation,
-  useFetchDocumentByIdMutation,
   useDeleteAppReleaseDocumentMutation,
   useFetchRolesDataQuery,
   useUpdateRoleDataMutation,

--- a/src/features/appSubscription/appSubscriptionApiSlice.ts
+++ b/src/features/appSubscription/appSubscriptionApiSlice.ts
@@ -169,13 +169,6 @@ export const apiSlice = createApi({
       query: (body) =>
         `/api/apps/${body.appId}/subscription/${body.subscriptionId}/provider`,
     }),
-    fetchTechnicalProfiles: builder.query<TechnicalProfilesResponse[], string>({
-      query: (appId) => {
-        return {
-          url: `/api/apps/appreleaseprocess/${appId}/technical-user-profiles`,
-        }
-      },
-    }),
     addUserSubscribtion: builder.mutation<
       SubscriptionActivationResponse,
       SubscriptionStoreRequest
@@ -206,7 +199,6 @@ export const {
   useFetchSubscriptionsQuery,
   useFetchAppFiltersQuery,
   useFetchSubscriptionDetailQuery,
-  useFetchTechnicalProfilesQuery,
   useAddUserSubscribtionMutation,
   useUpdateTenantUrlMutation,
   useActivateSubscriptionMutation,

--- a/src/features/companyRoles/companyRoleApiSlice.ts
+++ b/src/features/companyRoles/companyRoleApiSlice.ts
@@ -78,15 +78,6 @@ export const apiSlice = createApi({
         }
       },
     }),
-    fetchDocumentById: builder.mutation({
-      query: (documentId: string) => ({
-        url: `/api/administration/documents/frameDocuments/${documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
     updateCompanyRoles: builder.mutation<void, CompanyRoleRequest[]>({
       query: (data: CompanyRoleRequest[]) => ({
         url: '/api/administration/companydata/companyRolesAndConsents',
@@ -97,8 +88,4 @@ export const apiSlice = createApi({
   }),
 })
 
-export const {
-  useFetchRolesQuery,
-  useFetchDocumentByIdMutation,
-  useUpdateCompanyRolesMutation,
-} = apiSlice
+export const { useFetchRolesQuery, useUpdateCompanyRolesMutation } = apiSlice

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -247,24 +247,6 @@ export const apiSlice = createApi({
           : { error: response.error }
       },
     }),
-    fetchNewDocumentById: builder.mutation({
-      query: (documentId) => ({
-        url: `/api/administration/documents/${documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
-    fetchFrameDocumentById: builder.mutation({
-      query: (documentId) => ({
-        url: `/api/administration/documents/frameDocuments/${documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
     submitService: builder.mutation<void, string>({
       query: (id) => ({
         url: `/api/services/serviceRelease/${id}/submit`,
@@ -348,9 +330,7 @@ export const {
   useFetchServiceAgreementDataQuery,
   useFetchServiceConsentDataQuery,
   useUpdateServiceDocumentUploadMutation,
-  useFetchNewDocumentByIdMutation,
   useSubmitServiceMutation,
-  useFetchFrameDocumentByIdMutation,
   useFetchDocumentMutation,
   useFetchProvidedServicesQuery,
   useDeleteDocumentMutation,

--- a/src/features/serviceMarketplace/serviceApiSlice.ts
+++ b/src/features/serviceMarketplace/serviceApiSlice.ts
@@ -132,15 +132,6 @@ export const apiSlice = createApi({
     fetchAgreements: builder.query<AgreementRequest[], string>({
       query: (serviceId) => `/api/services/serviceAgreementData/${serviceId}`,
     }),
-    fetchDocumentById: builder.mutation({
-      query: (data: DocumentRequestData) => ({
-        url: `/api/apps/${data.appId}/appDocuments/${data.documentId}`,
-        responseHandler: async (response) => ({
-          headers: response.headers,
-          data: await response.blob(),
-        }),
-      }),
-    }),
   }),
 })
 
@@ -150,5 +141,4 @@ export const {
   useAddSubscribeServiceMutation,
   useFetchSubscriptionQuery,
   useFetchAgreementsQuery,
-  useFetchDocumentByIdMutation,
 } = apiSlice


### PR DESCRIPTION
## Description

remove duplicate api endpoints. keep most appropriate method

## Why

improve code maintainability and reduce the risk of introducing bugs.

## Issue

#587 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
