### PR TITLE
fix(osp consent): sanitize input fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   - Update API Endpoint for Fetching Certificate Document
   - Use listing page api to fetch certificates in details page
 - Add ErrorHandling in Main file
+- OSP Consent Sanitize input fix
 
 ### Bugfix
 

--- a/src/components/overlays/OSPConsent/OSPConsentContent.tsx
+++ b/src/components/overlays/OSPConsent/OSPConsentContent.tsx
@@ -32,6 +32,7 @@ import { useState } from 'react'
 import { getHeaders } from 'services/RequestService'
 import { getApiBase } from 'services/EnvironmentService'
 import './style.scss'
+import { download } from 'utils/downloadUtils'
 
 const DocumentDownloadLink = ({ id, name }: { id: string; name: string }) => {
   const onClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
@@ -40,15 +41,13 @@ const DocumentDownloadLink = ({ id, name }: { id: string; name: string }) => {
       `${getApiBase()}/api/administration/registration/documents/${id}`,
       getHeaders()
     )
-      .then((response) => response.blob())
-      .then((blob) => {
-        const url = window.URL.createObjectURL(new Blob([blob]))
-        const link = document.createElement('a')
-        link.href = url
-        link.setAttribute('download', `${name}.pdf`)
-        document.body.appendChild(link)
-        link.click()
-        link.parentNode!.removeChild(link)
+      .then(async (res) => {
+        const fileType = res.headers.get('content-type') ?? ''
+        const file = await res.blob()
+        download(file, fileType, name)
+      })
+      .catch((error) => {
+        console.log(error)
       })
   }
 


### PR DESCRIPTION
## Description

Remove appendchild from the code and replace it with alternative

## Why

Sanitize input from data from a remote resource flows into appendChild, where it is used to dynamically construct the HTML page on client side:

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/654

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally