### PR TITLE
fix(company certificate): show inactive certificate information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
   - fixed display of the description correctly
 - Add Roles
   - fixed empty chip display for additional roles in app overview active apps
+- Company Certificate
+  - Show inactive certificate information in details overlay
 
 ### Feature
 

--- a/src/components/overlays/CompanyCertificateDetails/index.tsx
+++ b/src/components/overlays/CompanyCertificateDetails/index.tsx
@@ -31,6 +31,7 @@ import './style.scss'
 import {
   useFetchDocumentQuery,
   useFetchCertificatesQuery,
+  type ComapnyCertificateData,
 } from 'features/companyCertification/companyCertificateApiSlice'
 import { Box } from '@mui/material'
 import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined'
@@ -46,7 +47,7 @@ import { OVERLAYS, ROLES } from 'types/Constants'
 import dayjs from 'dayjs'
 import LoadingProgress from 'components/shared/basic/LoadingProgress'
 import UserService from 'services/UserService'
-import { FilterType, SortType } from 'components/pages/CompanyCertificates'
+import { SortType } from 'components/pages/CompanyCertificates'
 
 export enum StatusTag {
   PENDING = 'Pending',
@@ -65,16 +66,25 @@ export default function CompanyCertificateDetails({
     dispatch(closeOverlay())
   }
   const { data: document } = useFetchDocumentQuery(id)
-
+  const [elements, setElements] = useState<ComapnyCertificateData[]>([])
+  const [page, setPage] = useState<number>(0)
   const { data, isFetching, isSuccess } = useFetchCertificatesQuery({
-    filter: FilterType.ACTIVE,
+    filter: '',
     sortOption: SortType.CertificateTypeAsc,
-    page: 0,
+    page,
   })
-
-  const companyData = data?.content.filter((cert) => cert.documentId === id)
+  const companyData = elements.filter((cert) => cert.documentId === id)
   const selected = companyData?.[0]
   const [pdf, setPdf] = useState<string>()
+
+  useEffect(() => {
+    if (data) {
+      setElements(page > 0 ? (i) => i.concat(data?.content) : data.content)
+      if (data?.meta?.totalPages > page + 1) {
+        setPage(page + 1)
+      }
+    }
+  }, [data, page])
 
   useEffect(() => {
     if (document) {

--- a/src/components/pages/CompanyCertificates/index.tsx
+++ b/src/components/pages/CompanyCertificates/index.tsx
@@ -75,6 +75,7 @@ export default function CompanyCertificates(): JSX.Element {
   const [elements, setElements] = useState<ComapnyCertificateData[]>([])
   const setBtnView = (e: React.MouseEvent<HTMLInputElement>): void => {
     setElements([])
+    setPage(0)
     setFilter(e.currentTarget.value)
   }
 


### PR DESCRIPTION
## Description

display inactive certificate information in details overlay with attached document

## Why

inactive certificate info not visible

## Issue

#692 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
