### PR TITLE
chore(upgrade): use shared components 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ## unreleased
 
 - Migrate from Create React App to Vite Framework
-  - The old base is deprecated so we switch to a new framework for build scripts and development server
+  - Switch from deperecated CRA to a new framework for build scripts and development server
+  - Upgrade to Portal Shared Components 3.x based on Vite
 - Subscription Management Board
   - Create new page for company subscriptions and add subscription management functionality
 - Quick links
   - update props for quick links and updated shared components package
-- Company Certificates
-  - Connect delete certificate to back end api
 - App Detail Pages
   - UI updates of order status button and back button
 - Service Release Process
@@ -34,11 +33,12 @@
   - New UI for Favourite icon
   - Change Favourite icon on add/remove item from favourite list
 - Company Certificates
+  - Connect delete certificate to back end api
   - Implementation of New UI Design for Company Certificates
   - Show error icon on certificate deletion error scenario
   - Update API Endpoint for Fetching Certificate Document
   - Use listing page api to fetch certificates in details page
-- Add ErrorHandling in Main file
+- Improve ErrorHandling in Main file
 - Organization
   - Redesign of page
 - App Marketplace

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -89,7 +89,7 @@ npm/npmjs/-/data-urls/3.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/data-view-buffer/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/data-view-byte-length/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/data-view-byte-offset/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/date-fns/2.30.0, MIT, approved, clearlydefined
+npm/npmjs/-/date-fns/3.6.0, MIT, approved, #14000
 npm/npmjs/-/dayjs/1.11.10, MIT, approved, #9149
 npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
 npm/npmjs/-/debug/4.3.4, MIT, approved, clearlydefined
@@ -218,7 +218,6 @@ npm/npmjs/-/https-proxy-agent/5.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/human-signals/2.1.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/husky/9.0.11, MIT, approved, clearlydefined
 npm/npmjs/-/i18next-browser-languagedetector/7.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/i18next/20.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/i18next/23.10.1, MIT, approved, #13869
 npm/npmjs/-/iconv-lite/0.6.3, MIT, approved, clearlydefined
 npm/npmjs/-/identity-obj-proxy/3.0.0, MIT, approved, clearlydefined
@@ -414,7 +413,6 @@ npm/npmjs/-/react-dom/18.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-dropzone/14.2.3, MIT, approved, clearlydefined
 npm/npmjs/-/react-fast-compare/3.2.2, MIT, approved, clearlydefined
 npm/npmjs/-/react-hook-form/7.51.1, MIT, approved, #13909
-npm/npmjs/-/react-i18next/13.5.0, MIT AND Apache-2.0, approved, #11697
 npm/npmjs/-/react-i18next/14.1.0, MIT AND Apache-2.0, approved, #13870
 npm/npmjs/-/react-is/16.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-is/17.0.2, MIT, approved, clearlydefined
@@ -424,7 +422,7 @@ npm/npmjs/-/react-redux/9.1.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-3-
 npm/npmjs/-/react-refresh/0.14.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-router-dom/6.22.3, MIT, approved, #13333
 npm/npmjs/-/react-router/6.22.3, MIT, approved, clearlydefined
-npm/npmjs/-/react-slick/0.29.0, MIT, approved, clearlydefined
+npm/npmjs/-/react-slick/0.30.2, MIT, approved, #14009
 npm/npmjs/-/react-transition-group/4.4.5, BSD-3-Clause, approved, CQ22955
 npm/npmjs/-/react/18.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/readdirp/3.6.0, MIT, approved, #2977
@@ -601,8 +599,10 @@ npm/npmjs/@babel/template/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/traverse/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
 npm/npmjs/@babel/types/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/2.1.45, Apache-2.0 AND CC-BY-4.0, approved, #10502
+npm/npmjs/@catena-x/portal-shared-components/3.0.4, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #14247
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
+npm/npmjs/@date-io/core/3.0.0, MIT, approved, clearlydefined
+npm/npmjs/@date-io/date-fns/3.0.0, MIT, approved, #14023
 npm/npmjs/@emotion/babel-plugin/11.11.0, MIT, approved, #8386
 npm/npmjs/@emotion/cache/11.11.0, MIT, approved, #8401
 npm/npmjs/@emotion/hash/0.9.1, MIT, approved, #8394
@@ -675,15 +675,19 @@ npm/npmjs/@jridgewell/trace-mapping/0.3.25, MIT, approved, #9904
 npm/npmjs/@jridgewell/trace-mapping/0.3.9, MIT, approved, #9904
 npm/npmjs/@mui/base/5.0.0-beta.40, MIT, approved, #2992
 npm/npmjs/@mui/core-downloads-tracker/5.15.14, MIT, approved, clearlydefined
+npm/npmjs/@mui/core-downloads-tracker/5.15.15, MIT, approved, clearlydefined
 npm/npmjs/@mui/icons-material/5.15.14, MIT AND CC-BY-3.0, approved, #13171
+npm/npmjs/@mui/icons-material/5.15.15, MIT AND CC-BY-3.0, approved, #13171
 npm/npmjs/@mui/material/5.15.14, MIT AND CC-BY-3.0, approved, #13175
+npm/npmjs/@mui/material/5.15.15, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
 npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
 npm/npmjs/@mui/system/5.15.14, MIT, approved, #13170
+npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
 npm/npmjs/@mui/types/7.2.14, MIT, approved, clearlydefined
 npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
-npm/npmjs/@mui/x-data-grid/6.19.6, MIT AND ISC, approved, #13932
-npm/npmjs/@mui/x-date-pickers/6.19.7, MIT AND ISC AND OFL-1.1, approved, #13929
+npm/npmjs/@mui/x-data-grid/6.19.9, MIT, approved, #14027
+npm/npmjs/@mui/x-date-pickers/6.19.9, MIT, approved, #14025
 npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.stat/2.0.5, MIT, approved, clearlydefined
 npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <div id="app"></div>
     <script>
       // Do NOT change 'ENV' without changing 'custom_env_vars_anchor' in scripts/inject-dynamic-env.sh as well
-      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth",BPDM_API_URL:"https://business-partners.example.org/pool/api",SEMANTICS_URL:"https://semantics.example.org",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.example.org",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian"}
+      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.dev.demo.catena-x.net",CENTRALIDP_URL:"https://centralidp.dev.demo.catena-x.net/auth",BPDM_API_URL:"https://business-partners.dev.demo.catena-x.net/pool/api",SEMANTICS_URL:"https://semantics.dev.demo.catena-x.net",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.dev.demo.catena-x.net",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian"}
     </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <div id="app"></div>
     <script>
       // Do NOT change 'ENV' without changing 'custom_env_vars_anchor' in scripts/inject-dynamic-env.sh as well
-      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.dev.demo.catena-x.net",CENTRALIDP_URL:"https://centralidp.dev.demo.catena-x.net/auth",BPDM_API_URL:"https://business-partners.dev.demo.catena-x.net/pool/api",SEMANTICS_URL:"https://semantics.dev.demo.catena-x.net",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.dev.demo.catena-x.net",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian"}
+      const ENV = {PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth",BPDM_API_URL:"https://business-partners.example.org/pool/api",SEMANTICS_URL:"https://semantics.example.org",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.example.org",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian"}
     </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^2.1.45",
+    "@catena-x/portal-shared-components": "^3.0.4",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.0",
     "@hookform/error-message": "^2.0.1",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
+    "@mui/x-data-grid": "^6.19.8",
     "@react-hook/cache": "^1.1.1",
     "@reduxjs/toolkit": "^2.2.1",
     "axios": "^1.6.8",

--- a/src/components/overlays/AddAppUserRoles/index.tsx
+++ b/src/components/overlays/AddAppUserRoles/index.tsx
@@ -24,6 +24,7 @@ import {
   DialogHeader,
   Button,
   Stepper,
+  Typography,
 } from '@catena-x/portal-shared-components'
 import { useTranslation } from 'react-i18next'
 import { useParams } from 'react-router-dom'
@@ -44,7 +45,7 @@ import {
   SuccessErrorType,
 } from 'features/admin/appuserApiSlice'
 import { setRolesToAdd } from 'features/admin/userDeprecated/actions'
-import { Box, Typography } from '@mui/material'
+import { Box } from '@mui/material'
 import { useState } from 'react'
 
 export default function AddAppUserRoles() {

--- a/src/components/overlays/AddMultipleUser/index.tsx
+++ b/src/components/overlays/AddMultipleUser/index.tsx
@@ -22,7 +22,6 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 import type { store } from 'features/store'
-import { Typography } from '@mui/material'
 import { Trans, useTranslation } from 'react-i18next'
 import {
   Button,
@@ -38,6 +37,7 @@ import {
   StaticTable,
   CircleProgress,
   PageSnackbar,
+  Typography,
 } from '@catena-x/portal-shared-components'
 import EditIcon from '@mui/icons-material/Edit'
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'

--- a/src/components/overlays/OSPConsent/OSPConsentContent.tsx
+++ b/src/components/overlays/OSPConsent/OSPConsentContent.tsx
@@ -18,8 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Checkbox } from '@catena-x/portal-shared-components'
-import { Typography } from '@mui/material'
+import { Checkbox, Typography } from '@catena-x/portal-shared-components'
 import {
   CONSENT_STATUS,
   type CompanyRole,

--- a/src/components/pages/Admin/components/RegistrationRequests/components/RequestList/index.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/components/RequestList/index.tsx
@@ -33,7 +33,7 @@ import {
   type ProgressButtonsType,
 } from 'features/admin/applicationRequestApiSlice'
 import { RegistrationRequestsTableColumns } from '../../registrationTableColumns'
-import type { GridCellParams } from '@mui/x-data-grid'
+import { type GridEventListener } from '@mui/x-data-grid'
 import './RequestListStyle.scss'
 import { refetch } from 'features/admin/registration/slice'
 import { isCompanyName } from 'types/Patterns'
@@ -53,7 +53,7 @@ export const RequestList = ({
   onChipButtonSelect,
 }: {
   fetchHook: (paginArgs: PaginFetchArgs) => void
-  onTableCellClick: (params: GridCellParams) => void
+  onTableCellClick: GridEventListener<'cellClick'>
   loaded: number
   handleDownloadDocument: (
     appId: string,

--- a/src/components/pages/DeleteCompany/index.tsx
+++ b/src/components/pages/DeleteCompany/index.tsx
@@ -19,11 +19,15 @@
 
 import { useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { CircularProgress, Typography } from '@mui/material'
+import { CircularProgress } from '@mui/material'
 import { uniqueId } from 'lodash'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import { getAssetBase } from 'services/EnvironmentService'
-import { Button, LoadingButton } from '@catena-x/portal-shared-components'
+import {
+  Button,
+  LoadingButton,
+  Typography,
+} from '@catena-x/portal-shared-components'
 import {
   ApplicationStatus,
   useDeclineRegistrationMutation,

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -24,7 +24,7 @@ import {
   type DropPreviewFileProps,
   type DropStatusHeaderProps,
   type UploadFile,
-  type deleteConfirmOverlayTranslation,
+  type DeleteConfirmOverlayTranslation,
   DropArea as DefaultDropArea,
   DropPreview as DefaultDropPreview,
   UploadStatus,
@@ -52,7 +52,7 @@ export interface DropzoneProps {
   DropPreviewFile?: FunctionComponent<DropPreviewFileProps> | false
   enableDeleteIcon?: boolean
   enableDeleteOverlay?: boolean
-  deleteOverlayTranslation?: deleteConfirmOverlayTranslation
+  deleteOverlayTranslation?: DeleteConfirmOverlayTranslation
   handleDownload?: () => void
   handleDelete?: (documentId: string) => void
   errorText?: string
@@ -183,7 +183,7 @@ export const Dropzone = ({
           placeholder: t('shared.dropzone.placeholder'),
           uploadError: t('shared.dropzone.uploadError'),
           uploadSuccess: t('shared.dropzone.uploadSuccess'),
-          uploadProgess: t('shared.dropzone.uploadProgess'),
+          uploadProgress: t('shared.dropzone.uploadProgess'),
         }}
         enableDeleteIcon={enableDeleteIcon}
         enableDeleteOverlay={enableDeleteOverlay}

--- a/src/components/shared/basic/Input/DebouncedSearchInput.tsx
+++ b/src/components/shared/basic/Input/DebouncedSearchInput.tsx
@@ -19,9 +19,8 @@
  ********************************************************************************/
 
 import debounce from 'lodash.debounce'
-import { useCallback, useMemo, useState } from 'react'
+import { type CSSProperties, useCallback, useMemo, useState } from 'react'
 import { SearchInput } from '@catena-x/portal-shared-components'
-import type { SxProps, Theme } from '@mui/material'
 
 const DebouncedSearchInput = ({
   sx = {},
@@ -30,7 +29,7 @@ const DebouncedSearchInput = ({
   onSearch,
   debounceTime = 300,
 }: {
-  sx?: SxProps<Theme>
+  sx?: CSSProperties
   placeholder?: string
   value?: string
   onSearch: (expr: string) => void

--- a/src/components/shared/frame/SubHeaderTitle/index.tsx
+++ b/src/components/shared/frame/SubHeaderTitle/index.tsx
@@ -23,8 +23,8 @@ import type { TypographyProps } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
 interface ComponentProps extends TypographyProps {
-  title: string
-  params?: Record<string, string>
+  readonly title: string
+  readonly params?: Record<string, string>
 }
 
 export default function SubHeaderTitle({

--- a/src/components/shared/frame/SubHeaderTitle/index.tsx
+++ b/src/components/shared/frame/SubHeaderTitle/index.tsx
@@ -19,10 +19,10 @@
  ********************************************************************************/
 
 import { Typography } from '@catena-x/portal-shared-components'
-import type { TypographyProps } from '@mui/material/Typography'
+import type { TypographyProps } from '@mui/material'
 import { useTranslation } from 'react-i18next'
 
-interface ComponentProps {
+interface ComponentProps extends TypographyProps {
   title: string
   params?: Record<string, string>
 }
@@ -31,12 +31,13 @@ export default function SubHeaderTitle({
   title,
   params,
   variant = 'body1',
-}: ComponentProps & TypographyProps) {
+}: ComponentProps) {
   const { t } = useTranslation()
 
   return (
     <Typography
       sx={{ fontFamily: 'LibreFranklin-Light' }}
+      // @ts-expect-error upgraded typescript version
       variant={variant}
       className="section-title"
     >

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,14 +283,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.24.0"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.23.9", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.24.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.1.tgz#431f9a794d173b53720e69a6464abc6f0e2a5c57"
   integrity sha512-+BIznRzyqBf+2wCTxcKE3wDjfGeCoVE61KSHGpkzqrLi8qxqFwBeUFyId2cxkTmm55fzDGnm0+yCxaxygrLUnQ==
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.22.5", "@babel/runtime@^7.23.2":
+"@babel/runtime@^7.23.2":
   version "7.23.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.6.tgz#c05e610dc228855dc92ef1b53d07389ed8ab521d"
   integrity sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==
@@ -336,22 +336,28 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^2.1.45":
-  version "2.1.45"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-2.1.45.tgz#caf6b6787be7415211ccc767bbaeecd194be3c5e"
-  integrity sha512-56fMNmOPB2ris4ODFnvSjI/wns9aAHHXtNrhkbFkGLjKCAf3QifIvebnBw5GmGWi1JQmVQl0UIPbn7KXHFfzFQ==
+"@catena-x/portal-shared-components@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-3.0.4.tgz#d4121f48c6bba0e1ce1ae8b816f64b74be50eb89"
+  integrity sha512-83ztMjPKT77qCFqnkbj9sDhxvOBh9yL4Ck2yScz9TWfHGilyDKwU9D9HWVLxASgaSNs4Q6f5/t4jl/bZZYLm8g==
   dependencies:
-    "@mui/base" "^5.0.0-beta.3"
-    "@mui/system" "^5.13.2"
-    "@mui/x-data-grid" "^6.0.0"
-    "@mui/x-date-pickers" "^6.0.0"
+    "@date-io/date-fns" "^3.0.0"
+    "@emotion/react" "^11.11.4"
+    "@emotion/styled" "^11.11.0"
+    "@mui/icons-material" "^5.11.16"
+    "@mui/material" "^5.13.2"
+    "@mui/system" "^5.15.14"
+    "@mui/x-data-grid" "^6.19.8"
+    "@mui/x-date-pickers" "^6.19.8"
     autosuggest-highlight "^3.3.4"
-    date-fns "^2.30.0"
-    i18next "20.3.1"
-    jquery "^3.7.0"
-    react-i18next "^13.2.2"
-    react-player "^2.13.0"
-    react-slick "^0.29.0"
+    date-fns "^3.6.0"
+    i18next "^23.10.1"
+    jquery "^3.7.1"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-i18next "^14.1.0"
+    react-player "^2.15.1"
+    react-slick "^0.30.2"
     slick-carousel "^1.8.1"
 
 "@cspotcode/source-map-support@^0.8.0":
@@ -360,6 +366,18 @@
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
+
+"@date-io/core@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-3.0.0.tgz#9fd2375383b5791b7211dfce3e576211f9ddce5e"
+  integrity sha512-S3j+IAQVBYNkQzchVVhX40eBkGDreBpScy9RXwTS5j2+k07+62pMVPisQ44Gq76Rqy5AOG/EZXCwBpY/jbemvA==
+
+"@date-io/date-fns@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-3.0.0.tgz#b082daa73ab9f1f8be55fe99a529653f69a7275b"
+  integrity sha512-hsLAbsdP8LKfi7OQ729cXMWfmHQEq0hn3ysXfAAoc92j6j6sBq0s0tplnkWu6O4iBUpVCYRPGuNjQQhTaOu2AA==
+  dependencies:
+    "@date-io/core" "^3.0.0"
 
 "@emotion/babel-plugin@^11.11.0":
   version "11.11.0"
@@ -914,7 +932,7 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@mui/base@5.0.0-beta.40", "@mui/base@^5.0.0-beta.22", "@mui/base@^5.0.0-beta.3":
+"@mui/base@5.0.0-beta.40", "@mui/base@^5.0.0-beta.22":
   version "5.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-beta.40.tgz#1f8a782f1fbf3f84a961e954c8176b187de3dae2"
   integrity sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==
@@ -932,12 +950,42 @@
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.14.tgz#f7c57b261904831877220182303761c012d05046"
   integrity sha512-on75VMd0XqZfaQW+9pGjSNiqW+ghc5E2ZSLRBXwcXl/C4YzjfyjrLPhrEpKnR9Uym9KXBvxrhoHfPcczYHweyA==
 
+"@mui/core-downloads-tracker@^5.15.15":
+  version "5.15.15"
+  resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.15.tgz#2bc2bda50db66c12f10aefec907c48c8f669ef59"
+  integrity sha512-aXnw29OWQ6I5A47iuWEI6qSSUfH6G/aCsW9KmW3LiFqr7uXZBK4Ks+z8G+qeIub8k0T5CMqlT2q0L+ZJTMrqpg==
+
+"@mui/icons-material@^5.11.16":
+  version "5.15.15"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.15.15.tgz#84ce08225a531d9f5dc5132009d91164b456a0ae"
+  integrity sha512-kkeU/pe+hABcYDH6Uqy8RmIsr2S/y5bP2rp+Gat4CcRjCcVne6KudS1NrZQhUCRysrTDCAhcbcf9gt+/+pGO2g==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+
 "@mui/icons-material@^5.15.14":
   version "5.15.14"
   resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.15.14.tgz#333468c94988d96203946d1cfeb8f4d7e8e7de34"
   integrity sha512-vj/51k7MdFmt+XVw94sl30SCvGx6+wJLsNYjZRgxhS6y3UtnWnypMOsm3Kmg8TN+P0dqwsjy4/fX7B1HufJIhw==
   dependencies:
     "@babel/runtime" "^7.23.9"
+
+"@mui/material@^5.13.2":
+  version "5.15.15"
+  resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.15.15.tgz#e3ba35f50b510aa677cec3261abddc2db7b20b59"
+  integrity sha512-3zvWayJ+E1kzoIsvwyEvkTUKVKt1AjchFFns+JtluHCuvxgKcLSRJTADw37k0doaRtVAsyh8bz9Afqzv+KYrIA==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/base" "5.0.0-beta.40"
+    "@mui/core-downloads-tracker" "^5.15.15"
+    "@mui/system" "^5.15.15"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    "@types/react-transition-group" "^4.4.10"
+    clsx "^2.1.0"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+    react-is "^18.2.0"
+    react-transition-group "^4.4.5"
 
 "@mui/material@^5.15.14":
   version "5.15.14"
@@ -976,10 +1024,24 @@
     csstype "^3.1.3"
     prop-types "^15.8.1"
 
-"@mui/system@^5.13.2", "@mui/system@^5.15.14":
+"@mui/system@^5.15.14":
   version "5.15.14"
   resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.15.14.tgz#8a0c6571077eeb6b5f1ff7aa7ff6a3dc4a14200d"
   integrity sha512-auXLXzUaCSSOLqJXmsAaq7P96VPRXg2Rrz6OHNV7lr+kB8lobUF+/N84Vd9C4G/wvCXYPs5TYuuGBRhcGbiBGg==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/private-theming" "^5.15.14"
+    "@mui/styled-engine" "^5.15.14"
+    "@mui/types" "^7.2.14"
+    "@mui/utils" "^5.15.14"
+    clsx "^2.1.0"
+    csstype "^3.1.3"
+    prop-types "^15.8.1"
+
+"@mui/system@^5.15.15":
+  version "5.15.15"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.15.15.tgz#658771b200ce3c4a0f28e58169f02e5e718d1c53"
+  integrity sha512-aulox6N1dnu5PABsfxVGOZffDVmlxPOVgj56HrUnJE8MCSh8lOvvkd47cebIVQQYAjpwieXQXiDPj5pwM40jTQ==
   dependencies:
     "@babel/runtime" "^7.23.9"
     "@mui/private-theming" "^5.15.14"
@@ -1005,10 +1067,10 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
-"@mui/x-data-grid@^6.0.0":
-  version "6.19.6"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.19.6.tgz#6334bb70a7a2685fc1cf3ed902172661c3206f3f"
-  integrity sha512-jpZkX1Gnlo87gKcD10mKMY8YoAzUD8Cv3/IvedH3FINDKO3hnraMeOciKDeUk0tYSj8RUDB02kpTHCM8ojLVBA==
+"@mui/x-data-grid@^6.19.8":
+  version "6.19.9"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-6.19.9.tgz#2fba9a74b827b5f478f4c0a331da9cb1f21261a5"
+  integrity sha512-Oj8mOBShrOiWYiWsbv2dKcctA3nrFRR+0MLyXOUDmz58r9jmpPFMSdFwm32Ki24sGPsjBUdb10CfUuypTdqyEw==
   dependencies:
     "@babel/runtime" "^7.23.2"
     "@mui/utils" "^5.14.16"
@@ -1016,10 +1078,10 @@
     prop-types "^15.8.1"
     reselect "^4.1.8"
 
-"@mui/x-date-pickers@^6.0.0":
-  version "6.19.7"
-  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-6.19.7.tgz#05bf07a7ae77af56b7bf3f2b1cb9d95b3325b72c"
-  integrity sha512-BCTOQjAuyU29Ymd2FJrHHdRh0U6Qve7MsthdrD2jjaMaR8ou455JuxsNTQUGSpiMkGHWOMVq+B8N1EBcSYH63g==
+"@mui/x-date-pickers@^6.19.8":
+  version "6.19.9"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-6.19.9.tgz#5fb7ecbeec5b5ce1fddbb547583d0083e30a845b"
+  integrity sha512-B2m4Fv/fOme5qmV6zuE3QnWQSvj3zKtI2OvikPz5prpiCcIxqpeytkQ7VfrWH3/Aqd5yhG1Yr4IgbqG0ymIXGg==
   dependencies:
     "@babel/runtime" "^7.23.2"
     "@mui/base" "^5.0.0-beta.22"
@@ -2378,12 +2440,10 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-date-fns@^2.30.0:
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
-  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
-  dependencies:
-    "@babel/runtime" "^7.21.0"
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
 
 dayjs@^1.11.10:
   version "1.11.10"
@@ -3452,13 +3512,6 @@ i18next-browser-languagedetector@^7.2.0:
   dependencies:
     "@babel/runtime" "^7.23.2"
 
-i18next@20.3.1:
-  version "20.3.1"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.3.1.tgz#b51dd281a2eec8087753edf1727e160dac8a5554"
-  integrity sha512-WTY07KreR5z2LBSzAIKs05zpR5tgUT98C4fD96e7Risbc/HZePwF6AEnb9VkjdeSeRn9PDqQBay7ZkphuXt0Xw==
-  dependencies:
-    "@babel/runtime" "^7.12.0"
-
 i18next@^23.10.1:
   version "23.10.1"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-23.10.1.tgz#217ce93b75edbe559ac42be00a20566b53937df6"
@@ -4211,7 +4264,7 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-jquery@^3.7.0:
+jquery@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
   integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
@@ -4932,14 +4985,6 @@ react-hook-form@^7.51.1:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.51.1.tgz#3ce5f8b5ef41903b4054a641cef8c0dc8bf8ae85"
   integrity sha512-ifnBjl+kW0ksINHd+8C/Gp6a4eZOdWyvRv0UBaByShwU8JbVx5hTcTWEcd5VdybvmPTATkVVXk9npXArHmo56w==
 
-react-i18next@^13.2.2:
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-13.5.0.tgz#44198f747628267a115c565f0c736a50a76b1ab0"
-  integrity sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==
-  dependencies:
-    "@babel/runtime" "^7.22.5"
-    html-parse-stringify "^3.0.1"
-
 react-i18next@^14.1.0:
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-14.1.0.tgz#44da74fbffd416f5d0c5307ef31735cf10cc91d9"
@@ -4963,7 +5008,7 @@ react-is@^18.0.0, react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-react-player@^2.13.0, react-player@^2.15.1:
+react-player@^2.15.1:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.15.1.tgz#a5905126a6c5ba2667391a0d72da9f3a1ab57d54"
   integrity sha512-ni1XFuYZuhIKKdeFII+KRLmIPcvCYlyXvtSMhNOgssdfnSovmakBtBTW2bxowPvmpKy5BTR4jC4CF79ucgHT+g==
@@ -5002,10 +5047,10 @@ react-router@6.22.3:
   dependencies:
     "@remix-run/router" "1.15.3"
 
-react-slick@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.29.0.tgz#0bed5ea42bf75a23d40c0259b828ed27627b51bb"
-  integrity sha512-TGdOKE+ZkJHHeC4aaoH85m8RnFyWqdqRfAGkhd6dirmATXMZWAxOpTLmw2Ll/jPTQ3eEG7ercFr/sbzdeYCJXA==
+react-slick@^0.30.2:
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.30.2.tgz#b28e992f9c519bb516a0af8d37e82cb59fee08ce"
+  integrity sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==
   dependencies:
     classnames "^2.2.5"
     enquire.js "^2.1.6"


### PR DESCRIPTION
## Description

Upgrade to Shared Components 3.x

## Why

The Shared Component Library has also been upgraded to the Vite Framework and we want to use the latest version.

## Issue

#537 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally