### PR TITLE
fix(sticky header): disable focus effect on button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Change
 
+- Sticky header
+  - Disable focus effect on button
+
+
+## 2.0.0-RC1
+
+### Change
+
 - Enhanced the IdP Config Overlay details by adding metadata of
   - clientId: string
   - hasClientSecret?: boolean

--- a/src/components/shared/templates/Templates.scss
+++ b/src/components/shared/templates/Templates.scss
@@ -50,6 +50,12 @@
 
 .subNavigationContainer button:hover {
   background-color: transparent !important;
+  box-shadow: none !important;
+}
+
+.subNavigationContainer button:focus {
+  background-color: transparent !important;
+  box-shadow: none !important;
 }
 
 //tab layout


### PR DESCRIPTION
## Description

disable border color change on focus and hover effect

## Why

focus effect is confusing with the selected button behaviour

## Issue

#690 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
