### PR TITLE
fix(technical setup): blank page fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Unreleased
+
+### Bugfix
+
+- Technical Setup
+  - fixed white page issue on connector registration with "Existing Technical User" selection
+
 ## 2.0.0-RC2
 
 ### Change

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -35,7 +35,7 @@ import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import Patterns from 'types/Patterns'
 import { ConnectType } from 'features/connector/connectorApiSlice'
 import { Dropzone } from '../../../../shared/basic/Dropzone'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import './EdcComponentStyles.scss'
 
 const ConnectorFormInput = ({
@@ -254,6 +254,16 @@ const ConnectorInsertForm = ({
 any) => {
   const { t } = useTranslation()
   const [selectedValue, setSelectedValue] = useState<string>()
+  const [serviceAccountUsers, setServiceAccountUsers] = useState([])
+
+  useEffect(() => {
+    if (fetchServiceAccountUsers?.content)
+      setServiceAccountUsers(
+        fetchServiceAccountUsers.content?.filter(
+          (item: { name: string }) => item.name
+        )
+      )
+  }, [fetchServiceAccountUsers])
 
   const handleTechnicalUserSubmit = () => {
     if (
@@ -364,9 +374,9 @@ any) => {
                   helperText: t(
                     'content.edcconnector.modal.insertform.technicalUser.error'
                   ),
-                  items: fetchServiceAccountUsers?.content,
+                  items: serviceAccountUsers,
                   defaultSelectValue: {},
-                  keyTitle: 'clientId',
+                  keyTitle: 'name',
                 }}
               />
             )}

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -165,9 +165,9 @@ export const apiSlice = createApi({
         method: 'POST',
       }),
     }),
-    fetchServiceAccountUsers: builder.query<ServiceAccountRole[], void>({
+    fetchServiceAccountUsers: builder.query<ServiceAccountListEntry[], void>({
       query: () =>
-        '/api/administration/serviceaccount/owncompany/serviceaccounts?page=0&size=10&filterForInactive=false',
+        `/api/administration/serviceaccount/owncompany/serviceaccounts?page=0&size=${PAGE_SIZE}&filterForInactive=false`,
     }),
   }),
 })


### PR DESCRIPTION
## Description

fixed white page issue on connector registration with "Existing Technical User" selection

## Why

ClientId was null in API response

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/730

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally