### PR TITLE
fix(error handling): display error page if backend not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.0-RC6
+
+### Bugfix
+
+- Display error page when backend not available
+
 ## 2.0.0-RC5
 
 ### Feature

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@catena-x/portal-frontend",
-  "version": "v2.0.0-RC4",
+  "version": "v2.0.0-RC5",
   "description": "Catena-X Portal Frontend",
   "author": "Catena-X Contributors",
   "license": "Apache-2.0",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -106,7 +106,11 @@
   "error": {
     "deleteTechUserNotificationErrorDescription": "Please try it later again or contact your administrator.",
     "tryAgain": "Try Again",
-    "errorBar": "Something went wrong. Try again"
+    "errorBar": "Something went wrong. Try again",
+    "title": "Hoppla! Etwas ist schiefgelaufen.",
+    "description": "Der Server hat einen internen Fehler oder eine Fehlkonfiguration festgestellt und konnte Ihre Anfrage nicht abschließen.",
+    "additionalDescription": "Bitte wenden Sie sich an Ihren Administrator.",
+    "reloadBtn": "Seite neuladen"
   },
   "content": {
     "registration": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -105,7 +105,11 @@
   "error": {
     "deleteTechUserNotificationErrorDescription": "Please try it later again or contact your administrator.",
     "tryAgain": "Try Again",
-    "errorBar": "Something went wrong. Try again"
+    "errorBar": "Something went wrong. Try again",
+    "title": "Oops, Something went wrong.",
+    "description": "The server encountered an internal error or misconfiguration and was unable to complete your request.",
+    "additionalDescription": "Please contact your admin.",
+    "reloadBtn": "Reload Page"
   },
   "content": {
     "registration": {

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -95,9 +95,11 @@ export default function Main() {
   if (error)
     return (
       <ErrorPage
-        header={t('error.tryAgain')}
-        title={t('error.deleteTechUserNotificationErrorDescription')}
-        reloadButtonTitle={t('error.tryAgain')}
+        header=""
+        title={t('error.title')}
+        description={t('error.description')}
+        additionalDescription={t('error.additionalDescription')}
+        reloadButtonTitle={t('error.reloadBtn')}
         onReloadClick={() => {
           navigate('/')
         }}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -51,17 +51,6 @@ export default function Main() {
   const dispatch = useDispatch()
 
   const { data, isLoading, error } = useFetchApplicationsQuery()
-  if (error)
-    return (
-      <ErrorPage
-        header={t('error.tryAgain')}
-        title={t('error.deleteTechUserNotificationErrorDescription')}
-        reloadButtonTitle={t('error.tryAgain')}
-        onReloadClick={() => {
-          navigate('/')
-        }}
-      />
-    )
   const companyData = data?.[0]
 
   const renderSection = () => {
@@ -102,6 +91,18 @@ export default function Main() {
       </>
     )
   }
+
+  if (error)
+    return (
+      <ErrorPage
+        header={t('error.tryAgain')}
+        title={t('error.deleteTechUserNotificationErrorDescription')}
+        reloadButtonTitle={t('error.tryAgain')}
+        onReloadClick={() => {
+          navigate('/')
+        }}
+      />
+    )
 
   return (
     <>


### PR DESCRIPTION
## Description

Display Error page if backend not available

## Why

When backend isn't available, the app continuously sends thousands of requests

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/632

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally