### PR TITLE
fix(admin credential): update approval and decline endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Partner Network
   - Fix white page blank issue
+- Admin Credential
+  - Change API endpoints for approval and decline request
 
 ## 2.0.0-RC5
 

--- a/src/features/certification/certificationApiSlice.tsx
+++ b/src/features/certification/certificationApiSlice.tsx
@@ -122,13 +122,13 @@ export const apiSlice = createApi({
     ),
     approveCredential: builder.mutation<boolean, string>({
       query: (credentialId) => ({
-        url: `api/administration/companydata/credentials/${credentialId}/approval`,
+        url: `${getSsiBase()}/api/issuer/${credentialId}/approval`,
         method: 'PUT',
       }),
     }),
     declineCredential: builder.mutation<boolean, string>({
       query: (credentialDetailId) => ({
-        url: `api/administration/companydata/credentials/${credentialDetailId}/reject`,
+        url: `${getSsiBase()}/api/issuer/${credentialDetailId}/reject`,
         method: 'PUT',
       }),
     }),


### PR DESCRIPTION
## Description

Update admin-credential approval and decline endpoints

## Why

Currently, when approving or declining a credential request on the page /admin-credential, the POST endpoint being triggered belongs to the portal backend. However, we need to switch this endpoint to the corresponding endpoint in the issuer component.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/764

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
