### PR TITLE
fix(usecase-participation): agreement status changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0-RC7
+
+### Bugfix
+
+- Usecase Participation
+  - Framework Agreement Request Page - Status missing
+
 ## 2.0.0-RC6
 
 ### Bugfix

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1736,6 +1736,7 @@
       "framework": "Framework",
       "nodocument": "Kein Dokument vorhanden",
       "expiry": "Expiry: {{expiry}}",
+      "request": "Request",
       "editUsecase": {
         "title": "Trigger the use case participation by signing and uploading the use case frame agreement for {{usecaseName}}",
         "description": "To be able to participate in the data exchange of the use case {{usecaseName}} please download the use case frame agreement {placeholder until download is available} and upload the signed document in the upload window below.After submission, the platform owner will validate the uploaded document you will be informed as soon as the validation is successfully finished",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1698,6 +1698,7 @@
       "framework": "Framework",
       "nodocument": "No document available",
       "expiry": "Expiry: {{expiry}}",
+      "request": "Request",
       "editUsecase": {
         "title": "Trigger the use case participation by signing and uploading the use case frame agreement for {{usecaseName}}",
         "description": "To be able to participate in the data exchange of the use case {{usecaseName}} please download the use case frame agreement {placeholder until download is available} and upload the signed document in the upload window below.After submission, the platform owner will validate the uploaded document you will be informed as soon as the validation is successfully finished",

--- a/src/components/pages/UsecaseParticipation/UsecaseParticipation.scss
+++ b/src/components/pages/UsecaseParticipation/UsecaseParticipation.scss
@@ -100,8 +100,12 @@
         .credential-list {
           list-style: none;
           .credential-list-item {
-            margin-bottom: 10px;
+            width: 100%;
+            margin-bottom: 0;
             display: flex;
+            .font-12 {
+              font-size: 12px;
+            }
             .firstSection {
               width: 60%;
             }
@@ -112,6 +116,9 @@
               width: 30%;
               color: #0f71cb;
               cursor: pointer;
+              > div {
+                height: 25px;
+              }
               .framework {
                 display: flex;
                 padding: 2px 8px;
@@ -134,7 +141,7 @@
               width: 35%;
             }
             .fifthSection {
-              width: 30%;
+              width: 20%;
             }
           }
         }

--- a/src/features/usecase/usecaseApiSlice.ts
+++ b/src/features/usecase/usecaseApiSlice.ts
@@ -18,6 +18,7 @@
  ********************************************************************************/
 
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import { type SSIDetailData } from 'features/certification/certificationApiSlice'
 import { getSsiBase } from 'services/EnvironmentService'
 import { apiBaseQuery } from 'utils/rtkUtil'
 
@@ -30,15 +31,7 @@ export type VerifiedCredentialsData = {
     validFrom: string
     expiry: string
   }
-  ssiDetailData: {
-    credentialId: string
-    participationStatus: string
-    expiryDate: string
-    document: {
-      documentId: string
-      documentName: string
-    }
-  }
+  ssiDetailData: SSIDetailData[]
 }
 
 export type UsecaseResponse = {


### PR DESCRIPTION
## Description

Framework Agreement Request Page - Status missing

## Why

The credential request status should be displayed correctly based on its actual status.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/777

## Checklist

Please delete options that are not relevant.

- [X] I have successfully tested my changes locally
- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
