### PR TITLE
fix(app marketplace): fix image display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.0-RC8
+
+### Bugfix
+
+- App marketplace
+  - fixed display of images in app detail page
+
 ## 2.0.0-RC7
 
 ### Change

--- a/src/services/CommonService.ts
+++ b/src/services/CommonService.ts
@@ -56,7 +56,7 @@ const imagesAndAppidToImageType = (
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
   images?.map((image: any) => ({
-    url: getPictureURL(appId, image.documentId),
+    url: getPictureURL(appId, image.documentId ?? image),
     text: 'Catena-X',
     loader: fetchImageWithToken,
   }))


### PR DESCRIPTION
## Description

App images not loading on app detail page in marketplace 

## Why

When accessing App Detail Page, instead of calling the image via the document API, it calls the value "undefined" in the API request.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/791

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally