### PR TITLE
feat(subscriptions): multiple tech user support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Feature
 
 - Technical User Creation - API Response Changes
+- AppSubscription, Service Subscription, Company Subscription
+  - Validation of Technical User UIs for multiple tech user support
 
 ### Change
 

--- a/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
@@ -77,7 +77,7 @@ const ActivateSubscriptionOverlay = ({
   const [URLErrorMsg, setURLErrorMessage] = useState('')
   const [loading, setLoading] = useState(false)
   const [activationResponse, setActivationResponse] =
-    useState<SubscriptionActivationResponse>()
+    useState<SubscriptionActivationResponse[]>()
 
   const [addUserSubscribtion] = useAddUserSubscribtionMutation()
   const { data } = useFetchTechnicalUserProfilesQuery(appId)
@@ -117,26 +117,30 @@ const ActivateSubscriptionOverlay = ({
     ],
   }
 
-  const tableData2: TableType = {
-    head: [t('content.appSubscription.activation.technicalDetails'), ''],
-    body: [
+  const activationData = activationResponse?.map(
+    (userdata: SubscriptionActivationResponse) => [
       [
         t('content.appSubscription.activation.appClientId'),
-        `${activationResponse?.clientInfo?.clientId}`,
+        `${userdata?.clientInfo?.clientId}`,
       ],
       [
         t('content.appSubscription.activation.technicalClientId'),
-        `${activationResponse?.technicalUserInfo?.technicalClientId}`,
+        `${userdata?.technicalUserInfo?.technicalClientId}`,
       ],
       [
         t('content.appSubscription.activation.technicalSecret'),
-        `${activationResponse?.technicalUserInfo?.technicalUserSecret}`,
+        `${userdata?.technicalUserInfo?.technicalUserSecret}`,
       ],
       [
         t('content.appSubscription.activation.technicalPermission'),
-        `${activationResponse?.technicalUserInfo?.technicalUserPermissions.toString()}`,
+        `${userdata?.technicalUserInfo?.technicalUserPermissions.toString()}`,
       ],
-    ],
+    ]
+  )
+
+  const tableData2: TableType = {
+    head: [t('content.appSubscription.activation.technicalDetails'), ''],
+    body: activationData?.flat(1) ?? [],
   }
 
   return (

--- a/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@catena-x/portal-shared-components'
 import {
   ProcessStep,
+  type TechnicalUserData,
   useFetchSubscriptionDetailQuery,
   useUpdateTenantUrlMutation,
 } from 'features/appSubscription/appSubscriptionApiSlice'
@@ -147,17 +148,23 @@ const AppSubscriptionDetailOverlay = ({
   const bodyData = [
     [
       `${t('content.appSubscription.detailOverlay.technicalName')}`,
-      data?.technicalUserData?.[0]?.name ??
-        (data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
+      data?.technicalUserData.length
+        ? data?.technicalUserData
+            .map((userdata: TechnicalUserData) => userdata.name)
+            .toString()
+        : data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
           ? 'N/A'
-          : ''),
+          : '',
     ],
     [
       `${t('content.appSubscription.detailOverlay.technicalPermission')}`,
-      data?.technicalUserData?.[0]?.permissions.toString() ??
-        (data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
+      data?.technicalUserData.length
+        ? data?.technicalUserData
+            .map((userdata: TechnicalUserData) => userdata.permissions)
+            .toString()
+        : data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
           ? 'N/A'
-          : ''),
+          : '',
     ],
   ]
 

--- a/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/index.tsx
@@ -120,15 +120,24 @@ const AppSubscriptionDetailOverlay = ({
     else return `${t('content.appSubscription.detailOverlay.serviceTitle')}`
   }
 
+  const getSubscriptionStatus = () => {
+    if (isAppSubscription) return getStatus()
+    else return getValue(data?.offerSubscriptionStatus)
+  }
+
+  const getTechnicalValue = () => {
+    if (data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING)
+      return 'N/A'
+    else return ''
+  }
+
   const subscriptionDetails: TableType = {
     head: [t('content.appSubscription.detailOverlay.subscriptionDetails'), ''],
     body: [
       [getTitle(), getValue(data?.name)],
       [
         `${t('content.appSubscription.detailOverlay.status')}`,
-        isAppSubscription
-          ? getStatus()
-          : getValue(data?.offerSubscriptionStatus),
+        getSubscriptionStatus(),
       ],
       [
         `${t('content.appSubscription.detailOverlay.customer')}`,
@@ -152,9 +161,7 @@ const AppSubscriptionDetailOverlay = ({
         ? data?.technicalUserData
             .map((userdata: TechnicalUserData) => userdata.name)
             .toString()
-        : data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
-          ? 'N/A'
-          : '',
+        : getTechnicalValue(),
     ],
     [
       `${t('content.appSubscription.detailOverlay.technicalPermission')}`,
@@ -162,9 +169,7 @@ const AppSubscriptionDetailOverlay = ({
         ? data?.technicalUserData
             .map((userdata: TechnicalUserData) => userdata.permissions)
             .toString()
-        : data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
-          ? 'N/A'
-          : '',
+        : getTechnicalValue(),
     ],
   ]
 
@@ -176,10 +181,7 @@ const AppSubscriptionDetailOverlay = ({
       ],
       [
         `${t('content.appSubscription.detailOverlay.appId')}`,
-        data?.appInstanceId ??
-          (data?.offerSubscriptionStatus !== SubscriptionStatus.PENDING
-            ? 'N/A'
-            : ''),
+        data?.appInstanceId ?? getTechnicalValue(),
       ]
     )
   }

--- a/src/components/pages/CompanySubscriptions/CompanySubscriptionDetail.tsx
+++ b/src/components/pages/CompanySubscriptions/CompanySubscriptionDetail.tsx
@@ -38,7 +38,10 @@ import { PAGES } from 'types/Constants'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import UnpublishedIcon from '@mui/icons-material/Unpublished'
 import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
-import { SubscriptionStatus } from 'features/apps/types'
+import {
+  type SubscribeTechnicalUserData,
+  SubscriptionStatus,
+} from 'features/apps/types'
 import { fetchImageWithToken } from 'services/ImageService'
 import { getApiBase } from 'services/EnvironmentService'
 import './CompanySubscriptions.scss'
@@ -61,7 +64,11 @@ export default function CompanySubscriptionDetail() {
     ],
     body: [
       [data?.connectorData?.[0]?.name ?? ''],
-      [data?.technicalUserData?.[0]?.name ?? ''],
+      [
+        data?.technicalUserData
+          ?.map((userdata: SubscribeTechnicalUserData) => userdata.name)
+          .toString() ?? '',
+      ],
     ],
   }
 

--- a/src/components/pages/Organization/UnSubscribeOverlay.tsx
+++ b/src/components/pages/Organization/UnSubscribeOverlay.tsx
@@ -34,7 +34,10 @@ import {
 import Box from '@mui/material/Box'
 import { useFetchSubscriptionAppQuery } from 'features/apps/apiSlice'
 import './Organization.scss'
-import { SubscriptionStatus } from 'features/apps/types'
+import {
+  type SubscribeTechnicalUserData,
+  SubscriptionStatus,
+} from 'features/apps/types'
 
 interface UnSubscribeOverlayProps {
   openDialog?: boolean
@@ -107,7 +110,12 @@ const UnSubscribeOverlay = ({
                     ],
                     [
                       t('content.organization.unsubscribe.table.techUser'),
-                      data?.technicalUserData[0]?.name ?? '',
+                      data?.technicalUserData
+                        ?.map(
+                          (userdata: SubscribeTechnicalUserData) =>
+                            userdata.name
+                        )
+                        .toString() ?? '',
                     ],
                   ],
                 }}

--- a/src/features/appSubscription/appSubscriptionApiSlice.ts
+++ b/src/features/appSubscription/appSubscriptionApiSlice.ts
@@ -170,7 +170,7 @@ export const apiSlice = createApi({
         `/api/apps/${body.appId}/subscription/${body.subscriptionId}/provider`,
     }),
     addUserSubscribtion: builder.mutation<
-      SubscriptionActivationResponse,
+      SubscriptionActivationResponse[],
       SubscriptionStoreRequest
     >({
       query: (data: SubscriptionStoreRequest) => ({


### PR DESCRIPTION
## Description

Validation of Technical User UIs for multiple tech user support

## Why

The frontend needs to be prepared to handle multiple service account responses.
Possible impacted pages: The backend response of the following 4 endpoints might include multiple technical users:
- appsubscription details page
- servicesubscription details page
- company-subscriptions details page

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/789

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
