### PR TITLE
fix(IdP): add delete for managed IdP's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Side menu - Mobile version shows up all the menu in My company section
 - App marketplace
   - fixed display of images in app detail page
+- Identity Provider Config
+  - Added delete option for newly created "Managed IdPs"
 
 ## 2.0.0-RC7
 

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -245,6 +245,10 @@ export const IDPList = () => {
           {idp.oidc?.clientId && menuItems.enableToggle}
           {!isManaged && (idp.enabled ? menuItems.addUsers : menuItems.delete)}
           {isManaged && !idp.enabled && idp.oidc?.clientId && menuItems.delete}
+          {isManaged &&
+            idp.oidc?.clientId === null &&
+            idp.oidc?.hasClientSecret === false &&
+            menuItems.delete}
         </DropdownMenu>
       </div>
     )


### PR DESCRIPTION
## Description

Added delete option for newly created "Managed IdPs"

## Why

To enhance Managed IdP's to support with deleting of newly created Managed IdP

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/757

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
