### PR TITLE
feat(admin credential): add revoke feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Technical User Creation - API Response Changes
 - AppSubscription, Service Subscription, Company Subscription
   - Validation of Technical User UIs for multiple tech user support
+- Admin Credential
+  - Implement Credential Revocation Feature
+  - Add Credential Status
 
 ### Change
 

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1770,7 +1770,14 @@
       },
       "approvedMessage": "Anmeldeinformationsanfrage erfolgreich angenommen.",
       "declinedMessage": "Anmeldeinformationsanfrage wurde abgelehnt.",
-      "errorMessage": "Etwas ist schief gelaufen. Bitte kontaktieren sie ihren Administrator."
+      "errorMessage": "Etwas ist schief gelaufen. Bitte kontaktieren sie ihren Administrator.",
+      "revokeOverlay": {
+        "title": "Revoke Credential",
+        "description": "Revoking a credential cannot be undone.",
+        "subDesc": "Do you want to revoke the credential:",
+        "success": "Der Widerruf Ihrer Zugangsdaten wurde erfolgreich verarbeitet. Mit der erfolgreichen Sperrung verliert der Ausweis seine Gültigkeit. Beachten Sie, dass die Aktion nach dem Widerrufen eines Berechtigungsnachweises nicht mehr rückgängig gemacht werden kann und der Berechtigungsnachweis nicht mehr als gültig anerkannt wird.",
+        "error": "Der Widerruf der Berechtigung war erfolglos. Bitte wenden Sie sich an den Administrator oder versuche Sie es später erneut."
+      }
     },
     "certificates": {
       "heading": "Zertifikate",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1841,7 +1841,14 @@
       },
       "approvedMessage": "Credential Request Accepted successfully.",
       "declinedMessage": "Credential Request Declined successfully.",
-      "errorMessage": "Something went wrong!"
+      "errorMessage": "Something went wrong!",
+      "revokeOverlay": {
+        "title": "Revoke Credential",
+        "description": "Revoking a credential cannot be undone.",
+        "subDesc": "Do you want to revoke the credential:",
+        "success": "The customer credential revocation has been successfully processed. With the successful revocation the credential is no longer valid. Note once a credential is revoked, the action cannot be undone, and the credential will no longer be recognized as valid.",
+        "error": "The revocation of the credential was unsuccessful. An error occurred. Please try again. If the problem persists, contact the site administrator"
+      }
     },
     "companyWallet": {
       "heading": "My Company Wallet",

--- a/src/components/pages/AdminCredential/AdminCredential.scss
+++ b/src/components/pages/AdminCredential/AdminCredential.scss
@@ -83,6 +83,8 @@
   }
   .statusBtn {
     border-radius: 20px;
+    padding: 4px 10px;
+    font-size: 12px;
   }
   .ml-10 {
     margin-left: 10px;

--- a/src/components/pages/AdminCredential/AdminCredential.scss
+++ b/src/components/pages/AdminCredential/AdminCredential.scss
@@ -87,4 +87,15 @@
   .ml-10 {
     margin-left: 10px;
   }
+  .revokeBtn {
+    color: #c84f4f;
+    cursor: pointer;
+  }
+}
+
+.revokeOverlay {
+  text-align: center !important;
+  .description {
+    margin-bottom: 20px;
+  }
 }

--- a/src/features/certification/certificationApiSlice.tsx
+++ b/src/features/certification/certificationApiSlice.tsx
@@ -28,6 +28,7 @@ export enum StatusEnum {
   ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',
   PENDING = 'PENDING',
+  REVOKED = 'REVOKED',
 }
 
 export type SSIDetailData = {
@@ -60,7 +61,7 @@ export type CredentialData = {
   companyId: string
   credentialType: string
   useCase: string
-  participantStatus: string
+  participantStatus: StatusEnum
   expiryDate: string
   documents: Array<{
     documentId: string
@@ -135,6 +136,12 @@ export const apiSlice = createApi({
     fetchCertificateTypes: builder.query<string[], void>({
       query: () => '/api/administration/companydata/certificateTypes',
     }),
+    revokeCredential: builder.mutation<string, string>({
+      query: (credentialId) => ({
+        url: `${getSsiBase()}/api/revocation/issuer/credentials/${credentialId}`,
+        method: 'POST',
+      }),
+    }),
   }),
 })
 
@@ -145,4 +152,5 @@ export const {
   useApproveCredentialMutation,
   useDeclineCredentialMutation,
   useFetchCertificateTypesQuery,
+  useRevokeCredentialMutation,
 } = apiSlice

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -226,6 +226,7 @@ export enum ROLES {
   DELETE_CERTIFICATES = 'delete_certificates',
   MY_ACCOUNT = 'view_own_user_account',
   CREDENTIAL_REQUESTS = 'view_credential_requests',
+  REVOKE_CREDENTIALS_ISSUER = 'revoke_credentials_issuer',
 }
 
 export enum HINTS {


### PR DESCRIPTION
## Description

- Implement Credential Revocation Feature for Issuer Admin Board
- Add Credential Status to Credential Admin Board 

## Why

Implement a revocation feature that allows issuers with the "revoke_credentials_issuer" permission to revoke credentials marked as "Active."

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/768
https://github.com/eclipse-tractusx/portal-frontend/issues/774

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
