### PR TITLE
fix: change required role for app user role overlay

### DIFF
--- a/src/components/pages/AppUserManagement/components/AppUserDetailsTable/index.tsx
+++ b/src/components/pages/AppUserManagement/components/AppUserDetailsTable/index.tsx
@@ -63,8 +63,11 @@ export const AppUserDetailsTable = ({
       fetchHook={useFetchAppUsersSearchQuery}
       fetchHookArgs={{ appId, expr, userRoleResponse, role: true }}
       onSearch={setExpr}
-      onDetailsClick={(row: TenantUser) =>
-        dispatch(show(OVERLAYS.EDIT_APP_USER_ROLES, row.companyUserId))
+      onDetailsClick={
+        UserService.hasRole(ROLES.MODIFY_USER_ACCOUNT)
+          ? (row: TenantUser) =>
+              dispatch(show(OVERLAYS.EDIT_APP_USER_ROLES, row.companyUserId))
+          : undefined
       }
     />
   )

--- a/src/components/pages/AppUserManagement/components/AppUserDetailsTable/index.tsx
+++ b/src/components/pages/AppUserManagement/components/AppUserDetailsTable/index.tsx
@@ -23,13 +23,14 @@ import { useParams } from 'react-router-dom'
 import { useState } from 'react'
 import { UserList } from 'components/shared/frame/UserList'
 import { show } from 'features/control/overlay'
-import { OVERLAYS } from 'types/Constants'
+import { OVERLAYS, ROLES } from 'types/Constants'
 import {
   type AppRole,
   useFetchAppUsersSearchQuery,
 } from 'features/admin/appuserApiSlice'
 import type { TenantUser } from 'features/admin/userApiSlice'
 import { useTranslation } from 'react-i18next'
+import UserService from 'services/UserService'
 
 export const AppUserDetailsTable = ({
   roles,
@@ -48,7 +49,11 @@ export const AppUserDetailsTable = ({
       sectionTitle={'content.usermanagement.appUserDetails.subheadline'}
       addButtonLabel={'content.usermanagement.appUserDetails.table.add'}
       addButtonClick={() => dispatch(show(OVERLAYS.ADD_APP_USER_ROLES, appId))}
-      addButtonDisabled={roles && roles?.length <= 0}
+      addButtonDisabled={
+        !roles ||
+        roles.length === 0 ||
+        !UserService.hasRole(ROLES.MODIFY_USER_ACCOUNT)
+      }
       addButtonTooltip={
         roles && roles?.length <= 0
           ? t('content.usermanagement.appUserDetails.table.buttonTooltip')

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -72,7 +72,7 @@ export const UserList = ({
   addMultipleButtonLabel?: string
   onMultipleButtonClick?: () => void
   tableLabel: string
-  onDetailsClick: (row: TenantUser) => void
+  onDetailsClick?: (row: TenantUser) => void
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
   fetchHook: (paginArgs: PaginFetchArgs) => any
@@ -168,9 +168,10 @@ export const UserList = ({
             flex: 2,
             renderCell: ({ row }: { row: TenantUser }) => (
               <IconButton
+                disabled={onDetailsClick === undefined}
                 color="secondary"
                 onClick={() => {
-                  onDetailsClick(row)
+                  onDetailsClick?.(row)
                 }}
               >
                 <ArrowForwardIcon />

--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -614,11 +614,11 @@ export const ALL_OVERLAYS: IOverlay[] = [
   },
   {
     name: OVERLAYS.ADD_APP_USER_ROLES,
-    role: ROLES.USERMANAGEMENT_ADD,
+    role: ROLES.MODIFY_USER_ACCOUNT,
   },
   {
     name: OVERLAYS.EDIT_APP_USER_ROLES,
-    role: ROLES.USERMANAGEMENT_ADD,
+    role: ROLES.MODIFY_USER_ACCOUNT,
   },
   { name: OVERLAYS.APP, role: ROLES.APPSTORE_VIEW },
   { name: OVERLAYS.NEWS },


### PR DESCRIPTION
## Description

Change of roles corresponding to add/edit app user role overlays.

## Why

This is for consistency with backend endpoint. [owncompany/users/{companyUserId}/apps/{appId}/roles](https://github.com/eclipse-tractusx/portal-backend/blob/a0b4b0d5729252bdf5b012d4cd592789092b68aa/src/administration/Administration.Service/Controllers/UserController.cs#L239)

## Issue

Refs: #822

## Checklist

- [x] I have performed a self-review of my own code

## Note
Edits by maintainers allowed:
<img width="328" alt="image" src="https://github.com/eclipse-tractusx/portal-frontend/assets/150006841/72690830-1ad8-4421-a3bf-f7626ff09275">
