### PR TITLE
fix(admin credential): update document download endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - Api url typo fix
 - App Access Management
   - Fix carousel element issue
+- Admin Credential
+  - Change document download endpoint
 
 ## 2.0.0-RC8
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <div id="app"></div>
     <script>
       // Do NOT change 'ENV' without changing 'custom_env_vars_anchor' in scripts/inject-dynamic-env.sh as well
-      const ENV = {REQUIRE_HTTPS_URL_PATTERN:"true",PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth",SSI_CREDENTIAL_URL:"https://ssi-credential-issuer.example.org",BPDM_API_URL:"https://business-partners.example.org/pool/v6",SEMANTICS_URL:"https://semantics.example.org",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.example.org",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian",CLIENT_ID_SSI_CREDENTIAL:"Cl24-CX-SSI-CredentialIssuer"}
+      const ENV = {REQUIRE_HTTPS_URL_PATTERN:"true",PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend-rc.dev.demo.catena-x.net",CENTRALIDP_URL:"https://centralidp-rc.dev.demo.catena-x.net/auth",SSI_CREDENTIAL_URL:"https://ssi-credential-issuer-rc.dev.demo.catena-x.net",BPDM_API_URL:"https://business-partners.dev.demo.catena-x.net/pool/v6",SEMANTICS_URL:"https://semantics.dev.demo.catena-x.net",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.dev.demo.catena-x.net",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian",CLIENT_ID_SSI_CREDENTIAL:"Cl24-CX-SSI-CredentialIssuer"}
     </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <div id="app"></div>
     <script>
       // Do NOT change 'ENV' without changing 'custom_env_vars_anchor' in scripts/inject-dynamic-env.sh as well
-      const ENV = {REQUIRE_HTTPS_URL_PATTERN:"true",PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend-rc.dev.demo.catena-x.net",CENTRALIDP_URL:"https://centralidp-rc.dev.demo.catena-x.net/auth",SSI_CREDENTIAL_URL:"https://ssi-credential-issuer-rc.dev.demo.catena-x.net",BPDM_API_URL:"https://business-partners.dev.demo.catena-x.net/pool/v6",SEMANTICS_URL:"https://semantics.dev.demo.catena-x.net",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.dev.demo.catena-x.net",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian",CLIENT_ID_SSI_CREDENTIAL:"Cl24-CX-SSI-CredentialIssuer"}
+      const ENV = {REQUIRE_HTTPS_URL_PATTERN:"true",PORTAL_ASSETS_URL:"http://localhost:3000/assets",PORTAL_BACKEND_URL:"https://portal-backend.example.org",CENTRALIDP_URL:"https://centralidp.example.org/auth",SSI_CREDENTIAL_URL:"https://ssi-credential-issuer.example.org",BPDM_API_URL:"https://business-partners.example.org/pool/v6",SEMANTICS_URL:"https://semantics.example.org",MANAGED_IDENTITY_WALLETS_NEW_URL:"https://managed-identity-wallets-new.example.org",REALM:"CX-Central",CLIENT_ID:"Cl2-CX-Portal",CLIENT_ID_SEMANTIC:"Cl3-CX-Semantic",CLIENT_ID_MIW:"Cl5-CX-Custodian",CLIENT_ID_SSI_CREDENTIAL:"Cl24-CX-SSI-CredentialIssuer"}
     </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>

--- a/src/features/appManagement/apiSlice.ts
+++ b/src/features/appManagement/apiSlice.ts
@@ -22,6 +22,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { apiBaseQuery } from 'utils/rtkUtil'
 import type { AppStatusDataState } from './types'
 import i18next from 'i18next'
+import { getSsiBase } from 'services/EnvironmentService'
 
 export type useCasesItem = {
   useCaseId: string
@@ -322,7 +323,7 @@ export const apiSlice = createApi({
     }),
     fetchNewDocumentById: builder.mutation({
       query: (documentId) => ({
-        url: `/api/administration/documents/${documentId}`,
+        url: `${getSsiBase()}/api/credential/documents/${documentId}`,
         responseHandler: async (response) => ({
           headers: response.headers,
           data: await response.blob(),


### PR DESCRIPTION
## Description

Update document download functionality on the page /admin-credential

## Why

Currently, the document download feature on the page /admin-credential is not functioning correctly. This issue is due to the connection with the outdated backend endpoint {portalhostname}/api/administration/documents/{documentID}. We need to switch to the new provided endpoint {issuercomponenthostname}/credentialRequest/documents/{documentId} located inside the issuer component, instead of the portal backend.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/763

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
