### PR TITLE
fix(osp): preset unique ID type in partner registration form

### DIFF
--- a/src/components/overlays/OSPRegister/OSPRegisterContent.tsx
+++ b/src/components/overlays/OSPRegister/OSPRegisterContent.tsx
@@ -341,14 +341,12 @@ const OSPRegisterForm = ({
             onChangeItem: (value: ItemType): void => {
               updateData({
                 ...data,
-                uniqueIds: value
-                  ? [
-                      {
-                        ...data.uniqueIds[0],
-                        type: value.id as UNIQUE_ID_TYPE,
-                      },
-                    ]
-                  : [],
+                uniqueIds: [
+                  {
+                    ...data.uniqueIds[0],
+                    type: value.id as UNIQUE_ID_TYPE,
+                  },
+                ],
               })
             },
           }}
@@ -460,56 +458,23 @@ export const OSPRegisterContent = ({
   companyRoleAgreementData: CompanyRoleAgreementData
   onValid: (form: PartnerRegistration | undefined) => void
 }) => {
-  const initialData: PartnerRegistration = {
-    ...emptyPartnerRegistration,
-    userDetails: [
-      {
-        ...emptyPartnerRegistration.userDetails[0],
-        identityProviderId: idp.identityProviderId,
-      },
-    ],
-  }
-  const [formData, setFormData] = useState<string>(
-    JSON.stringify(initialData, null, 2)
-  )
-  const [debug, setDebug] = useState<boolean>(false)
-  const toggleDebug = () => {
-    setDebug(!debug)
-  }
-
   const doCheckForm = (
     partnerRegistration: PartnerRegistration | undefined
   ) => {
     const valid =
       partnerRegistration &&
       partnerRegistration.companyRoles.length > 0 &&
-      partnerRegistration?.uniqueIds.length > 0
+      partnerRegistration?.uniqueIds.length > 0 &&
+      isPartnerUniqueID(partnerRegistration?.uniqueIds[0].value)
     onValid(valid ? partnerRegistration : undefined)
-    setFormData(
-      valid ? JSON.stringify(partnerRegistration, null, 2) : '# data invalid'
-    )
     return !!valid
   }
 
   return (
-    <>
-      <OSPRegisterForm
-        idp={idp}
-        companyRoleAgreementData={companyRoleAgreementData}
-        onChange={doCheckForm}
-      />
-      <pre
-        style={{
-          fontSize: '10px',
-          backgroundColor: '#eeeeee',
-          cursor: 'pointer',
-        }}
-        onClick={toggleDebug}
-        onKeyUp={toggleDebug}
-      >
-        {debug ? formData : '{...}'}
-      </pre>
-      ,
-    </>
+    <OSPRegisterForm
+      idp={idp}
+      companyRoleAgreementData={companyRoleAgreementData}
+      onChange={doCheckForm}
+    />
   )
 }

--- a/src/components/shared/basic/Input/BasicInput.tsx
+++ b/src/components/shared/basic/Input/BasicInput.tsx
@@ -45,6 +45,7 @@ export type BasicInputProps = {
   value?: string
   onValue?: (value: string) => void
   type?: InputType
+  disabled?: boolean
   toggleHide?: boolean
   errorMessage?: string
   style?: React.CSSProperties
@@ -72,6 +73,7 @@ const BasicInput = ({
   value = '',
   onValue,
   type = InputType.text,
+  disabled = false,
   toggleHide = false,
   errorMessage,
   style,
@@ -92,7 +94,7 @@ const BasicInput = ({
 
   return (
     <div style={{ width: '100%' }}>
-      <div style={{ display: 'flex', marginTop: '12px' }}>
+      <div style={{ display: 'flex', marginTop: '12px', minHeight: '27px' }}>
         {label && (
           <Typography
             variant="label3"
@@ -131,6 +133,7 @@ const BasicInput = ({
           name={name}
           type={hidden ? InputType.password : InputType.text}
           defaultValue={value}
+          disabled={disabled}
           onKeyUp={() => {
             onValue?.(ref.current?.value ?? '')
           }}

--- a/src/components/shared/basic/Input/ValidatingInput.tsx
+++ b/src/components/shared/basic/Input/ValidatingInput.tsx
@@ -41,6 +41,7 @@ const ValidatingInput = ({
   value = '',
   onValue,
   type = InputType.text,
+  disabled = false,
   toggleHide = false,
   errorMessage,
   style,
@@ -81,7 +82,17 @@ const ValidatingInput = ({
 
   return (
     <BasicInput
-      {...{ name, label, hint, value, onValue, type, toggleHide, errorMessage }}
+      {...{
+        name,
+        label,
+        hint,
+        value,
+        onValue,
+        type,
+        disabled,
+        toggleHide,
+        errorMessage,
+      }}
       {...(color === Colors.error ? { errorMessage: hint } : {})}
       style={{
         ...style,

--- a/src/features/admin/networkApiSlice.ts
+++ b/src/features/admin/networkApiSlice.ts
@@ -137,7 +137,12 @@ export const emptyPartnerRegistration: PartnerRegistration = {
   zipCode: '',
   region: '',
   countryAlpha2Code: '',
-  uniqueIds: [],
+  uniqueIds: [
+    {
+      type: UNIQUE_ID_TYPE.COMMERCIAL_REG_NUMBER,
+      value: '',
+    },
+  ],
   userDetails: [
     {
       identityProviderId: '',

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -107,6 +107,7 @@ export const Patterns = {
   },
 }
 
+export const isEmpty = (expr: string) => !expr || expr.trim() === ''
 export const isID = (expr: string) => Patterns.ID.test(expr)
 export const isMail = (expr: string) => Patterns.MAIL.test(expr)
 export const isBPN = (expr: string) => Patterns.BPN.test(expr)


### PR DESCRIPTION
## Description

Set default for mandatory unique ID field 

## Why

The default was empty and so the request data when field unchanged by user. Also removed the debug output below the form.

## Issue

#826 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally