### PR TITLE
fix(connector): show service accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - Api url typo fix
 - App Access Management
   - Fix carousel element issue
+- Connectors
+  - Fetch all service accounts and show them in the auto complete list
 
 ## 2.0.0-RC8
 

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorInsertForm.tsx
@@ -258,11 +258,9 @@ any) => {
   const [serviceAccountUsers, setServiceAccountUsers] = useState([])
 
   useEffect(() => {
-    if (fetchServiceAccountUsers?.content)
+    if (fetchServiceAccountUsers)
       setServiceAccountUsers(
-        fetchServiceAccountUsers.content?.filter(
-          (item: { name: string }) => item.name
-        )
+        fetchServiceAccountUsers?.filter((item: { name: string }) => item.name)
       )
   }, [fetchServiceAccountUsers])
 

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -39,7 +39,7 @@ import {
 } from 'features/connector/connectorApiSlice'
 import Box from '@mui/material/Box'
 import { useFetchOwnCompanyDetailsQuery } from 'features/admin/userApiSlice'
-import { useFetchServiceAccountUsersQuery } from 'features/admin/serviceApiSlice'
+import { type ServiceAccountListEntry, useFetchServiceAccountUsersQuery } from 'features/admin/serviceApiSlice'
 
 interface AddCollectorOverlayProps {
   openDialog?: boolean
@@ -97,8 +97,10 @@ const AddConnectorOverlay = ({
   const { t } = useTranslation()
   const { data } = useFetchOfferSubscriptionsQuery()
   const { data: ownCompanyDetails } = useFetchOwnCompanyDetailsQuery()
-  const fetchServiceAccountUsers = useFetchServiceAccountUsersQuery().data
+  const [page, setPage] = useState<number>(0)
+  const { data: serviceAccounts } = useFetchServiceAccountUsersQuery(page)
   const [newTechnicalUSer, setNewTechnicalUSer] = useState(false)
+  const [allAccounts, setAllAccounts] = useState<ServiceAccountListEntry[]>([])
 
   const {
     handleSubmit,
@@ -117,6 +119,13 @@ const AddConnectorOverlay = ({
   useEffect(() => {
     if (openDialog) reset(formFields)
   }, [openDialog, reset])
+
+  useEffect(() => {
+    if (serviceAccounts && serviceAccounts?.meta?.totalPages > page) {
+      setPage((pre) => pre + 1)
+      setAllAccounts((i: ServiceAccountListEntry[]) => i.concat(serviceAccounts?.content))
+    }
+  }, [serviceAccounts])
 
   const onFormSubmit = async () => {
     const validateFields =
@@ -197,7 +206,7 @@ const AddConnectorOverlay = ({
               <ConnectorInsertForm
                 subscriptions={data}
                 selectedService={selected}
-                fetchServiceAccountUsers={fetchServiceAccountUsers}
+                fetchServiceAccountUsers={allAccounts}
                 onFormSubmitt={onFormSubmit}
                 setNewTechnicalUSer={setNewTechnicalUSer}
                 newUserLoading={newUserLoading}

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -39,7 +39,10 @@ import {
 } from 'features/connector/connectorApiSlice'
 import Box from '@mui/material/Box'
 import { useFetchOwnCompanyDetailsQuery } from 'features/admin/userApiSlice'
-import { type ServiceAccountListEntry, useFetchServiceAccountUsersQuery } from 'features/admin/serviceApiSlice'
+import {
+  type ServiceAccountListEntry,
+  useFetchServiceAccountUsersQuery,
+} from 'features/admin/serviceApiSlice'
 
 interface AddCollectorOverlayProps {
   openDialog?: boolean
@@ -123,7 +126,9 @@ const AddConnectorOverlay = ({
   useEffect(() => {
     if (serviceAccounts && serviceAccounts?.meta?.totalPages > page) {
       setPage((pre) => pre + 1)
-      setAllAccounts((i: ServiceAccountListEntry[]) => i.concat(serviceAccounts?.content))
+      setAllAccounts((i: ServiceAccountListEntry[]) =>
+        i.concat(serviceAccounts?.content)
+      )
     }
   }, [serviceAccounts])
 

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -77,6 +77,16 @@ export type AppRoleCreate = {
   roles: string[]
 }
 
+export interface ServiceAccountsResponseType {
+  content: ServiceAccountListEntry[]
+  meta: {
+    contentSize: number
+    page: number
+    totalElements: number
+    totalPages: number
+  }
+}
+
 export enum ServiceAccountStatusFilter {
   ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',
@@ -165,9 +175,12 @@ export const apiSlice = createApi({
         method: 'POST',
       }),
     }),
-    fetchServiceAccountUsers: builder.query<ServiceAccountListEntry[], void>({
-      query: () =>
-        `/api/administration/serviceaccount/owncompany/serviceaccounts?page=0&size=${PAGE_SIZE}&filterForInactive=false`,
+    fetchServiceAccountUsers: builder.query<
+      ServiceAccountsResponseType,
+      number
+    >({
+      query: (page) =>
+        `/api/administration/serviceaccount/owncompany/serviceaccounts?page=${page}&size=${PAGE_SIZE}&filterForInactive=false`,
     }),
   }),
 })


### PR DESCRIPTION
## Description

Fetch all the service accounts and then load the auto complete component.

## Why

auto complete does not show up all the service accounts

## Issue

#752 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
