### PR TITLE
feat(my organization view): Change required role for my organization view

### DIFF
--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -195,7 +195,7 @@ export const ALL_PAGES: IPage[] = [
   },
   {
     name: PAGES.ORGANIZATION,
-    role: ROLES.PARTNER_NETWORK_VIEW,
+    role: ROLES.MY_ORGANIZATION_VIEW,
     element: <Organization />,
   },
   {

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -203,6 +203,7 @@ export enum ROLES {
   IDP_DISABLE = 'disable_idp',
   MODIFY_USER_ACCOUNT = 'modify_user_account',
   ORGANIZATION_VIEW = 'view_organization',
+  MY_ORGANIZATION_VIEW = 'view_company_data',
   PARTNER_NETWORK_VIEW = 'view_partner_network',
   DEVELOPER = 'catenax_developer',
   CONNECTORS_VIEW = 'view_connectors',

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -202,7 +202,6 @@ export enum ROLES {
   IDP_SETUP = 'setup_idp',
   IDP_DISABLE = 'disable_idp',
   MODIFY_USER_ACCOUNT = 'modify_user_account',
-  ORGANIZATION_VIEW = 'view_organization',
   MY_ORGANIZATION_VIEW = 'view_company_data',
   PARTNER_NETWORK_VIEW = 'view_partner_network',
   DEVELOPER = 'catenax_developer',


### PR DESCRIPTION
## Description

Added ROLES.MY_ORGANIZATION_VIEW constant and use this to decide access for PAGES.ORGANIZATION

I was unsure about the intention for **unused** ROLES.ORGANIZATION_VIEW @oyo. Alternatively we can use that one instead.

## Why

With role to access data for my organization I also want access to FE view. There is a mismatch between [BE endpoint](https://github.com/eclipse-tractusx/portal-backend/blob/73e24a69521f7ef757985328520b54c0c6649c71/src/administration/Administration.Service/Controllers/CompanyDataController.cs#L55-L69) and FE page role requirement.

## Issue

Refs: [#856](https://github.com/eclipse-tractusx/portal-frontend/issues/856)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally