### PR TITLE
fix(user management): fix disable button state when deselect all checkboxes [updated]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@
 - **Connector Management**:
   - fixed blank page issue on clicking on details [#925](https://github.com/eclipse-tractusx/portal-frontend/pull/925)
 
-
 ## 2.0.0
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   - Add correct registration application checklist items
 - Credential Request
   - UI Improvements
+- User Management
+  - Fix disable button state when deselect all checkboxes  
 
 ### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - **User Management**:
   - Fix disable button state when deselect all checkboxes [#923](https://github.com/eclipse-tractusx/portal-frontend/pull/923)
 
-
 ## 2.1.0-RC1
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bugfixes
+
+- **User Management**:
+  - Fix disable button state when deselect all checkboxes [#923](https://github.com/eclipse-tractusx/portal-frontend/pull/923)
+
+
 ## 2.1.0-RC1
 
 ### Change
@@ -45,8 +53,6 @@
   - fixed app category view more and collapse button function [#805](https://github.com/eclipse-tractusx/portal-frontend/pull/805)
 - **Connector Management**:
   - fixed blank page issue on clicking on details [#925](https://github.com/eclipse-tractusx/portal-frontend/pull/925)
-- **User Management**:
-  - Fix disable button state when deselect all checkboxes [#923](https://github.com/eclipse-tractusx/portal-frontend/pull/923)
 
 
 ## 2.0.0

--- a/src/components/overlays/EditPortalRoles/index.tsx
+++ b/src/components/overlays/EditPortalRoles/index.tsx
@@ -106,10 +106,11 @@ export default function EditPortalRoles({ id }: { id: string }) {
   }
 
   const checkConfirmButton = () =>
-    assignedRoles &&
-    selectedRoles &&
-    assignedRoles.length === selectedRoles.length &&
-    assignedRoles.every((value) => selectedRoles.includes(value))
+    selectedRoles.length === 0 ||
+    (assignedRoles &&
+      selectedRoles &&
+      assignedRoles.length === selectedRoles.length &&
+      assignedRoles.every((value) => selectedRoles.includes(value)))
 
   return (
     <>


### PR DESCRIPTION
## Description

Users/Admins are able to deselect all roles assigned to them and confirm during role updates.

Users should not be able to confirm the role update after deselecting all roles assigned to them. At least one role should remain selected at all times.

Users should not be able to confirm the role update after deselecting all roles assigned to them. At least one role should remain selected at all times.


## Why

Please include an explanation of why this change is necessary as well as relevant motivation and context. List any dependencies that are required for this change.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/919

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
