### PR TITLE
fix(connector-details): fix blank page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Remove unnecessary import of Typography, Dialog and Circular Progress from mui and use those from shared-components
 - Connector Management
   - fetch details using api, added permissions and fixed error messages
+  - Fixed blank page issue on cliking on details
 - App Release Process
   - Integrated role deletion with BE api reponse
 - Company Application Registraion Detail Overlay

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -116,9 +116,15 @@ const ConnectorDetailsOverlay = ({
     {
       key: t('content.edcconnector.details.technicalUser'),
       value:
-        fetchConnectorDetails?.technicalUser === null
-          ? t('content.edcconnector.details.noTechnicalUserAvailable')
-          : fetchConnectorDetails?.technicalUser,
+        fetchConnectorDetails?.technicalUser === null ? (
+          t('content.edcconnector.details.noTechnicalUserAvailable')
+        ) : (
+          <a
+            href={`/techuserdetails/${fetchConnectorDetails?.technicalUser?.id}`}
+          >
+            {fetchConnectorDetails?.technicalUser?.name}
+          </a>
+        ),
     },
     {
       key: t('content.edcconnector.details.SdRegistration'),

--- a/src/features/connector/connectorApiSlice.ts
+++ b/src/features/connector/connectorApiSlice.ts
@@ -92,7 +92,12 @@ export interface ConnectorDetailsType {
   hostId: string
   hostCompanyName: string
   connectorUrl: string
-  technicalUser: string
+  technicalUser: null | {
+    id: string
+    name: string
+    clientId: string
+    description: string
+  }
   selfDescriptionDocumentId?: string | null
 }
 


### PR DESCRIPTION
## Description

Fixed blank page issue on clicking on details

## Why

As clicking on connector details leads to blank page

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/924

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally