### PR TITLE
fix(connector management): update api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Remove unnecessary import of Typography, Dialog and Circular Progress from mui and use those from shared-components
 - Connector Management
   - fetch details using api, added permissions and fixed error messages
+  - update get endpoint for 'Connect Company Connector' to consider technical user status
 - App Release Process
   - Integrated role deletion with BE api reponse
 - Company Application Registraion Detail Overlay

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -180,7 +180,7 @@ export const apiSlice = createApi({
       number
     >({
       query: (page) =>
-        `/api/administration/serviceaccount/owncompany/serviceaccounts?page=${page}&size=${PAGE_SIZE}&filterForInactive=false`,
+        `/api/administration/serviceaccount/owncompany/serviceaccounts?page=${page}&size=${PAGE_SIZE}&filterForInactive=false&userStatus=ACTIVE`,
     }),
   }),
 })


### PR DESCRIPTION
## Description

update get endpoint for 'Connect Company Connector' to consider technical user status

## Why

The API call currently lists all technical users, including those that are inactive or deleted, which are not eligible for connection to new connector objects.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/929

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally