### PR TITLE
feat(subscription details): implement loader for subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Use scroll to top button from shared components
 - Subscription Overlay
-  - implement loading state for provider subscription details overlay
+  - implement loading state for provider subscription detail overlay
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Feature
 
 - Use scroll to top button from shared components
+- Subscription Overlay
+  - implement loading state for provider subscription detail overlay
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Use scroll to top button from shared components
 - Subscription Overlay
-  - implement loading state for provider subscription detail overlay
+  - implement loading state for provider subscription details overlay
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,82 @@ yarn start
 
 Note: if you'd like to run the complete frontend application, follow the `Run frontend on localhost.md` guide available within the technical documentation of [portal-assets](https://github.com/eclipse-tractusx/portal-assets).
 
+## Coding guidelines
+
+### Naming conventions for custom components
+
+Folder, File and component name to be in Camel Case\
+Scss files to be in Camel Case\
+RTK folders and files to be in small case
+
+### Import Components
+
+Always use components from [portal-shared-components library](https://github.com/eclipse-tractusx/portal-shared-components)\
+Do not import components directly from mui
+
+### Allowed imports from mui
+
+Box, useMediaQuery
+
+### Guidelines for consistent styling and theming
+
+Do not use useTheme from mui\
+Use theme from the [portal-shared-components library](https://github.com/eclipse-tractusx/portal-shared-components)\
+Use custom class names to override default or mui styles\
+Use appropriate `Typography` for the text and do not override font family of it
+
+### Create new text locale file
+
+Create a new file in the respective `language` folder with the module name in `assets/locales`\
+Use small cases for the `json` file\
+
+ex: notifications.json
+
+### Add new text values in locale file
+
+Keys inside `json` file should be in Camel Case\
+
+ex: notificationTitle
+
+### Read text values from locale file
+
+Import `useTranslation` from `react-i18next`\
+Declare translation object using the specific module\
+
+```
+const { t } = useTranslation('notification')
+```
+
+Empty in the usetransation() will pull the data from `main.json` file
+
+```
+const { t } = useTranslation()
+```
+
+Usage ex:
+
+```
+t('header.title')
+```
+
+### Code formatting and linting
+
+Before committing your changes,
+
+s1. Remove all the disabled linter rules from `.eslintrc.json` and run `yarn lint` on your newly created file or folder to see the results 2. Disable linter rules is allowd only for the exceptional cases. Code comments with proper reason is mandatory
+
+### Handling of API responses and error states
+
+1. All the api call has to be addressed with a throbber in the UI
+2. Empty response to be shown with a proper message to the user
+3. API error has to be shown in a component with appropriate action\
+   a. Error code 4xx needs to show error component with message\
+   b. Error code 5xx should allow user to refetch the api once again.
+
+### State Managment
+
+URL path names to be in Camel Case
+
 ## Known Issues and Limitations
 
 See [Known Knowns](/CHANGELOG.md#known-knowns).

--- a/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
@@ -29,6 +29,7 @@ import {
   StaticTable,
   type TableType,
   Typography,
+  CircleProgress,
 } from '@catena-x/portal-shared-components'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { useTranslation, Trans } from 'react-i18next'
@@ -171,8 +172,23 @@ const ActivateSubscriptionOverlay = ({
               onCloseWithIcon={() => dispatch(closeOverlay())}
             />
             <DialogContent>
-              <StaticTable data={tableData1} horizontal={false} />
-              <StaticTable data={tableData2} horizontal={false} />
+              {loading ? (
+                <div className="loading-progress">
+                  <CircleProgress
+                    size={40}
+                    step={1}
+                    interval={0.1}
+                    colorVariant={'primary'}
+                    variant={'indeterminate'}
+                    thickness={8}
+                  />
+                </div>
+              ) : (
+                <>
+                  <StaticTable data={tableData1} horizontal={false} />
+                  <StaticTable data={tableData2} horizontal={false} />
+                </>
+              )}
             </DialogContent>
             <DialogActions>
               <Button variant="outlined" onClick={closeActivationOverlay}>

--- a/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/index.tsx
@@ -32,6 +32,7 @@ import {
   EditField,
   type TableCellType,
   Tooltips,
+  CircleProgress,
 } from '@catena-x/portal-shared-components'
 import {
   ProcessStep,
@@ -44,6 +45,7 @@ import { SubscriptionStatus } from 'features/apps/types'
 import UserService from 'services/UserService'
 import { ROLES } from 'types/Constants'
 import { useState } from 'react'
+import './style.scss'
 import { SuccessErrorType } from 'features/admin/appuserApiSlice'
 import { isURL } from 'types/Patterns'
 import { SubscriptionTypes } from 'components/shared/templates/Subscription'
@@ -78,7 +80,7 @@ const AppSubscriptionDetailOverlay = ({
   const fetchAPI = isAppSubscription
     ? useFetchSubscriptionDetailQuery
     : useFetchServiceSubDetailQuery
-  const { data, refetch } = fetchAPI({
+  const { data, refetch, isFetching } = fetchAPI({
     appId,
     subscriptionId,
   })
@@ -348,12 +350,29 @@ const AppSubscriptionDetailOverlay = ({
             numberOfSteps={3}
             activePage={getActiveSteps()}
           />
-          <div style={{ marginTop: '30px' }}>
-            <StaticTable data={subscriptionDetails} />
-          </div>
-          <div style={{ marginTop: '20px' }}>
-            <VerticalTableNew data={technicalDetails} />
-          </div>
+          {isFetching ? (
+            <div className="app-subscription-overlay">
+              <div className="loading-progress">
+                <CircleProgress
+                  size={40}
+                  step={1}
+                  interval={0.1}
+                  colorVariant={'primary'}
+                  variant={'indeterminate'}
+                  thickness={8}
+                />
+              </div>
+            </div>
+          ) : (
+            <div>
+              <div style={{ marginTop: '30px' }}>
+                <StaticTable data={subscriptionDetails} />
+              </div>
+              <div style={{ marginTop: '20px' }}>
+                <VerticalTableNew data={technicalDetails} />
+              </div>
+            </div>
+          )}
           <div style={{ marginTop: '20px' }}>
             <Typography
               variant="caption2"

--- a/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/style.scss
+++ b/src/components/pages/AppSubscription/AppSubscriptionDetailOverlay/style.scss
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+.app-subscription-overlay {
+  .loading-progress {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+  }
+}


### PR DESCRIPTION
## Description

implement loading state for provider subscription detail overlay

## Why

When accessing the provider subscription detail view and initiating the detail overlay, the UI currently pre-fills data fields with "n/a" before the backend has completed fetching the data. So, loader is needed


## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/922

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally