### PR TITLE
feat(technical user management): enhance table with status column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - implement loading state for provider subscription detail overlay
 - Technical User Management
   - Enhance technical user table by adding StatusTag to the status column
+  - Enhance technical user table status column by adding new status 'pending deletion'
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Use scroll to top button from shared components
 - Subscription Overlay
   - implement loading state for provider subscription detail overlay
+- Technical User Management
+  - Enhance technical user table by adding StatusTag to the status column
 
 ### Bugfixes
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -601,7 +601,7 @@ npm/npmjs/@babel/template/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/traverse/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
 npm/npmjs/@babel/types/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/3.0.28, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #14247
+npm/npmjs/@catena-x/portal-shared-components/3.0.29, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #14247
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
 npm/npmjs/@date-io/core/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/@date-io/date-fns/3.0.0, MIT, approved, #14023

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^3.0.28",
+    "@catena-x/portal-shared-components": "^3.0.29",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@hookform/error-message": "^2.0.1",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -927,7 +927,8 @@
           "ACTIVE": "AKTIV",
           "INACTIVE": "INAKTIV",
           "PENDING": "AUSSTEHEND",
-          "DELETED": "GELÖSCHT"
+          "DELETED": "GELÖSCHT",
+          "PENDING_DELETION": "PENDING_DELETION"
         },
         "confirmDeleteUser": "Sind Sie sicher, dass Sie user '{{ user }}' löschen möchten?",
         "noteDeleteUser": "Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -923,6 +923,12 @@
           "spoc": "SPOC",
           "permission": "Berechtigungen"
         },
+        "status": {
+          "ACTIVE": "AKTIV",
+          "INACTIVE": "INAKTIV",
+          "PENDING": "AUSSTEHEND",
+          "DELETED": "GELÖSCHT"
+        },
         "confirmDeleteUser": "Sind Sie sicher, dass Sie user '{{ user }}' löschen möchten?",
         "noteDeleteUser": "Diese Aktion kann nicht rückgängig gemacht werden.",
         "confirmDeleteNotificationTitle": "Das Löschen des Benutzers war erfolgreich.",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -931,7 +931,8 @@
           "ACTIVE": "ACTIVE",
           "INACTIVE": "INACTIVE",
           "PENDING": "PENDING",
-          "DELETED": "DELETED"
+          "DELETED": "DELETED",
+          "PENDING_DELETION": "PENDING_DELETION"
         },
         "confirmDeleteUser": "Are you sure you want to delete technical user {{ user }}?",
         "noteDeleteUser": "Note: The deletion will be permanently. It is not possible the reactive the user again.",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -927,6 +927,12 @@
           "spoc": "SPOC",
           "permission": "Permission"
         },
+        "status": {
+          "ACTIVE": "ACTIVE",
+          "INACTIVE": "INACTIVE",
+          "PENDING": "PENDING",
+          "DELETED": "DELETED"
+        },
         "confirmDeleteUser": "Are you sure you want to delete technical user {{ user }}?",
         "noteDeleteUser": "Note: The deletion will be permanently. It is not possible the reactive the user again.",
         "confirmDeleteNotificationTitle": "User deletion was successful.",

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -43,10 +43,10 @@ interface FetchHookArgsType {
 }
 
 enum ServiceAccountStatus {
-  ACTIVE = 'Active',
-  INACTIVE = 'Inactive',
-  PENDING = 'Pending',
-  DELETED = 'Deleted',
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  PENDING = 'PENDING',
+  DELETED = 'DELETED',
 }
 
 export const TechnicalUserTable = () => {
@@ -98,10 +98,17 @@ export const TechnicalUserTable = () => {
   ]
 
   const renderStatusColor = (status: string) => {
-    if (status === ServiceAccountStatus.ACTIVE) return 'confirmed'
-    else if (status === ServiceAccountStatus.INACTIVE) return 'declined'
-    else if (status === ServiceAccountStatus.PENDING) return 'pending'
-    else return 'label'
+    if (status.toLowerCase() === ServiceAccountStatus.ACTIVE.toLowerCase())
+      return 'confirmed'
+    else if (
+      status.toLowerCase() === ServiceAccountStatus.INACTIVE.toLowerCase()
+    )
+      return 'declined'
+    else if (
+      status.toLowerCase() === ServiceAccountStatus.PENDING.toLowerCase()
+    )
+      return 'pending'
+    else return 'deleted'
   }
 
   return (
@@ -164,7 +171,9 @@ export const TechnicalUserTable = () => {
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <StatusTag
                 color={renderStatusColor(row.status)}
-                label={row.status}
+                label={t(
+                  `content.usermanagement.technicalUser.status.${row.status}`
+                )}
               />
             ),
           },

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -21,6 +21,7 @@
 import {
   IconButton,
   PageLoadingTable,
+  StatusTag,
 } from '@catena-x/portal-shared-components'
 import { useTranslation } from 'react-i18next'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
@@ -39,6 +40,13 @@ import Patterns from 'types/Patterns'
 interface FetchHookArgsType {
   statusFilter: string
   expr: string
+}
+
+enum ServiceAccountStatus {
+  ACTIVE = 'Active',
+  INACTIVE = 'Inactive',
+  PENDING = 'Pending',
+  DELETED = 'Deleted',
 }
 
 export const TechnicalUserTable = () => {
@@ -89,6 +97,13 @@ export const TechnicalUserTable = () => {
     },
   ]
 
+  const renderStatusColor = (status: string) => {
+    if (status === ServiceAccountStatus.ACTIVE) return 'confirmed'
+    else if (status === ServiceAccountStatus.INACTIVE) return 'declined'
+    else if (status === ServiceAccountStatus.PENDING) return 'pending'
+    else return 'label'
+  }
+
   return (
     <div style={{ paddingTop: '30px' }}>
       <PageLoadingTable<ServiceAccountListEntry, FetchHookArgsType>
@@ -126,7 +141,7 @@ export const TechnicalUserTable = () => {
           {
             field: 'serviceAccountType',
             headerName: t('global.field.type'),
-            flex: 1,
+            flex: 1.2,
           },
           {
             field: 'offer',
@@ -138,9 +153,20 @@ export const TechnicalUserTable = () => {
           {
             field: 'isOwner',
             headerName: t('global.field.owner'),
-            flex: 1,
+            flex: 0.8,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.isOwner ? 'Yes' : 'No',
+          },
+          {
+            field: 'status',
+            headerName: t('global.field.status'),
+            flex: 1.2,
+            renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
+              <StatusTag
+                color={renderStatusColor(row.status)}
+                label={row.status}
+              />
+            ),
           },
           {
             field: 'details',

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from 'react-i18next'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import {
   type ServiceAccountListEntry,
+  ServiceAccountStatus,
   ServiceAccountStatusFilter,
   useFetchServiceAccountListQuery,
 } from 'features/admin/serviceApiSlice'
@@ -41,14 +42,13 @@ interface FetchHookArgsType {
   statusFilter: string
   expr: string
 }
-
-enum ServiceAccountStatus {
-  ACTIVE = 'ACTIVE',
-  INACTIVE = 'INACTIVE',
-  PENDING = 'PENDING',
-  DELETED = 'DELETED',
-  PENDING_DELETION = 'PENDING_DELETION',
-}
+type StatusTagColor =
+  | 'pending'
+  | 'confirmed'
+  | 'declined'
+  | 'label'
+  | 'deleted'
+  | undefined
 
 export const TechnicalUserTable = () => {
   const { t } = useTranslation()
@@ -98,18 +98,12 @@ export const TechnicalUserTable = () => {
     },
   ]
 
-  const renderStatusColor = (status: string) => {
-    if (status.toLowerCase() === ServiceAccountStatus.ACTIVE.toLowerCase())
-      return 'confirmed'
-    else if (
-      status.toLowerCase() === ServiceAccountStatus.INACTIVE.toLowerCase()
-    )
-      return 'declined'
-    else if (
-      status.toLowerCase() === ServiceAccountStatus.DELETED.toLowerCase()
-    )
-      return 'deleted'
-    else return 'pending'
+  const statusColorMap: Record<ServiceAccountStatus, StatusTagColor> = {
+    [ServiceAccountStatus.ACTIVE]: 'confirmed',
+    [ServiceAccountStatus.INACTIVE]: 'declined',
+    [ServiceAccountStatus.DELETED]: 'deleted',
+    [ServiceAccountStatus.PENDING]: 'pending',
+    [ServiceAccountStatus.PENDING_DELETION]: 'pending',
   }
 
   return (
@@ -171,7 +165,7 @@ export const TechnicalUserTable = () => {
             flex: 1.2,
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <StatusTag
-                color={renderStatusColor(row.status)}
+                color={statusColorMap[row.status]}
                 label={t(
                   `content.usermanagement.technicalUser.status.${row.status}`
                 )}

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -47,6 +47,7 @@ enum ServiceAccountStatus {
   INACTIVE = 'INACTIVE',
   PENDING = 'PENDING',
   DELETED = 'DELETED',
+  PENDING_DELETION = 'PENDING_DELETION',
 }
 
 export const TechnicalUserTable = () => {
@@ -105,10 +106,10 @@ export const TechnicalUserTable = () => {
     )
       return 'declined'
     else if (
-      status.toLowerCase() === ServiceAccountStatus.PENDING.toLowerCase()
+      status.toLowerCase() === ServiceAccountStatus.DELETED.toLowerCase()
     )
-      return 'pending'
-    else return 'deleted'
+      return 'deleted'
+    else return 'pending'
   }
 
   return (

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -52,6 +52,7 @@ export interface ServiceAccountListEntry {
   serviceAccountId: string
   clientId: string
   name: string
+  status: string
   isOwner?: boolean
   offer?: {
     name?: string

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -48,11 +48,19 @@ export interface ServiceAccountCreate {
   roleIds: string[]
 }
 
+export enum ServiceAccountStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  PENDING = 'PENDING',
+  DELETED = 'DELETED',
+  PENDING_DELETION = 'PENDING_DELETION',
+}
+
 export interface ServiceAccountListEntry {
   serviceAccountId: string
   clientId: string
   name: string
-  status: string
+  status: ServiceAccountStatus
   isOwner?: boolean
   offer?: {
     name?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^3.0.28":
-  version "3.0.28"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-3.0.28.tgz#efb60e91e34bf9221e565f19b258db913f5712be"
-  integrity sha512-XLHgksVGtg16Vm567NhpM9QZBCBLS9QOTEjr9zqwjI3Rq+7/0iH/7SLtpoHBAeEfKSgBaBX5yktKXdyX59D01A==
+"@catena-x/portal-shared-components@^3.0.29":
+  version "3.0.29"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-3.0.29.tgz#85f83ce4a3d7b8d19c9719af9cd138a93070269a"
+  integrity sha512-VFzU+Krmt6doZWPLMn91FvqTXbF/bACKkdm7e+cAyGkiarTs4hL1iv4wjtgwSp/Uq0qZUKBL46N6Ouxyw5p3iQ==
   dependencies:
     "@date-io/date-fns" "^3.0.0"
     "@emotion/react" "^11.11.4"


### PR DESCRIPTION
## Description

Enhance technical user table by adding StatusTag to the status column by fetching the status from the backend 
Enhance technical user table status column by adding new status 'pending deletion'

## Why

To enhance technical user table by adding StatusTag to the status column 
Technical user table status column is updated with new status 'pending deletion'
## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/944, https://github.com/eclipse-tractusx/portal-frontend/issues/988

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
