### PR TITLE
fix(codeQL-finding): remove unnecessary condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Fixed incorrect usage of pre-commit hook
 - Fix consistency issue in constants file. Use camel case for all page paths. Update corresponding usage in other files
+- Remove unnecessary condition in semantic hub page's table
 
 ## 2.1.0
 

--- a/src/components/pages/SemanticHub/ModelTable.tsx
+++ b/src/components/pages/SemanticHub/ModelTable.tsx
@@ -157,7 +157,7 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
   if (error) {
     errorObj.status = Number(error)
     errorObj.message =
-      error && Number(error) >= 400 && Number(error) < 500
+      Number(error) >= 400 && Number(error) < 500
         ? t('global.errors.dataLoadFailed')
         : t('global.errors.loadFailed')
   }


### PR DESCRIPTION
## Description

Remove unnecessary condition in semantic hub page's table

## Why

Conditionals don't make sense where their value can have only one value

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/975

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally