### PR TITLE
fix: change text of button when user requests subscription

### DIFF
--- a/src/components/overlays/AppMarketplaceRequest/index.tsx
+++ b/src/components/overlays/AppMarketplaceRequest/index.tsx
@@ -39,6 +39,7 @@ import './AppMarketplaceRequest.scss'
 import { error } from 'services/NotifyService'
 import { AgreementStatus } from '../UpdateCompanyRole'
 import { type AgreementRequest } from 'features/apps/types'
+import { confirmDialog } from 'features/overlay/slice'
 
 export default function AppMarketplaceRequest({ id }: { id: string }) {
   const { t } = useTranslation()
@@ -86,6 +87,7 @@ export default function AppMarketplaceRequest({ id }: { id: string }) {
         .then(() => {
           setSuccessOverlay(true)
           setSubscriptionOverlay(false)
+          dispatch(confirmDialog())
         })
         .catch((err) => {
           error(t('content.appMarketplace.errorMessage'), '', err as object)

--- a/src/components/pages/AppDetail/components/AppDetailHeader/index.tsx
+++ b/src/components/pages/AppDetail/components/AppDetailHeader/index.tsx
@@ -36,6 +36,7 @@ import { SubscriptionStatus } from 'features/apps/types'
 import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 import CommonService from 'services/CommonService'
 import type { UseCaseType } from 'features/appManagement/types'
+import type { RootState } from 'features/store'
 
 enum Roles {
   SUBSCRIBE_APPS = 'subscribe_apps',
@@ -56,20 +57,37 @@ export interface ButtonColorType {
 export default function AppDetailHeader({ item }: AppDetailHeaderProps) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const isDialogConfirmed = useSelector(
+    (state: RootState) => state?.dialog?.isConfirmed
+  )
+
   const { appId } = useParams()
   const user = useSelector(userSelector)
   const [image, setImage] = useState('')
   const [fetchDocumentById] = useFetchDocumentByIdMutation()
+  const [buttonLabel, setButtonLabel] = useState(
+    t('content.appdetail.subscribe')
+  )
 
   const getStatusLabel = (subscribeStatus: string) => {
     if (subscribeStatus === SubscriptionStatus.PENDING) {
-      return t('content.appdetail.requested')
+      setButtonLabel(t('content.appdetail.requested'))
     } else if (subscribeStatus === SubscriptionStatus.ACTIVE) {
-      return t('content.appdetail.subscribed')
+      setButtonLabel(t('content.appdetail.subscribed'))
     } else {
-      return t('content.appdetail.subscribe')
+      setButtonLabel(t('content.appdetail.subscribe'))
     }
   }
+
+  useEffect(() => {
+    if (isDialogConfirmed) {
+      setButtonLabel(t('content.appdetail.requested'))
+    }
+  }, [isDialogConfirmed])
+
+  useEffect(() => {
+    getStatusLabel(item.isSubscribed ?? SubscriptionStatus.INACTIVE)
+  }, [])
 
   const getBtnColor = (subscribeStatus: string) => {
     let btnColor: ButtonColorType
@@ -131,7 +149,7 @@ export default function AppDetailHeader({ item }: AppDetailHeaderProps) {
 
     return (
       <OrderStatusButton
-        label={getStatusLabel(subscribeStatus)}
+        label={buttonLabel}
         color={btnColor.color}
         buttonData={OrderStatusButtonItems}
         selectable={

--- a/src/components/pages/AppMarketplace/components/AppListSection/index.tsx
+++ b/src/components/pages/AppMarketplace/components/AppListSection/index.tsx
@@ -26,7 +26,7 @@ import {
 import { useTheme } from '@mui/material'
 import { AppListGroupView } from '../AppListGroupView'
 import { useDispatch, useSelector } from 'react-redux'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { addItem, removeItem } from 'features/apps/favorites/actions'
 import {
   useFetchActiveAppsQuery,
@@ -45,6 +45,8 @@ export const label = 'AppList'
 export default function AppListSection() {
   const { t } = useTranslation()
   const theme = useTheme()
+  const { id } = useParams()
+  const location = useLocation()
 
   const dispatch = useDispatch<AppDispatch>()
   const navigate = useNavigate()
@@ -82,6 +84,10 @@ export default function AppListSection() {
     setList(d)
     setFavlist(favs)
   }
+
+  useEffect(() => {
+    refetch()
+  }, [id, location.key])
 
   useEffect(() => {
     if (data && favoriteItems) {

--- a/src/features/overlay/slice.ts
+++ b/src/features/overlay/slice.ts
@@ -37,7 +37,6 @@ const dialog = createSlice({
       state.isOpen = true
     },
     closeDialog: (state) => {
-      console.log(state, 'close dialog')
       state.isOpen = false
     },
     confirmDialog: (state) => {

--- a/src/features/overlay/slice.ts
+++ b/src/features/overlay/slice.ts
@@ -1,5 +1,4 @@
 /********************************************************************************
- * Copyright (c) 2024 BMW Group AG
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/src/features/overlay/slice.ts
+++ b/src/features/overlay/slice.ts
@@ -1,6 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2023 BMW Group AG
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 BMW Group AG
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/features/overlay/slice.ts
+++ b/src/features/overlay/slice.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+import { createSlice } from '@reduxjs/toolkit'
+
+interface DialogState {
+  isOpen: boolean
+  isConfirmed: boolean
+}
+
+const initialState: DialogState = {
+  isOpen: false,
+  isConfirmed: false,
+}
+
+const dialog = createSlice({
+  name: 'dialog',
+  initialState,
+  reducers: {
+    openDialog: (state) => {
+      state.isOpen = true
+    },
+    closeDialog: (state) => {
+      console.log(state, 'close dialog')
+      state.isOpen = false
+    },
+    confirmDialog: (state) => {
+      state.isConfirmed = true
+    },
+    resetDialog: (state) => {
+      state.isConfirmed = false
+    },
+  },
+})
+
+export const { openDialog, closeDialog, confirmDialog, resetDialog } =
+  dialog.actions
+export default dialog

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -30,6 +30,7 @@ import connectorSlice from './connector/slice'
 import notificationSliceDep from './notification/slice'
 import ErrorSlice from './error/slice'
 import images from './images/slice'
+import dialog from './overlay/slice'
 import managementSlice from './appManagement/slice'
 import serviceManagementSlice from './serviceManagement/slice'
 import serviceMarketplaceSlice from './serviceMarketplace/slice'
@@ -81,6 +82,7 @@ export const reducers = {
   control,
   info,
   images,
+  dialog: dialog.reducer,
   companyData: companyDataSlice.reducer,
   management: managementSlice.reducer,
   serviceManagement: serviceManagementSlice.reducer,


### PR DESCRIPTION
## Description
- I've to update the global store as we don't have any common state for the app details page and subscription dialog.
Added a slice which tell us if dialog is open/closed or is confirm button clicked.
- Globally, we can use this state to perform any action based on the dialog ex. if dialog is open/closed, or user confirms the action, we can perform any dependant action based on this.
- 
![image](https://github.com/user-attachments/assets/919cbcbc-d783-471c-8c7e-a0324748e85c)


## Why
- App Marketplace : After requesting an app subscription, users need to perform a hard refresh of the page to view the updated status

## Issue
- https://github.com/eclipse-tractusx/portal-frontend/issues/984

## Checklist

Please delete options that are not relevant.
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
