### PR TITLE
fix: block user from removing own admin roles

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2178,7 +2178,7 @@
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
       "changeRoleBtn": "Change Portal Role",
-      "errorMsg": "Sie sind nicht berechtigt, Ihre eigenen Administrator-Rollen zu ändern. Bitte wenden Sie sich an einen anderen Unternehmens- oder IT-Administrator."
+      "errorMsg": "Sie sind nicht berechtigt, Ihre eigenen Administrator-Rollen zu ändern. Bitte wenden Sie sich an einen anderen Administrator."
     }
   },
   "global": {

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2177,7 +2177,8 @@
     },
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
-      "changeRoleBtn": "Change Portal Role"
+      "changeRoleBtn": "Change Portal Role",
+      "errorMsg": "Sie sind nicht berechtigt, Ihre eigenen Rollen zu ändern. Bitte wenden Sie sich an einen anderen Unternehmens- oder IT-Administrator."
     }
   },
   "global": {

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2178,7 +2178,7 @@
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
       "changeRoleBtn": "Change Portal Role",
-      "errorMsg": "Sie sind nicht berechtigt, Ihre eigenen Rollen zu ändern. Bitte wenden Sie sich an einen anderen Unternehmens- oder IT-Administrator."
+      "errorMsg": "Sie sind nicht berechtigt, Ihre eigenen Administrator-Rollen zu ändern. Bitte wenden Sie sich an einen anderen Unternehmens- oder IT-Administrator."
     }
   },
   "global": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2150,7 +2150,7 @@
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
       "changeRoleBtn": "Change Portal Role",
-      "errorMsg": "You are not authorized to change your own admin roles. Please contact another Company Admin or IT Admin"
+      "errorMsg": "You are not authorized to change your own admin roles. Please contact another Company Admin or IT Admin."
     }
   },
   "global": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2150,7 +2150,7 @@
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
       "changeRoleBtn": "Change Portal Role",
-      "errorMsg": "You are not authorized to change your own roles. Please contact another Company Admin or IT Admin"
+      "errorMsg": "You are not authorized to change your own admin roles. Please contact another Company Admin or IT Admin"
     }
   },
   "global": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2149,7 +2149,8 @@
     },
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
-      "changeRoleBtn": "Change Portal Role"
+      "changeRoleBtn": "Change Portal Role",
+      "errorMsg": "You are not authorized to change your own roles. Please contact another Company Admin or IT Admin"
     }
   },
   "global": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2150,7 +2150,7 @@
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",
       "changeRoleBtn": "Change Portal Role",
-      "errorMsg": "You are not authorized to change your own admin roles. Please contact another Company Admin or IT Admin."
+      "errorMsg": "You are not authorized to change your own admin roles. Please contact another admin."
     }
   },
   "global": {

--- a/src/components/overlays/EditPortalRoles/index.tsx
+++ b/src/components/overlays/EditPortalRoles/index.tsx
@@ -41,6 +41,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { OVERLAYS } from 'types/Constants'
 import './style.scss'
+import UserService from 'services/UserService'
 
 export default function EditPortalRoles({ id }: { id: string }) {
   const { t } = useTranslation()
@@ -113,17 +114,12 @@ export default function EditPortalRoles({ id }: { id: string }) {
       assignedRoles.length === selectedRoles.length &&
       assignedRoles.every((value) => selectedRoles.includes(value)))
 
-  const disabledCheckbox = (currentRole: string) => {
-    const adminRoles = selectedRoles.filter((item) => item.includes('Admin'))
-    const assignedAdminRoles = assignedRoles.filter((item) =>
-      item.includes('Admin')
-    )
+  const disabledCheckbox = (currentRole: AppRole) => {
+    const allAdminRoles = allRoles.filter((item) => item.role.includes('Admin'))
 
-    return (
-      assignedAdminRoles.length >= 1 &&
-      adminRoles.length < 3 &&
-      adminRoles.indexOf(currentRole) !== -1
-    )
+    return UserService.getUsername() === id
+      ? allAdminRoles.indexOf(currentRole) !== -1
+      : false
   }
 
   return (
@@ -146,7 +142,7 @@ export default function EditPortalRoles({ id }: { id: string }) {
               allRoles.map((role) => (
                 <li key={role.roleId}>
                   <Checkbox
-                    disabled={disabledCheckbox(role.role)}
+                    disabled={disabledCheckbox(role)}
                     label={role.role}
                     checked={selectedRoles.indexOf(role.role) !== -1}
                     onChange={(e) => {
@@ -157,9 +153,11 @@ export default function EditPortalRoles({ id }: { id: string }) {
               ))}
           </ul>
         </div>
-        <Typography variant="body3" sx={{ mt: 3 }}>
-          {t('shared.userRoles.errorMsg')}
-        </Typography>
+        {UserService.getUsername() === id && (
+          <Typography variant="body3" sx={{ mt: 3 }}>
+            {t('shared.userRoles.errorMsg')}
+          </Typography>
+        )}
       </DialogContent>
 
       <DialogActions>

--- a/src/components/overlays/EditPortalRoles/index.tsx
+++ b/src/components/overlays/EditPortalRoles/index.tsx
@@ -60,6 +60,7 @@ export default function EditPortalRoles({ id }: { id: string }) {
   const [allRoles, setAllRoles] = useState<AppRole[]>([])
   const [selectedRoles, setSelectedRoles] = useState<string[]>([])
   const [offerId, setOfferId] = useState<string>('')
+  const [allAdminRoles, setAllAdminRoles] = useState<AppRole[]>([])
 
   const [updatePortalRoles] = useUpdatePortalRolesMutation()
 
@@ -69,6 +70,13 @@ export default function EditPortalRoles({ id }: { id: string }) {
       setOfferId(appRoles[0].offerId)
     }
   }, [appRoles])
+
+  useEffect(() => {
+    if (allRoles) {
+      const adminRoles = allRoles.filter((item) => item.role.includes('Admin'))
+      setAllAdminRoles(adminRoles)
+    }
+  }, [allRoles])
 
   useEffect(() => {
     setSelectedRoles(assignedRoles ?? [])
@@ -114,13 +122,10 @@ export default function EditPortalRoles({ id }: { id: string }) {
       assignedRoles.length === selectedRoles.length &&
       assignedRoles.every((value) => selectedRoles.includes(value)))
 
-  const disabledCheckbox = (currentRole: AppRole) => {
-    const allAdminRoles = allRoles.filter((item) => item.role.includes('Admin'))
-
-    return UserService.getUsername() === id
-      ? allAdminRoles.indexOf(currentRole) !== -1
+  const disabledCheckbox = (currentRole: AppRole) =>
+    UserService.getUsername() === id
+      ? allAdminRoles.includes(currentRole)
       : false
-  }
 
   return (
     <>

--- a/src/components/overlays/EditPortalRoles/index.tsx
+++ b/src/components/overlays/EditPortalRoles/index.tsx
@@ -24,6 +24,7 @@ import {
   DialogActions,
   DialogContent,
   DialogHeader,
+  Typography,
 } from '@catena-x/portal-shared-components'
 import {
   type AppRole,
@@ -112,6 +113,19 @@ export default function EditPortalRoles({ id }: { id: string }) {
       assignedRoles.length === selectedRoles.length &&
       assignedRoles.every((value) => selectedRoles.includes(value)))
 
+  const disabledCheckbox = (currentRole: string) => {
+    const adminRoles = selectedRoles.filter((item) => item.includes('Admin'))
+    const assignedAdminRoles = assignedRoles.filter((item) =>
+      item.includes('Admin')
+    )
+
+    return (
+      assignedAdminRoles.length >= 1 &&
+      adminRoles.length < 3 &&
+      adminRoles.indexOf(currentRole) !== -1
+    )
+  }
+
   return (
     <>
       <div className="roles-heading">
@@ -132,6 +146,7 @@ export default function EditPortalRoles({ id }: { id: string }) {
               allRoles.map((role) => (
                 <li key={role.roleId}>
                   <Checkbox
+                    disabled={disabledCheckbox(role.role)}
                     label={role.role}
                     checked={selectedRoles.indexOf(role.role) !== -1}
                     onChange={(e) => {
@@ -142,6 +157,9 @@ export default function EditPortalRoles({ id }: { id: string }) {
               ))}
           </ul>
         </div>
+        <Typography variant="body3" sx={{ mt: 3 }}>
+          {t('shared.userRoles.errorMsg')}
+        </Typography>
       </DialogContent>
 
       <DialogActions>

--- a/src/components/shared/basic/UserRoles/index.tsx
+++ b/src/components/shared/basic/UserRoles/index.tsx
@@ -40,7 +40,6 @@ import {
   currentUserRoleResp,
   SuccessErrorType,
 } from 'features/admin/appuserApiSlice'
-import type { RootState } from 'features/store'
 
 export const UserRoles = ({
   user,
@@ -59,8 +58,6 @@ export const UserRoles = ({
     )[0]?.roles ?? []
 
   const portalRoleResponse = useSelector(currentUserRoleResp)
-  const loggedInUser = useSelector((state: RootState) => state.user.email)
-  const isButtonDisabled = loggedInUser === data?.email
 
   return (
     <>
@@ -75,19 +72,12 @@ export const UserRoles = ({
                 color="secondary"
                 size="small"
                 onClick={() =>
-                  !isButtonDisabled &&
                   dispatch(show(OVERLAYS.EDIT_PORTAL_ROLES, user.companyUserId))
                 }
-                disabled={isButtonDisabled}
               >
                 <EditIcon className="edit-icon" />
                 {t('shared.userRoles.changeRoleBtn')}
               </Button>
-              {isButtonDisabled && (
-                <Typography variant="body2" sx={{ mt: 3 }}>
-                  {t('shared.userRoles.errorMsg')}
-                </Typography>
-              )}
             </div>
           )}
 

--- a/src/components/shared/basic/UserRoles/index.tsx
+++ b/src/components/shared/basic/UserRoles/index.tsx
@@ -40,6 +40,7 @@ import {
   currentUserRoleResp,
   SuccessErrorType,
 } from 'features/admin/appuserApiSlice'
+import type { RootState } from 'features/store'
 
 export const UserRoles = ({
   user,
@@ -58,6 +59,8 @@ export const UserRoles = ({
     )[0]?.roles ?? []
 
   const portalRoleResponse = useSelector(currentUserRoleResp)
+  const loggedInUser = useSelector((state: RootState) => state.user.email)
+  const isButtonDisabled = loggedInUser === data?.email
 
   return (
     <>
@@ -72,12 +75,19 @@ export const UserRoles = ({
                 color="secondary"
                 size="small"
                 onClick={() =>
+                  !isButtonDisabled &&
                   dispatch(show(OVERLAYS.EDIT_PORTAL_ROLES, user.companyUserId))
                 }
+                disabled={isButtonDisabled}
               >
                 <EditIcon className="edit-icon" />
                 {t('shared.userRoles.changeRoleBtn')}
               </Button>
+              {isButtonDisabled && (
+                <Typography variant="body2" sx={{ mt: 3 }}>
+                  {t('shared.userRoles.errorMsg')}
+                </Typography>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Description

**GOAL:**
To ensure that a company can not block itself by removing all Adminroles from their enabled users.

**Option 1:**

We check how many users in the company have the respective admin role (e.g. CX Admin) and allow the removal only if there are >2 people with this specific role.
Otherwise, the role selector will be greyed out and the tooltip will explain the situation

**Option 2:**

We grey out all admin roles from a user if he goes into his role configuration.
Only if someone else would try to remove his role this would be possible.

This would at least ensure that someone is not removing his own role on fault but would include a 4-eye principle process.

Option 1 has a dependency on BE as we don't have an API that fetches all users of the company with roles.
So I've implemented the option 2

## Why
- User should not be able to change their own roles.
- Ref : https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/user/03.%20User%20Management/01.%20User%20Account/02.%20User%20Account.md

## Issue 
- https://github.com/eclipse-tractusx/portal-frontend/issues/986

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
