### PR TITLE
fix(service detail): add missing header image implementation 

### DIFF
--- a/src/components/pages/ServiceReleaseProcess/components/ServiceDetails.tsx
+++ b/src/components/pages/ServiceReleaseProcess/components/ServiceDetails.tsx
@@ -51,7 +51,7 @@ export default function ServiceDetails() {
     refetchOnMountOrArgChange: true,
   }).data
   const [fetchDocument] = useFetchDocumentMutation()
-  const [image, setActualImage] = useState('')
+  const [image, setActualImage] = useState<string>('')
 
   const getServiceTypes = useCallback(() => {
     const newArr: string[] = []
@@ -90,14 +90,18 @@ export default function ServiceDetails() {
 
   useEffect(() => {
     async function fetchImage() {
-      const actualImage = await fetchImageWithToken(getImageUrl())
-      const firstByte = Buff2Hex(actualImage.slice(0, 1))
-      const first3Bytes = Buff2Hex(actualImage.slice(0, 3))
-      const imageType =
-        IMAGE_TYPES[firstByte] ?? IMAGE_TYPES[first3Bytes] ?? 'image/*'
-      setActualImage(
-        URL.createObjectURL(new Blob([actualImage], { type: imageType }))
-      )
+      try {
+        const actualImage = await fetchImageWithToken(getImageUrl())
+        const firstByte = Buff2Hex(actualImage.slice(0, 1))
+        const first3Bytes = Buff2Hex(actualImage.slice(0, 3))
+        const imageType =
+          IMAGE_TYPES[firstByte] ?? IMAGE_TYPES[first3Bytes] ?? 'image/*'
+        setActualImage(
+          URL.createObjectURL(new Blob([actualImage], { type: imageType }))
+        )
+      } catch (error) {
+        console.error('An error occurred while fetching the image:', error)
+      }
     }
     fetchImage()
   }, [fetchServiceStatus])

--- a/src/types/MainTypes.ts
+++ b/src/types/MainTypes.ts
@@ -151,3 +151,10 @@ export const initErrorServiceState: ErrorServiceState = {
   homePageLink: '',
   homeButtonTitle: '',
 }
+
+export const IMAGE_TYPES: Record<string, string> = {
+  '3c': 'image/svg+xml',
+  ffd8ff: 'image/jpeg',
+  '89504e': 'image/png',
+  474946: 'image/gif',
+}

--- a/src/utils/buff2hex.ts
+++ b/src/utils/buff2hex.ts
@@ -1,0 +1,4 @@
+export const Buff2Hex = (buffer: ArrayBuffer): string =>
+  [...new Uint8Array(buffer)]
+    .map((x) => x.toString(16).padStart(2, '0'))
+    .join('')

--- a/src/utils/buff2hex.ts
+++ b/src/utils/buff2hex.ts
@@ -1,4 +1,0 @@
-export const Buff2Hex = (buffer: ArrayBuffer): string =>
-  [...new Uint8Array(buffer)]
-    .map((x) => x.toString(16).padStart(2, '0'))
-    .join('')


### PR DESCRIPTION
## Description

- Added function to create image object url
- Added image type constants
- Buffer to hex conversion function

## Why

Upon opening any service detail, images set during service onboarding were not being displayed and only a static default image was being rendered for all services. due to missing/not yet present implementation. 

## Issue

#990 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
