### PR TITLE
fix: Resolve height related displaying issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed incorrect usage of pre-commit hook
 - Fix consistency issue in constants file. Use camel case for all page paths. Update corresponding usage in other files
 - Remove unnecessary condition in semantic hub page's table
+- Remove fixed height for "Admin Service Detail" page content.
 
 ## 2.1.0
 

--- a/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
+++ b/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
@@ -24,7 +24,6 @@
     padding: 48px 256px 48px 160px;
   }
   .service-content {
-    // height: 1352px;
     padding: 0px 256px 0px 256px;
     .divider-height {
       height: 39px;

--- a/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
+++ b/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
@@ -24,7 +24,7 @@
     padding: 48px 256px 48px 160px;
   }
   .service-content {
-    height: 1352px;
+    // height: 1352px;
     padding: 0px 256px 0px 256px;
     .divider-height {
       height: 39px;


### PR DESCRIPTION
## Description

- Specifically, the footer section overlaps with the service content, and the content extends beyond the footer section.
- The footer section overlaps with the service details page's service context.

## Why

- Page content has a fixed height that is creating an issue for the footer, I have removed that height, and working perfectly fine for now.

## Issue

[Link to Github issue.
](https://github.com/eclipse-tractusx/portal-frontend/issues/995)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)

- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
