### PR TITLE
fix: Resolve blank page issue after activating service subscription

### DIFF
--- a/src/components/overlays/ActivateServiceSubscription/index.tsx
+++ b/src/components/overlays/ActivateServiceSubscription/index.tsx
@@ -93,44 +93,49 @@ export default function ActivateserviceSubscription({
 
   const tableData: TableType = {
     head: [t('serviceSubscription.activation.tableheader'), ''],
-    body: [
-      [
-        t('serviceSubscription.activation.userId'),
-        techUserInfo?.technicalUserInfo.technicalClientId ?? '',
-      ],
-      [
-        t('serviceSubscription.activation.sercret'),
-        techUserInfo?.technicalUserInfo.technicalUserSecret ?? '',
-      ],
-      [
-        t('serviceSubscription.activation.url'),
-        techUserInfo?.clientInfo?.clientUrl ?? 'n/a',
-      ],
-      [
-        t('serviceSubscription.activation.technicaluserType'),
-        techUserInfo?.technicalUserInfo.technicalUserPermissions.join(', ') ??
-          '',
-      ],
-    ],
-    edit: [
-      [
-        {
-          icon: false,
-        },
-        {
-          icon: false,
-        },
-      ],
-      [
-        {
-          icon: false,
-        },
-        {
-          icon: false,
-          copyValue: techUserInfo?.technicalUserInfo.technicalUserSecret,
-        },
-      ],
-    ],
+    body:
+      techUserInfo?.technicalUserInfo
+        ?.map((userData) => [
+          [
+            t('serviceSubscription.activation.userId'),
+            userData.technicalClientId ?? '',
+          ],
+          [
+            t('serviceSubscription.activation.sercret'),
+            userData.technicalUserSecret ?? '',
+          ],
+          [
+            t('serviceSubscription.activation.url'),
+            techUserInfo?.clientInfo?.clientUrl ?? 'N/A',
+          ],
+          [
+            t('serviceSubscription.activation.technicaluserType'),
+            userData.technicalUserPermissions.join(', ') ?? '',
+          ],
+        ])
+        .flat(1) ?? [],
+    edit:
+      techUserInfo?.technicalUserInfo
+        ?.map((userData) => [
+          [
+            {
+              icon: false,
+            },
+            {
+              icon: false,
+            },
+          ],
+          [
+            {
+              icon: false,
+            },
+            {
+              icon: false,
+              copyValue: userData.technicalUserSecret,
+            },
+          ],
+        ])
+        .flat(1) ?? [],
   }
 
   return (
@@ -177,7 +182,10 @@ export default function ActivateserviceSubscription({
                 </Typography>
               </Trans>
             </Box>
-            <StaticTable data={tableData} horizontal={false} />
+            {techUserInfo?.technicalUserInfo &&
+            techUserInfo?.technicalUserInfo?.length > 0 ? (
+              <StaticTable data={tableData} horizontal={false} />
+            ) : null}
           </DialogContent>
           <DialogActions>
             <Button

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -178,7 +178,7 @@ export type ActivateSubscriptionRequest = {
 }
 
 export type ActivateSubscriptionResponse = {
-  technicalUserInfo: TechnicalUserInfoType
+  technicalUserInfo: Array<TechnicalUserInfoType>
   clientInfo: ClientInfoType
 }
 


### PR DESCRIPTION

## Description

- In the Service Subscriptions section, after activating a service, the user is redirected to a blank page.

## why 

- When we hit the Confirm button, we get multiple Technical Users in technicalUserInfo. Ideally, The frontend has to display various Technical Users. But, according to the current Implementation, we are expecting an object that is WRONG.
- Currently, We are showing multiple Technical Users in "Provider View" in the same way I show multiple Technical Users in the Confirmation Screen.

## Issue

[Link to Github issue.
](https://github.com/eclipse-tractusx/portal-frontend/issues/1004)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
