### PR TITLE
fix: add load more button app overview

### DIFF
--- a/src/components/pages/AppOverview/AppOverview.scss
+++ b/src/components/pages/AppOverview/AppOverview.scss
@@ -180,3 +180,7 @@
   margin-top: 3px !important;
   font-size: 0.75rem !important;
 }
+
+.load-more-btn {
+  text-align: center;
+}

--- a/src/components/pages/AppOverview/index.tsx
+++ b/src/components/pages/AppOverview/index.tsx
@@ -88,7 +88,6 @@ export default function AppOverview() {
 
   const { data, isFetching, isSuccess, refetch } =
     useFetchProvidedAppsQuery(argsData)
-
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
   const valueMap: any = {

--- a/src/components/pages/AppOverview/index.tsx
+++ b/src/components/pages/AppOverview/index.tsx
@@ -334,11 +334,7 @@ export default function AppOverview() {
                 ))}
             </>
           )}
-          <div
-            style={{
-              textAlign: 'center',
-            }}
-          >
+          <div className="load-more-btn">
             {data?.meta && data?.meta?.totalPages > page + 1 && (
               <LoadMoreButton onClick={nextPage} label={t('loadmore')} />
             )}

--- a/src/components/pages/AppOverview/index.tsx
+++ b/src/components/pages/AppOverview/index.tsx
@@ -30,6 +30,7 @@ import {
   PageSnackbar,
   ErrorBar,
   CircleProgress,
+  LoadMoreButton,
 } from '@catena-x/portal-shared-components'
 import { useTheme, Box } from '@mui/material'
 import {
@@ -38,7 +39,11 @@ import {
   appToCard,
 } from 'features/apps/mapper'
 import { useFetchProvidedAppsQuery } from 'features/apps/apiSlice'
-import { type AppInfo, type AppMarketplaceApp } from 'features/apps/types'
+import {
+  type ProvidedApps,
+  type AppInfo,
+  type AppMarketplaceApp,
+} from 'features/apps/types'
 import { useDispatch } from 'react-redux'
 import debounce from 'lodash.debounce'
 import { OVERLAYS } from 'types/Constants'
@@ -58,7 +63,6 @@ export default function AppOverview() {
   const theme = useTheme()
   const dispatch = useDispatch()
 
-  const { data, refetch, isSuccess, isFetching } = useFetchProvidedAppsQuery()
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
   const [itemCards, setItemCards] = useState<any>([])
@@ -72,6 +76,18 @@ export default function AppOverview() {
   const [group, setGroup] = useState<string>('')
   const [filterItem, setFilterItem] = useState<CardItems[]>()
   const [searchExpr, setSearchExpr] = useState<string>('')
+
+  const [page, setPage] = useState<number>(0)
+  const [argsData, setArgsData] = useState({
+    page,
+    args: {
+      expr: '',
+      statusFilter: '',
+    },
+  })
+
+  const { data, isFetching, isSuccess, refetch } =
+    useFetchProvidedAppsQuery(argsData)
 
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
@@ -107,13 +123,17 @@ export default function AppOverview() {
   }, [itemCards])
 
   useEffect(() => {
-    if (data) {
-      const filterItems = data.content?.map((item: AppMarketplaceApp) =>
-        appToCard(item)
+    dispatch(setCurrentActiveStep())
+    if (data?.content)
+      setCards(
+        data?.meta.page === 0
+          ? setDataInfo(data)
+          : (i: CardItems[]) => i.concat(setDataInfo(data))
       )
-      setCards(filterItems)
-    }
-  }, [data])
+  }, [data, dispatch])
+
+  const setDataInfo = (data: ProvidedApps) =>
+    data.content.map((item: AppMarketplaceApp) => appToCard(item))
 
   const debouncedSearch = useMemo(
     () =>
@@ -157,7 +177,25 @@ export default function AppOverview() {
   const setView = (e: React.MouseEvent<HTMLInputElement>) => {
     const viewValue = e.currentTarget.value
     setGroup(viewValue)
-    debouncedSearch(searchExpr, itemCards, viewValue)
+    setArgsData({
+      page: 0,
+      args: {
+        expr: '',
+        statusFilter: viewValue,
+      },
+    })
+    setPage(0)
+  }
+
+  const nextPage = () => {
+    setArgsData({
+      page: page + 1,
+      args: {
+        expr: '',
+        statusFilter: group,
+      },
+    })
+    setPage(page + 1)
   }
 
   const categoryViews = [
@@ -297,6 +335,15 @@ export default function AppOverview() {
                 ))}
             </>
           )}
+          <div
+            style={{
+              textAlign: 'center',
+            }}
+          >
+            {data?.meta && data?.meta?.totalPages > page + 1 && (
+              <LoadMoreButton onClick={nextPage} label={t('loadmore')} />
+            )}
+          </div>
         </div>
       </div>
       {state && (

--- a/src/components/pages/AppOverviewNew/index.tsx
+++ b/src/components/pages/AppOverviewNew/index.tsx
@@ -28,7 +28,15 @@ import { appToCard } from 'features/apps/mapper'
 
 export default function AppOverviewNew() {
   const { t } = useTranslation()
-  const { data, refetch, isSuccess } = useFetchProvidedAppsQuery()
+  const { data, refetch, isSuccess } = useFetchProvidedAppsQuery({
+    page: 0,
+    args: {
+      expr: '',
+      statusFilter: 'All',
+    },
+  })
+  // apiSlice has since been updated to accept params for pagination.
+  // Temporary solution until this page is completed.
 
   return (
     <main>

--- a/src/features/apps/apiSlice.ts
+++ b/src/features/apps/apiSlice.ts
@@ -109,7 +109,9 @@ export const apiSlice = createApi({
       query: (fetchArgs) => {
         const { page, args } = fetchArgs
         const baseUrl = `/api/apps/provided?page=${page}&size=15`
-        const statusId = args?.statusFilter || StatusIdEnum.All
+        const statusId = args?.statusFilter
+          ? args.statusFilter
+          : StatusIdEnum.All
         const offerName = args?.expr ? `&offerName=${args.expr}` : ''
         return `${baseUrl}&statusId=${statusId}${offerName}`
       },

--- a/src/features/apps/apiSlice.ts
+++ b/src/features/apps/apiSlice.ts
@@ -107,16 +107,11 @@ export const apiSlice = createApi({
     }),
     fetchProvidedApps: builder.query<ProvidedApps, PaginFetchArgs>({
       query: (fetchArgs) => {
-        const url = `/api/apps/provided?page=${fetchArgs.page}&size=15`
-        if (fetchArgs?.args?.statusFilter && !fetchArgs?.args?.expr) {
-          return `${url}&statusId=${fetchArgs?.args?.statusFilter}`
-        } else if (fetchArgs?.args?.expr && !fetchArgs?.args?.statusFilter) {
-          return `${url}&statusId=${StatusIdEnum.All}&offerName=${fetchArgs?.args?.expr}`
-        } else if (fetchArgs?.args?.expr && fetchArgs?.args?.statusFilter) {
-          return `${url}&statusId=${fetchArgs?.args?.statusFilter}&offerName=${fetchArgs?.args?.expr}`
-        } else {
-          return `${url}&statusId=${StatusIdEnum.All}`
-        }
+        const { page, args } = fetchArgs
+        const baseUrl = `/api/apps/provided?page=${page}&size=15`
+        const statusId = args?.statusFilter || StatusIdEnum.All
+        const offerName = args?.expr ? `&offerName=${args.expr}` : ''
+        return `${baseUrl}&statusId=${statusId}${offerName}`
       },
     }),
     fetchBusinessApps: builder.query<AppMarketplaceApp[], void>({

--- a/src/features/apps/apiSlice.ts
+++ b/src/features/apps/apiSlice.ts
@@ -27,20 +27,21 @@ import i18next from 'i18next'
 import { getApiBase } from 'services/EnvironmentService'
 import { apiBaseQuery } from 'utils/rtkUtil'
 import { PAGE_SIZE } from 'types/Constants'
-import type {
-  AppDetails,
-  AppMarketplaceApp,
-  SubscriptionStatusItem,
-  SubscriptionStatusDuplicateItem,
-  ActiveSubscriptionItem,
-  ProvidedApps,
-  DocumentRequestData,
-  SubscriptionAppRequest,
-  AgreementRequest,
-  ActiveSubscription,
-  ActiveSubscriptionDetails,
-  FetchSubscriptionAppQueryType,
-  SubscribedActiveApps,
+import {
+  type AppDetails,
+  type AppMarketplaceApp,
+  type SubscriptionStatusItem,
+  type SubscriptionStatusDuplicateItem,
+  type ActiveSubscriptionItem,
+  type ProvidedApps,
+  type DocumentRequestData,
+  type SubscriptionAppRequest,
+  type AgreementRequest,
+  type ActiveSubscription,
+  type ActiveSubscriptionDetails,
+  type FetchSubscriptionAppQueryType,
+  type SubscribedActiveApps,
+  StatusIdEnum,
 } from './types'
 
 export const apiSlice = createApi({
@@ -104,8 +105,19 @@ export const apiSlice = createApi({
         return { data: subscriptionData }
       },
     }),
-    fetchProvidedApps: builder.query<ProvidedApps, void>({
-      query: () => '/api/apps/provided',
+    fetchProvidedApps: builder.query<ProvidedApps, PaginFetchArgs>({
+      query: (fetchArgs) => {
+        const url = `/api/apps/provided?page=${fetchArgs.page}&size=15`
+        if (fetchArgs?.args?.statusFilter && !fetchArgs?.args?.expr) {
+          return `${url}&statusId=${fetchArgs?.args?.statusFilter}`
+        } else if (fetchArgs?.args?.expr && !fetchArgs?.args?.statusFilter) {
+          return `${url}&statusId=${StatusIdEnum.All}&offerName=${fetchArgs?.args?.expr}`
+        } else if (fetchArgs?.args?.expr && fetchArgs?.args?.statusFilter) {
+          return `${url}&statusId=${fetchArgs?.args?.statusFilter}&offerName=${fetchArgs?.args?.expr}`
+        } else {
+          return `${url}&statusId=${StatusIdEnum.All}`
+        }
+      },
     }),
     fetchBusinessApps: builder.query<AppMarketplaceApp[], void>({
       query: () => '/api/apps/business',

--- a/src/features/apps/types.ts
+++ b/src/features/apps/types.ts
@@ -264,3 +264,11 @@ export interface SubscribedActiveApps {
   subscriptionId: string
   image: string
 }
+
+export enum StatusIdEnum {
+  Active = 'Active',
+  Inactive = 'Inactive',
+  InReview = 'InReview',
+  WIP = 'WIP',
+  All = 'All',
+}


### PR DESCRIPTION
## Description

- Added Load more button in app overview
- Updated apiSlice fetchProvidedApps query to allow pagination 
- Added StatusIdEnum to handle pagination of different category views

## Why

load more button missing. Unable to expand list view to show available apps of all categories.  When the number apps exceeds 15, there is now possibility to see the rest. 

## Issue

#1008

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
