### PR TITLE
fix: Fix click handling on 'Details' tab in Managed Connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - removed unnecessary condition in semantic hub page's table [#979](https://github.com/eclipse-tractusx/portal-frontend/pull/979)
 - fixed unchanged text of button when user requests subscription [#985](https://github.com/eclipse-tractusx/portal-frontend/pull/985)
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
+- fixed click handling on 'Details' tab in Managed Connectors [#1017](https://github.com/eclipse-tractusx/portal-frontend/issues/1017)
 
 ## 2.1.0
 

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -158,12 +158,9 @@ const EdcConnector = () => {
     setAddConnectorOverlayOpen(false)
   }
 
-  const onTableCellClick = (params: GridCellParams, title: string) => {
+  const onTableCellClick = (params: GridCellParams) => {
     // Show overlay only when detail field clicked
-    if (
-      params.field === 'details' &&
-      title === t('content.edcconnector.tabletitle')
-    ) {
+    if (params.field === 'details') {
       setOpenDetailsOverlay(true)
       setOverlayData(params.row)
     }
@@ -497,7 +494,7 @@ const EdcConnector = () => {
               getRowId={(row: { [key: string]: string }) => row.id}
               columns={ownConnectorCols}
               onCellClick={(params: GridCellParams) => {
-                onTableCellClick(params, t('content.edcconnector.tabletitle'))
+                onTableCellClick(params)
               }}
             />
           </div>
@@ -514,10 +511,7 @@ const EdcConnector = () => {
               columns={managedConnectorCols}
               noRowsMsg={t('content.edcconnector.noConnectorsMessage')}
               onCellClick={(params: GridCellParams) => {
-                onTableCellClick(
-                  params,
-                  t('content.edcconnector.managedtabletitle')
-                )
+                onTableCellClick(params)
               }}
             />
           </div>


### PR DESCRIPTION
## Description

- Nothing happened whenever the user clicked on Managed Connector's "Details" CTA. It should open a detailed model like Owned Connectors. 

Steps To Reproduce
- Goto User Menu & Click on "Connectors Management"
- Switch to “Managed Connectors“
- Click on the “Details“ link for any existing connector under Managed Connectors

## Why

- When the user clicks on the "Details" CTA it should work like Owned Connectors.

## Issue

[Link to Github issue.
](https://github.com/eclipse-tractusx/portal-frontend/issues/1017)
## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
