### PR TITLE
feat(application requests and connector management): update skipped status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Change
 
 - **Application Requests and Connector Management**
-  - update the status(skipped) in application requests and necessary changes with checkbox in connector management
+  - update the status(skipped) in application requests and necessary changes with checkbox in connector management [#1019](https://github.com/eclipse-tractusx/portal-frontend/pull/1019)
 
 ## 2.2.0-RC1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Change
+
+- **Application Requests and Connector Management**
+  - update the status(skipped) in application requests and necessary changes with checkbox in connector management
+
 ## 2.2.0-RC1
 
 ### Change

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -684,7 +684,7 @@ npm/npmjs/@mui/material/5.15.15, MIT AND CC-BY-3.0, approved, #13175
 npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
 npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
 npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
-npm/npmjs/@mui/types/7.2.14, MIT, approved, clearlydefined
+npm/npmjs/@mui/types/7.2.14, MIT, approved, #16017
 npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
 npm/npmjs/@mui/x-data-grid/6.19.11, MIT, approved, #14027
 npm/npmjs/@mui/x-date-pickers/6.19.9, MIT, approved, #14025

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -187,6 +187,7 @@
         "buttonprogress": "in progress",
         "buttonrejected": "rejected",
         "buttoncompleted": "completed",
+        "buttonPartiallyCompleted": "teilweise abgeschlossen",
         "buttonerror": "error",
         "cellconfirmed": "bestätigt",
         "celldeclined": "abgelehnt",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1615,7 +1615,8 @@
         "DONE": "approved",
         "IN_PROGRESS": "in progress",
         "FAILED": "failed",
-        "TO_DO": "to do"
+        "TO_DO": "to do",
+        "SKIPPED": "skipped"
       },
       "buttonApprove": "Approve",
       "buttonConfirm": "Confirm",
@@ -1773,6 +1774,10 @@
         "FAILED": {
           "title": "Ihre Aktion ist erforderlich, um fortzufahren.",
           "description": "The self-description creation was unsuccessful. Details regarding the unsuccessful process can get found below. Additionally you can retrigger the endpoint (by resetting the status) or close/reject the company registration."
+        },
+        "SKIPPED": {
+          "title": "Von Ihrer Seite sind keine Maßnahmen erforderlich",
+          "description": "Die Erstellung der Selbstbeschreibung wurde absichtlich übersprungen. Dieser Prozess wird vom CX-Operator so bald wie möglich wieder ausgelöst."
         }
       }
     },

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -568,7 +568,7 @@
         "location": "Location",
         "tooltipText": "Connector's status is pending",
         "sdDescription": "SD Registration",
-        "sdRegistrationToolTip": "Die Selbstbeschreibung wurde ausgelöst. Der Vorgang kann bis zu ein paar Minuten dauern.",
+        "sdRegistrationToolTip": "Das SD-Dokument ist noch nicht geladen. Dies könnte auf die Deaktivierung der SD-Fabrik zurückzuführen sein. Dieser Prozess wird so bald wie möglich vom CX-Administrator neu ausgelöst.",
         "hostCompanyName": "Host",
         "providerCompanyName": "Customer",
         "connectorUrl": "Connector-URL"

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1582,7 +1582,8 @@
         "DONE": "approved",
         "IN_PROGRESS": "in progress",
         "FAILED": "failed",
-        "TO_DO": "to do"
+        "TO_DO": "to do",
+        "SKIPPED": "skipped"
       },
       "buttonApprove": "Approve",
       "buttonConfirm": "Confirm",
@@ -1740,6 +1741,10 @@
         "FAILED": {
           "title": "Your action is needed.",
           "description": "The self-description creation was unsuccessful. Details regarding the unsuccessful process can get found below. Additionally you can retrigger the endpoint (by resetting the status) or close/reject the company registration."
+        },
+        "SKIPPED": {
+          "title": "No action needed from your side",
+          "description": "The self-description creation was skipped on purpose. This process will be retriggered by the CX Operator as soon as possible."
         }
       }
     },

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -567,7 +567,7 @@
         "location": "Location",
         "tooltipText": "Connector's status is pending",
         "sdDescription": "SD Registration",
-        "sdRegistrationToolTip": "The Self-Description is triggered. Process might take up to a couple of minutes.",
+        "sdRegistrationToolTip": "The SD Document is not yet loaded. This could be due to the deactivation of the Sd Factory. This process will be retriggered as soon as possible by the CX Admin",
         "hostCompanyName": "Host",
         "providerCompanyName": "Customer",
         "connectorUrl": "Connector URL"

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -186,6 +186,7 @@
         "buttonprogress": "in progress",
         "buttonrejected": "rejected",
         "buttoncompleted": "completed",
+        "buttonPartiallyCompleted": "partially completed",
         "buttonerror": "error",
         "cellconfirmed": "confirmed",
         "celldeclined": "declined",

--- a/src/components/pages/Admin/components/RegistrationRequests/CompanyDetailOverlay/CompanyDetailsHelper.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/CompanyDetailOverlay/CompanyDetailsHelper.tsx
@@ -36,6 +36,14 @@ export const getTitle = (
 ) => {
   const getStatus = () => {
     if (
+      selectedRequest?.applicationStatus ===
+        ApplicationRequestStatus.CONFIRMED &&
+      selectedRequest?.applicationChecklist?.filter(
+        (checklist) => checklist.statusId === ProgressStatus.SKIPPED
+      ).length > 0
+    ) {
+      return t('content.admin.registration-requests.buttonPartiallyCompleted')
+    } else if (
       selectedRequest?.applicationStatus === ApplicationRequestStatus.SUBMITTED
     ) {
       const failedItems = selectedRequest.applicationChecklist.filter(

--- a/src/components/pages/Admin/components/RegistrationRequests/RegistrationRequests.scss
+++ b/src/components/pages/Admin/components/RegistrationRequests/RegistrationRequests.scss
@@ -197,7 +197,6 @@
   align-items: center;
   border-radius: 30px;
   padding: 5px;
-  width: 140px;
 
   .statusText {
     margin: 0 auto;

--- a/src/components/pages/Admin/components/RegistrationRequests/components/CheckList/CheckListFullButtons.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/components/CheckList/CheckListFullButtons.tsx
@@ -98,6 +98,19 @@ export default function CheckListFullButtons({
           ),
           backgroundColor: '#FFF6FF',
         }
+      case ProgressStatus.SKIPPED:
+        return {
+          icon: (
+            <PendingActionsIcon
+              style={{
+                color: '#0F71CB',
+                height: '30px',
+                width: '20px',
+              }}
+            />
+          ),
+          backgroundColor: '#ffffff',
+        }
     }
   }
 
@@ -111,6 +124,8 @@ export default function CheckListFullButtons({
         return 'confirmed'
       case ProgressStatus.FAILED:
         return 'declined'
+      case ProgressStatus.SKIPPED:
+        return 'label'
     }
   }
 

--- a/src/components/pages/Admin/components/RegistrationRequests/registrationTableColumns.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/registrationTableColumns.tsx
@@ -143,8 +143,8 @@ export const StatusProgress = ({
     items?.SKIPPED === 1
   ) {
     const style = {
-      border: '#00AA55',
-      color: '#00AA55',
+      border: '#0f71cb',
+      color: '#0f71cb',
       background: '#eaf1fe',
     }
     return getProgressStatus(

--- a/src/components/pages/Admin/components/RegistrationRequests/registrationTableColumns.tsx
+++ b/src/components/pages/Admin/components/RegistrationRequests/registrationTableColumns.tsx
@@ -69,6 +69,11 @@ export const StatusProgress = ({
         style={{
           border: `2px solid ${style.border}`,
           background: style.background,
+          width:
+            statusText ===
+            t('content.admin.registration-requests.buttonPartiallyCompleted')
+              ? 'max-width'
+              : '140px',
         }}
       >
         <Progress
@@ -132,6 +137,20 @@ export const StatusProgress = ({
       style,
       application,
       t('content.admin.registration-requests.buttonrejected')
+    )
+  } else if (
+    application.applicationStatus === ApplicationRequestStatus.CONFIRMED &&
+    items?.SKIPPED === 1
+  ) {
+    const style = {
+      border: '#00AA55',
+      color: '#00AA55',
+      background: '#eaf1fe',
+    }
+    return getProgressStatus(
+      style,
+      application,
+      t('content.admin.registration-requests.buttonPartiallyCompleted')
     )
   } else if (
     application.applicationStatus === ApplicationRequestStatus.CONFIRMED

--- a/src/components/pages/EdcConnector/edcConnectorTableColumns.tsx
+++ b/src/components/pages/EdcConnector/edcConnectorTableColumns.tsx
@@ -27,6 +27,7 @@ import {
 } from '@catena-x/portal-shared-components'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import CheckBoxIcon from '@mui/icons-material/CheckBox'
+import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank'
 import Box from '@mui/material/Box'
 import type { ConnectorContentAPIResponse } from 'features/connector/types'
 import { useTranslation } from 'react-i18next'
@@ -92,7 +93,7 @@ export const ConnectorTableColumns = (
               children={
                 <span>
                   <Box>
-                    <CheckBoxIcon
+                    <CheckBoxOutlineBlankIcon
                       sx={{
                         color: '#b6b6b6',
                         cursor: 'pointer',

--- a/src/components/pages/EdcConnector/edcConnectorTableColumns.tsx
+++ b/src/components/pages/EdcConnector/edcConnectorTableColumns.tsx
@@ -84,7 +84,6 @@ export const ConnectorTableColumns = (
             <Tooltips
               additionalStyles={{
                 cursor: 'pointer',
-                marginTop: '30px !important',
               }}
               tooltipPlacement="bottom"
               tooltipText={t(

--- a/src/components/shared/basic/Progress/index.tsx
+++ b/src/components/shared/basic/Progress/index.tsx
@@ -19,24 +19,31 @@ export const Progress = ({
   const red = (items.FAILED / totalItems) * 360 + yellow
 
   const progressColor = () => {
-    switch (applicationStatus) {
-      case ApplicationRequestStatus.CONFIRMED:
-        return {
-          progressBg: '#e2f6c7',
-          progressColor: 'conic-gradient(#00aa55 360deg 360deg)',
-        }
-      case ApplicationRequestStatus.DECLINED:
-      case ApplicationRequestStatus.CANCELLED_BY_CUSTOMER:
-        return {
-          progressBg: '#fee7e2',
-          progressColor: 'conic-gradient(#d91e18 360deg 360deg)',
-        }
-      default:
-        return {
-          progressBg: '#ffffff',
-          progressColor: `conic-gradient(#00aa55 ${green}deg, #efb800 ${green}deg ${yellow}deg, #d91e18 ${yellow}deg ${red}deg, #ffffff ${red}deg 360deg)`,
-        }
-    }
+    if (ApplicationRequestStatus.CONFIRMED && items?.SKIPPED === 1) {
+      return {
+        progressBg: '#e2f6c7',
+        progressColor:
+          'conic-gradient(#02aa56 308deg, rgb(245 243 237) 102.857deg, rgb(239, 184, 0) 154.286deg, rgb(217, 30, 24) 154.286deg, rgb(217, 30, 24) 154.286deg, rgb(255, 255, 255) 154.286deg, rgb(255, 255, 255) 360deg)',
+      }
+    } else
+      switch (applicationStatus) {
+        case ApplicationRequestStatus.CONFIRMED:
+          return {
+            progressBg: '#e2f6c7',
+            progressColor: 'conic-gradient(#00aa55 360deg 360deg)',
+          }
+        case ApplicationRequestStatus.DECLINED:
+        case ApplicationRequestStatus.CANCELLED_BY_CUSTOMER:
+          return {
+            progressBg: '#fee7e2',
+            progressColor: 'conic-gradient(#d91e18 360deg 360deg)',
+          }
+        default:
+          return {
+            progressBg: '#ffffff',
+            progressColor: `conic-gradient(#00aa55 ${green}deg, #efb800 ${green}deg ${yellow}deg, #d91e18 ${yellow}deg ${red}deg, #ffffff ${red}deg 360deg)`,
+          }
+      }
   }
 
   return (

--- a/src/components/shared/basic/Progress/index.tsx
+++ b/src/components/shared/basic/Progress/index.tsx
@@ -22,7 +22,7 @@ export const Progress = ({
     if (ApplicationRequestStatus.CONFIRMED && items?.SKIPPED === 1) {
       return {
         progressBg: '#eaf1fe',
-        progressColor: 'conic-gradient(#00aa55 360deg 360deg)',
+        progressColor: '#0f71cb',
       }
     } else
       switch (applicationStatus) {

--- a/src/components/shared/basic/Progress/index.tsx
+++ b/src/components/shared/basic/Progress/index.tsx
@@ -21,9 +21,8 @@ export const Progress = ({
   const progressColor = () => {
     if (ApplicationRequestStatus.CONFIRMED && items?.SKIPPED === 1) {
       return {
-        progressBg: '#e2f6c7',
-        progressColor:
-          'conic-gradient(#02aa56 308deg, rgb(245 243 237) 102.857deg, rgb(239, 184, 0) 154.286deg, rgb(217, 30, 24) 154.286deg, rgb(217, 30, 24) 154.286deg, rgb(255, 255, 255) 154.286deg, rgb(255, 255, 255) 360deg)',
+        progressBg: '#eaf1fe',
+        progressColor: 'conic-gradient(#00aa55 360deg 360deg)',
       }
     } else
       switch (applicationStatus) {
@@ -72,7 +71,7 @@ export const Progress = ({
         }}
       >
         {applicationStatus !== ApplicationRequestStatus.DECLINED &&
-          `${items.DONE}/${totalItems}`}
+          `${items.DONE + items.SKIPPED}/${totalItems}`}
       </div>
     </div>
   )

--- a/src/features/admin/applicationRequestApiSlice.ts
+++ b/src/features/admin/applicationRequestApiSlice.ts
@@ -133,7 +133,6 @@ export const progressMapper = {
   IN_PROGRESS: 5,
   TO_DO: 0,
   FAILED: 0,
-  SKIPPED: 0,
 }
 
 export interface ApplicationRequest {

--- a/src/features/admin/applicationRequestApiSlice.ts
+++ b/src/features/admin/applicationRequestApiSlice.ts
@@ -133,6 +133,7 @@ export const progressMapper = {
   IN_PROGRESS: 5,
   TO_DO: 0,
   FAILED: 0,
+  SKIPPED: 0,
 }
 
 export interface ApplicationRequest {

--- a/src/features/admin/applicationRequestApiSlice.ts
+++ b/src/features/admin/applicationRequestApiSlice.ts
@@ -55,6 +55,7 @@ export enum ProgressStatus {
   TO_DO = 'TO_DO',
   DONE = 'DONE',
   FAILED = 'FAILED',
+  SKIPPED = 'SKIPPED',
 }
 
 export type ProgressType = {
@@ -62,6 +63,7 @@ export type ProgressType = {
   DONE: number
   FAILED: number
   IN_PROGRESS: number
+  SKIPPED: number
 }
 
 export const initialProgressValue: ProgressType = {
@@ -69,6 +71,7 @@ export const initialProgressValue: ProgressType = {
   DONE: 0,
   FAILED: 0,
   IN_PROGRESS: 0,
+  SKIPPED: 0,
 }
 
 export enum StatusType {
@@ -130,6 +133,7 @@ export const progressMapper = {
   IN_PROGRESS: 5,
   TO_DO: 0,
   FAILED: 0,
+  SKIPPED: 0,
 }
 
 export interface ApplicationRequest {


### PR DESCRIPTION
## Description

 update the status(skipped) in application requests and necessary changes with checkbox in connector management

## Why

Due to the implementation of a new status for the self description step we need to be able to show the status skipped in application requests and Connector SD Checkbox should be empty if connector status is skipped

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/948

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
