### PR TITLE
fix(service subscription): update auto setup api response data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Service Subscription
+  - Update auto setup api response data in the service subscription response overlay
+
 ## 2.2.0-RC1
 
 ### Change

--- a/src/components/overlays/ActivateServiceSubscription/index.tsx
+++ b/src/components/overlays/ActivateServiceSubscription/index.tsx
@@ -96,11 +96,11 @@ export default function ActivateserviceSubscription({
     body: [
       [
         t('serviceSubscription.activation.userId'),
-        techUserInfo?.technicalUserInfo.technicalClientId ?? '',
+        techUserInfo?.technicalUserInfo[0]?.technicalClientId ?? '',
       ],
       [
         t('serviceSubscription.activation.sercret'),
-        techUserInfo?.technicalUserInfo.technicalUserSecret ?? '',
+        techUserInfo?.technicalUserInfo[0]?.technicalUserSecret ?? '',
       ],
       [
         t('serviceSubscription.activation.url'),
@@ -108,8 +108,9 @@ export default function ActivateserviceSubscription({
       ],
       [
         t('serviceSubscription.activation.technicaluserType'),
-        techUserInfo?.technicalUserInfo.technicalUserPermissions.join(', ') ??
-          '',
+        techUserInfo?.technicalUserInfo[0]?.technicalUserPermissions?.join(
+          ', '
+        ) ?? '',
       ],
     ],
     edit: [
@@ -127,7 +128,7 @@ export default function ActivateserviceSubscription({
         },
         {
           icon: false,
-          copyValue: techUserInfo?.technicalUserInfo.technicalUserSecret,
+          copyValue: techUserInfo?.technicalUserInfo[0]?.technicalUserSecret,
         },
       ],
     ],

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -178,7 +178,7 @@ export type ActivateSubscriptionRequest = {
 }
 
 export type ActivateSubscriptionResponse = {
-  technicalUserInfo: TechnicalUserInfoType
+  technicalUserInfo: TechnicalUserInfoType[]
   clientInfo: ClientInfoType
 }
 


### PR DESCRIPTION

## Description

update auto setup api response data in the service subscription response overlay

## Why

after autosetup api, website showing up a blank page

## Issue

#1016 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
