### PR TITLE
fix: Overview My App button not working on App Release Process page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - removed unnecessary condition in semantic hub page's table [#979](https://github.com/eclipse-tractusx/portal-frontend/pull/979)
 - fixed unchanged text of button when user requests subscription [#985](https://github.com/eclipse-tractusx/portal-frontend/pull/985)
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
-- fixed on click on "Overview My Apps" button on App Release Process screen [#1022](https://github.com/eclipse-tractusx/portal-frontend/issues/1022)
+- fixed onClick of "Overview My Apps" button in App Release Process screen [#1022](https://github.com/eclipse-tractusx/portal-frontend/issues/1022)
 
 ## 2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - removed unnecessary condition in semantic hub page's table [#979](https://github.com/eclipse-tractusx/portal-frontend/pull/979)
 - fixed unchanged text of button when user requests subscription [#985](https://github.com/eclipse-tractusx/portal-frontend/pull/985)
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
+- fixed on click on "Overview My Apps" button on App Release Process screen [#1022](https://github.com/eclipse-tractusx/portal-frontend/issues/1022)
 
 ## 2.1.0
 

--- a/src/components/pages/AppReleaseProcess/index.tsx
+++ b/src/components/pages/AppReleaseProcess/index.tsx
@@ -79,7 +79,7 @@ export default function AppReleaseProcess() {
   }
 
   const onOverviewButton = () => {
-    // do nothing
+    navigate(`/${PAGES.APP_OVERVIEW}`)
   }
 
   const requirements = [


### PR DESCRIPTION
## Description

- The "Overview My Apps" button is not working whenever the user clicks the button. It should be working like the Service Release Process and redirect to the respective page (App Overview Page)

## Why
- 'Overview my apps' button is not working on the App Release Process page.

## Issue

[Link to Github issue.
](https://github.com/eclipse-tractusx/portal-frontend/issues/1022)

## Checklist


- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
