### PR TITLE
fix(sd document): update SD document download API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **IDP management**
   - Fixed statusTag color in status coloumn [#978](https://github.com/eclipse-tractusx/portal-frontend/pull/978)
+- **Connector Management**
+  - Updated SD document download API to fix downloading SD document issue
+- **Service Release Process**
+  - Fixed back button navigation to service management instead of navigating to home page
 
 ### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 - **IDP management**
   - Fixed statusTag color in status coloumn [#978](https://github.com/eclipse-tractusx/portal-frontend/pull/978)
 - **Connector Management**
-  - Updated SD document download API to fix downloading SD document issue
+  - Updated SD document download API to fix downloading SD document issue [#1038](https://github.com/eclipse-tractusx/portal-frontend/pull/1038)
 - **Service Release Process**
-  - Fixed back button navigation to service management instead of navigating to home page
+  - Fixed back button navigation to service management instead of navigating to home page[#1038](https://github.com/eclipse-tractusx/portal-frontend/pull/1038)
 
 ### Feature
 

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -35,6 +35,7 @@ import {
   useDeleteConnectorMutation,
   useUpdateConnectorUrlMutation,
   useFetchConnectorDetailsQuery,
+  useFetchSdDocumentMutation,
 } from 'features/connector/connectorApiSlice'
 import { Box, Divider, Grid } from '@mui/material'
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
@@ -42,7 +43,6 @@ import { useEffect, useState } from 'react'
 import { error, success } from 'services/NotifyService'
 import EditIcon from '@mui/icons-material/Edit'
 import Patterns from 'types/Patterns'
-import { useFetchDocumentMutation } from 'features/serviceManagement/apiSlice'
 import { download } from 'utils/downloadUtils'
 import UserService from 'services/UserService'
 import { ROLES } from 'types/Constants'
@@ -59,7 +59,7 @@ const ConnectorDetailsOverlay = ({
   overlayData,
 }: DeleteConfirmationOverlayProps) => {
   const { t } = useTranslation()
-  const [fetchDocumentById] = useFetchDocumentMutation()
+  const [fetchSDDocument] = useFetchSdDocumentMutation()
   const {
     data: fetchConnectorDetails,
     isFetching,
@@ -135,10 +135,7 @@ const ConnectorDetailsOverlay = ({
   const handleDownloadFn = async (documentId: string, documentName: string) => {
     if (fetchConnectorDetails?.id) {
       try {
-        const response = await fetchDocumentById({
-          appId: fetchConnectorDetails.id,
-          documentId,
-        }).unwrap()
+        const response = await fetchSDDocument(documentId).unwrap()
 
         const fileType = response.headers.get('content-type')
         const file = response.data
@@ -600,8 +597,8 @@ const ConnectorDetailsOverlay = ({
                     null ? (
                       t('content.edcconnector.details.noDocumentAvailable')
                     ) : (
-                      <>
-                        <ArticleOutlinedIcon sx={{ color: '#9c9c9c' }} />
+                      <Box sx={{ display: 'flex' }}>
+                        <ArticleOutlinedIcon sx={{ color: '#9c9c9c', mr: 1 }} />
                         <button
                           className="document-button-link"
                           onClick={() =>
@@ -616,7 +613,7 @@ const ConnectorDetailsOverlay = ({
                             'content.edcconnector.details.selfDescriptionDocument'
                           )}
                         </button>
-                      </>
+                      </Box>
                     )}
                   </Typography>
                 </Grid>

--- a/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -65,6 +65,7 @@ import { ButtonLabelTypes } from '..'
 import RetryOverlay from '../components/RetryOverlay'
 import { success, error } from 'services/NotifyService'
 import { DocumentTypeId } from 'features/appManagement/apiSlice'
+import { PAGES } from 'types/Constants'
 
 type FormDataType = {
   title: string
@@ -520,7 +521,7 @@ export default function OfferCard() {
           setServiceCardSnackbar(false)
         }}
         onBackIconClick={() => {
-          navigate('/home')
+          navigate(`/${PAGES.SERVICE_MANAGEMENT}`)
         }}
         // Add an ESLint exception until there is a solution
         // eslint-disable-next-line

--- a/src/features/connector/connectorApiSlice.ts
+++ b/src/features/connector/connectorApiSlice.ts
@@ -173,6 +173,15 @@ export const apiSlice = createApi({
         body: data.body,
       }),
     }),
+    fetchSdDocument: builder.mutation({
+      query: (documentId) => ({
+        url: `/api/administration/documents/selfDescription/${documentId}`,
+        responseHandler: async (response) => ({
+          headers: response.headers,
+          data: await response.blob(),
+        }),
+      }),
+    }),
   }),
 })
 
@@ -186,4 +195,5 @@ export const {
   useFetchOfferSubscriptionsQuery,
   useFetchDecentralIdentityUrlsQuery,
   useUpdateConnectorUrlMutation,
+  useFetchSdDocumentMutation,
 } = apiSlice


### PR DESCRIPTION
## Description

Updated SD document download API to fix downloading SD document issue
Also, fixed back button navigation to service management instead of navigating to home page

## Why

On clicking self description document, instead of downloading document, it throws error.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1037

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally