### PR TITLE
Fix/tech user setup none selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - removed unnecessary condition in semantic hub page's table [#979](https://github.com/eclipse-tractusx/portal-frontend/pull/979)
 - fixed unchanged text of button when user requests subscription [#985](https://github.com/eclipse-tractusx/portal-frontend/pull/985)
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
+- fixed "None" selection issue in Technical Integration -> App Release Process [#1036](https://github.com/eclipse-tractusx/portal-frontend/issues/1036)
 
 ## 2.1.0
 

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/index.tsx
@@ -143,7 +143,13 @@ export default function TechnicalIntegration() {
   )
 
   useEffect(() => {
-    setTechUserProfiles(userProfiles)
+    if (userProfiles.length > 0) {
+      setTechUserProfiles(userProfiles)
+    } else {
+      // Set default value as "None" when user profiles don't have any roles
+      // Initially, value is "None"
+      setTechUserProfiles([technicalUserNone])
+    }
   }, [userProfiles])
 
   const defaultValues = {


### PR DESCRIPTION
## Description
- **Context:** App Release Process -> Step 4: Technical Integration -> Technical User Setup.
- **Change:** Added an `if` condition in `useEffect` to verify if the user has assigned roles. If no roles are found, the "None" option is automatically selected.


## Why
- **Issue:** The "None" option in the Technical User Setup was not retaining its selection after submission.
- **Solution:** This fix ensures that the "None" option remains selected when the user revisits the "Technical Integration" step, providing a more consistent and user-friendly experience.

## Issue
Github Issue: [#1036](https://github.com/eclipse-tractusx/portal-frontend/issues/1036)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas

https://github.com/user-attachments/assets/acfee86c-72a7-430e-9325-8956adbbd7e9



