### PR TITLE
fix: update service subscription mgt page role

### DIFF
--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -183,7 +183,7 @@ export enum ROLES {
   APPMANAGEMENT_VIEW = 'add_apps',
   SERVICEMANAGEMENT_VIEW = 'add_service_offering',
   APP_MANAGEMENT = 'app_management',
-  SERVICE_SUBSCRIPTION_MANAGEMENT = 'activate_subscription',
+  SERVICE_SUBSCRIPTION_MANAGEMENT = 'service_management',
   APPOVERVIEW_VIEW = 'add_apps',
   SERVICEOVERVIEW_VIEW = 'add_service_offering',
   CONNECTOR_SETUP = 'setup_connector',


### PR DESCRIPTION
## Description

Prevent users with the 'App Manager' role from accessing the Service Subscription Management page via the URL.

## Why

To maintain role-based access control and prevent unauthorized actions.

## Issue

[991](https://github.com/eclipse-tractusx/portal-frontend/issues/991)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally