### PR TITLE
fix: rename 'appsubscription' to 'appSubscription' in notification.json

### DIFF
--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -104,7 +104,7 @@
     "appmanagementboard": "App Management Board öffnen",
     "servicemanagementboard": "Service Management Board öffnen",
     "appOverview": "Get there",
-    "appsubscription": "Get there",
+    "appSubscription": "Get there",
     "adminboard": "Get there",
     "technicaluser": "Get there",
     "companyRolesServiceProvider": "Get there",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -104,7 +104,7 @@
     "appmanagementboard": "Get there",
     "servicemanagementboard": "Get there",
     "appOverview": "Get there",
-    "appsubscription": "Get there",
+    "appSubscription": "Get there",
     "adminboard": "Get there",
     "technicaluser": "Get there",
     "companyRolesServiceProvider": "Get there",


### PR DESCRIPTION
## Description
Renamed the translation key from `appsubscription` to `appSubscription` in the `notification.json` file to fix a key mismatch.

## Why
The text `link.appSubscription` is displayed because the key `appSubscription` does not exist in the translation file, as the current key is incorrectly named `appsubscription`.

## Issue

[1053](https://github.com/eclipse-tractusx/portal-frontend/issues/1053)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally