### PR TITLE
feat(technical user management): remove inactive filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## (unreleased) 2.2.0-RC3
+
+### Change
+
+- **Technical User Management**
+  - Removed 'Inactive' filter in technical user management [#1046](https://github.com/eclipse-tractusx/portal-frontend/pull/1046)
+
 ## 2.2.0-RC2
 
 ### Feature

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -64,7 +64,7 @@ npm/npmjs/-/ci-info/3.9.0, MIT, approved, clearlydefined
 npm/npmjs/-/cjs-module-lexer/1.2.3, MIT, approved, #9069
 npm/npmjs/-/classnames/2.5.1, MIT, approved, clearlydefined
 npm/npmjs/-/cliui/8.0.1, ISC AND Artistic-2.0, approved, #3753
-npm/npmjs/-/clsx/2.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/clsx/2.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/co/4.6.0, MIT, approved, clearlydefined
 npm/npmjs/-/collect-v8-coverage/1.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/color-convert/1.9.3, MIT, approved, clearlydefined
@@ -90,7 +90,7 @@ npm/npmjs/-/data-view-buffer/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/data-view-byte-length/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/data-view-byte-offset/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/date-fns/3.6.0, MIT, approved, #14000
-npm/npmjs/-/dayjs/1.11.13, MIT, approved, #9149
+npm/npmjs/-/dayjs/1.11.12, MIT, approved, #9149
 npm/npmjs/-/debug/3.2.7, MIT, approved, clearlydefined
 npm/npmjs/-/debug/4.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/decimal.js/10.4.3, MIT, approved, clearlydefined
@@ -389,7 +389,7 @@ npm/npmjs/-/path-is-absolute/1.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/path-key/3.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/path-parse/1.0.7, MIT, approved, clearlydefined
 npm/npmjs/-/path-type/4.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/phone/3.1.50, MIT, approved, #10500
+npm/npmjs/-/phone/3.1.49, MIT, approved, #10500
 npm/npmjs/-/picocolors/1.0.0, ISC, approved, #14718
 npm/npmjs/-/picomatch/2.3.1, MIT, approved, clearlydefined
 npm/npmjs/-/pirates/4.0.6, MIT, approved, #680
@@ -416,7 +416,7 @@ npm/npmjs/-/react-hook-form/7.51.5, MIT, approved, #13909
 npm/npmjs/-/react-i18next/14.1.3, MIT AND Apache-2.0, approved, #13870
 npm/npmjs/-/react-is/16.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/react-is/17.0.2, MIT, approved, clearlydefined
-npm/npmjs/-/react-is/18.3.1, MIT, approved, clearlydefined
+npm/npmjs/-/react-is/18.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/react-player/2.15.1, MIT, approved, #13914
 npm/npmjs/-/react-redux/9.1.2, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-3-Clause, approved, #13913
 npm/npmjs/-/react-refresh/0.14.0, MIT, approved, clearlydefined
@@ -678,14 +678,14 @@ npm/npmjs/@jridgewell/sourcemap-codec/1.4.15, MIT, approved, clearlydefined
 npm/npmjs/@jridgewell/trace-mapping/0.3.25, MIT, approved, #9904
 npm/npmjs/@jridgewell/trace-mapping/0.3.9, MIT, approved, #9904
 npm/npmjs/@mui/base/5.0.0-beta.40, MIT, approved, #2992
-npm/npmjs/@mui/core-downloads-tracker/5.16.7, MIT, approved, clearlydefined
-npm/npmjs/@mui/icons-material/5.15.21, MIT AND CC-BY-3.0, approved, #13171
-npm/npmjs/@mui/material/5.15.21, MIT AND CC-BY-3.0, approved, #13175
-npm/npmjs/@mui/private-theming/5.16.6, MIT, approved, #15717
-npm/npmjs/@mui/styled-engine/5.16.6, MIT, approved, #15718
-npm/npmjs/@mui/system/5.16.7, MIT, approved, #15715
-npm/npmjs/@mui/types/7.2.15, MIT, approved, #16017
-npm/npmjs/@mui/utils/5.16.6, MIT, approved, #15716
+npm/npmjs/@mui/core-downloads-tracker/5.15.15, MIT, approved, clearlydefined
+npm/npmjs/@mui/icons-material/5.15.15, MIT AND CC-BY-3.0, approved, #13171
+npm/npmjs/@mui/material/5.15.15, MIT AND CC-BY-3.0, approved, #13175
+npm/npmjs/@mui/private-theming/5.15.14, MIT AND CC-BY-3.0, approved, #13174
+npm/npmjs/@mui/styled-engine/5.15.14, MIT AND CC-BY-3.0, approved, #13173
+npm/npmjs/@mui/system/5.15.15, MIT, approved, #13170
+npm/npmjs/@mui/types/7.2.14, MIT, approved, #16017
+npm/npmjs/@mui/utils/5.15.14, MIT AND OFL-1.1 AND CC-BY-3.0, approved, #13927
 npm/npmjs/@mui/x-data-grid/6.19.11, MIT, approved, #14027
 npm/npmjs/@mui/x-date-pickers/6.19.9, MIT, approved, #14025
 npm/npmjs/@nodelib/fs.scandir/2.1.5, MIT, approved, clearlydefined
@@ -694,7 +694,7 @@ npm/npmjs/@nodelib/fs.walk/1.2.8, MIT, approved, clearlydefined
 npm/npmjs/@popperjs/core/2.11.8, MIT, approved, clearlydefined
 npm/npmjs/@react-hook/cache/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
-npm/npmjs/@reduxjs/toolkit/2.2.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
+npm/npmjs/@reduxjs/toolkit/2.2.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
 npm/npmjs/@remix-run/router/1.15.3, MIT, approved, clearlydefined
 npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, clearlydefined
 npm/npmjs/@rollup/rollup-android-arm-eabi/4.17.2, MIT, approved, clearlydefined
@@ -729,7 +729,7 @@ npm/npmjs/@svgr/core/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/hast-util-to-babel-ast/8.0.0, MIT, approved, clearlydefined
 npm/npmjs/@svgr/plugin-jsx/8.1.0, MIT, approved, clearlydefined
 npm/npmjs/@testing-library/dom/9.3.4, MIT AND (MIT AND WTFPL), approved, #9038
-npm/npmjs/@testing-library/jest-dom/6.4.8, MIT, approved, clearlydefined
+npm/npmjs/@testing-library/jest-dom/6.4.6, MIT, approved, clearlydefined
 npm/npmjs/@testing-library/react/14.2.2, MIT, approved, #13316
 npm/npmjs/@testing-library/user-event/14.5.2, MIT, approved, clearlydefined
 npm/npmjs/@tootallnate/once/2.0.0, MIT, approved, clearlydefined
@@ -760,7 +760,6 @@ npm/npmjs/@types/node/20.11.30, MIT, approved, #13826
 npm/npmjs/@types/papaparse/5.3.14, MIT, approved, #10964
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
 npm/npmjs/@types/prop-types/15.7.11, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
 npm/npmjs/@types/qs/6.9.15, MIT, approved, #14071
 npm/npmjs/@types/react-dom/18.2.22, MIT, approved, #8256
 npm/npmjs/@types/react-redux/7.1.33, MIT, approved, #10970

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -82,11 +82,6 @@ export const TechnicalUserTable = () => {
       onButtonClick: setView,
     },
     {
-      buttonText: t('content.usermanagement.technicalUser.tabs.inactive'),
-      buttonValue: ServiceAccountStatusFilter.INACTIVE,
-      onButtonClick: setView,
-    },
-    {
       buttonText: t('content.usermanagement.technicalUser.tabs.managed'),
       buttonValue: ServiceAccountStatusFilter.MANAGED,
       onButtonClick: setView,

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -98,7 +98,6 @@ export interface ServiceAccountsResponseType {
 
 export enum ServiceAccountStatusFilter {
   ACTIVE = 'ACTIVE',
-  INACTIVE = 'INACTIVE',
   MANAGED = 'MANAGED',
   OWNED = 'OWNED',
 }
@@ -152,12 +151,6 @@ export const apiSlice = createApi({
           fetchArgs.args.statusFilter === ServiceAccountStatusFilter.ACTIVE
         ) {
           return `${url}&clientId=${fetchArgs.args!.expr}`
-        } else if (
-          !isFetchArgs &&
-          fetchArgs.args.statusFilter &&
-          fetchArgs.args.statusFilter === ServiceAccountStatusFilter.INACTIVE
-        ) {
-          return `${url}&filterForInactive=true`
         } else if (
           !isFetchArgs &&
           fetchArgs.args.statusFilter &&


### PR DESCRIPTION
## Description

Removed 'Inactive' filter in technical user management

## Why

Filter is not needed

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/983

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally