### PR TITLE
fix(tech user): error message and close notification bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Customer Detail Data Overlay
   - implement new UI design for customer detail data overlay
 
+### BugFix
+
+- Technical User
+  - Show appropriate error message.
+  - Fix closing page notification bar issue
+
 ### Change
 
 - **Technical User Management**

--- a/src/components/overlays/DeleteTechnicalUser/index.tsx
+++ b/src/components/overlays/DeleteTechnicalUser/index.tsx
@@ -55,13 +55,14 @@ export const DeleteTechnicalUser = ({ id }: { id: string }) => {
     navigate(`/${PAGES.TECH_USER_MANAGEMENT}`)
   }
 
-  const deleteUserError = (err: unknown) => {
+  // eslint-disable-next-line
+  const deleteUserError = (err: any) => {
     const notification: PageNotificationsProps = {
       open: true,
       severity: SuccessErrorType.ERROR,
       title:
         'content.usermanagement.technicalUser.deleteTechUserNotificationErrorTitle',
-      description: err as string,
+      description: err.data.details[0].message,
     }
     dispatch(closeOverlay())
     dispatch(setNotification(notification))
@@ -71,11 +72,12 @@ export const DeleteTechnicalUser = ({ id }: { id: string }) => {
   const handleRemove = async () => {
     if (!data) return
     try {
-      await removeServiceAccount(data.serviceAccountId).unwrap()
-      deleteUserSuccess()
+      await removeServiceAccount(data.serviceAccountId)
+        .unwrap()
+        .then(() => { deleteUserSuccess() })
+        .catch((err) => { deleteUserError(err) })
     } catch (err: unknown) {
       deleteUserError(err)
-      console.log(err)
     }
   }
   return data ? (

--- a/src/components/overlays/DeleteTechnicalUser/index.tsx
+++ b/src/components/overlays/DeleteTechnicalUser/index.tsx
@@ -74,8 +74,12 @@ export const DeleteTechnicalUser = ({ id }: { id: string }) => {
     try {
       await removeServiceAccount(data.serviceAccountId)
         .unwrap()
-        .then(() => { deleteUserSuccess() })
-        .catch((err) => { deleteUserError(err) })
+        .then(() => {
+          deleteUserSuccess()
+        })
+        .catch((err) => {
+          deleteUserError(err)
+        })
     } catch (err: unknown) {
       deleteUserError(err)
     }

--- a/src/components/pages/TechnicalUserManagement/index.tsx
+++ b/src/components/pages/TechnicalUserManagement/index.tsx
@@ -25,13 +25,16 @@ import SubHeaderTitle from 'components/shared/frame/SubHeaderTitle'
 import { Button, PageNotifications } from '@catena-x/portal-shared-components'
 import { show } from 'features/control/overlay'
 import UserService from 'services/UserService'
-import { resetNotification } from 'features/notification/actions'
-import { notificationSelector } from 'features/notification/slice'
+import {
+  notificationSelector,
+  setNotification,
+} from 'features/notification/slice'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import './style.scss'
 import { TechnicalUserTable } from './TechnicalUserTable'
 import { getAssetBase } from 'services/EnvironmentService'
+import { initServicetNotifications } from 'types/MainTypes'
 
 export default function TechnicalUserManagement() {
   const { t } = useTranslation()
@@ -39,7 +42,7 @@ export default function TechnicalUserManagement() {
   const dispatch = useDispatch()
 
   const handleCloseNotification = () => {
-    dispatch(resetNotification())
+    dispatch(setNotification(initServicetNotifications))
   }
 
   return (
@@ -79,7 +82,7 @@ export default function TechnicalUserManagement() {
         </div>
 
         <div style={{ paddingTop: '70px' }}>
-          {notification.title && notification.description && (
+          {notification?.title && notification?.description && (
             <PageNotifications
               open={notification.open}
               severity={notification.severity}


### PR DESCRIPTION
## Description

show proper errors on page notification.
closing page notification bar issue.

## Why

broken error message on error scenario.
not able to close the page notification bar

## Issue

#1034 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
