### PR TITLE
feat: modify delete connector user popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Delete Confirmation Overlay
+  - updated delete connector confirmation logic with technical user
+
 ## 2.2.0-RC3
 
 ### Change

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -646,7 +646,7 @@
       "deletemodal": {
         "title": "EDC-Connector Löschen",
         "description": "Möchten Sie den ausgewählten Connector wirklich löschen? Die Löschung kann nicht rückgängig gemacht werden.",
-        "techUserdescription": "Möchten Sie den Connector wirklich löschen? Mit der Löschung wird der Connector automatisch vom Endpunkt „Connector Discovery“ gelöscht und das Selbstbeschreibungsdokument auf inaktiv gesetzt.\n Bitte beachten Sie, dass mit dem Connector ein technischer Benutzer verbunden ist – der technische Benutzer wird ebenfalls sofort inaktiviert, wenn mit dem Löschen fortgefahren wird.",
+        "techUserdescription": "Möchten Sie den Connector wirklich löschen? Mit der Löschung wird der Connector automatisch vom Endpunkt „Connector Discovery“ gelöscht und das Selbstbeschreibungsdokument auf inaktiv gesetzt.\n Bitte beachten Sie, dass mit dem Connector ein technischer Benutzer verbunden ist. Der technische Benutzer kann gelöscht werden, wenn Sie das Kontrollkästchen unten aktivieren. Andernfalls wird nur die Zuordnung zwischen Connector und technischem Benutzer gelöscht.",
         "techUserCheckBoxLabel": "Ja, ich möchte den Connector deaktivieren, wodurch automatisch auch der erwähnte technische Benutzer gelöscht wird.",
         "techDetails": {
           "title": "Technical Details",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -650,7 +650,7 @@
       "deletemodal": {
         "title": "Delete Connector",
         "description": "Do you really want to delete the registered connector? Please note that the deletion is not reversable.",
-        "techUserdescription": "Do you really want to delete the connector? With the deletion the connector will be automatically deleted from the „connector discovery“ endpoint as well as the self-description document will be set to inactive.\n\n Please note, the connector has a technical user connected – the technical user will get inactived immediadetly as well when proceeding with the deletion.",
+        "techUserdescription": "Do you really want to delete the connector? With the deletion the connector will be automatically deleted from the „connector discovery“ endpoint as well as the self-description document will be set to inactive.\n\n Please note, the connector has a technical user connected - the technical user can be deleted if you select the checkbox below otherwise only the mapping between connector and technical user will be deleted.",
         "techUserCheckBoxLabel": "Yes, I want to deactivate the connector which will automatically also delete the mentioned technical user.",
         "techDetails": {
           "title": "Technical Details",

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -149,9 +149,15 @@ const ConnectorDetailsOverlay = ({
     }
   }
 
-  const handleDeleteConnector = async () => {
+  const handleDeleteConnector = async (status: boolean) => {
     setDeleteLoading(true)
-    await deleteConnector({ connectorID: fetchConnectorDetails?.id ?? '' })
+    // Include the deleteServiceAccount query only if the connector is linked to a technical user account
+    await deleteConnector({
+      connectorID: fetchConnectorDetails?.id ?? '',
+      deleteServiceAccount: fetchConnectorDetails?.technicalUser
+        ? status
+        : undefined,
+    })
       .unwrap()
       .then(() => {
         setDeleteConnectorSuccess(true)
@@ -373,7 +379,7 @@ const ConnectorDetailsOverlay = ({
                 <Button
                   variant="outlined"
                   onClick={() => {
-                    handleDeleteConnector()
+                    handleDeleteConnector(false)
                   }}
                 >
                   {t('content.edcconnector.details.delete')}

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -151,7 +151,7 @@ const ConnectorDetailsOverlay = ({
 
   const handleDeleteConnector = async () => {
     setDeleteLoading(true)
-    await deleteConnector(fetchConnectorDetails?.id ?? '')
+    await deleteConnector({ connectorID: fetchConnectorDetails?.id ?? '' })
       .unwrap()
       .then(() => {
         setDeleteConnectorSuccess(true)
@@ -305,7 +305,7 @@ const ConnectorDetailsOverlay = ({
 
       {openDeleteConnector && (
         <Dialog
-          open={openDeleteConnector}
+          open
           sx={{
             '.MuiDialog-paper': {
               maxWidth: '45%',

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -32,7 +32,6 @@ import {
 } from '@catena-x/portal-shared-components'
 import {
   type ConnectorDetailsType,
-  useDeleteConnectorMutation,
   useUpdateConnectorUrlMutation,
   useFetchConnectorDetailsQuery,
 } from 'features/connector/connectorApiSlice'
@@ -66,10 +65,6 @@ const ConnectorDetailsOverlay = ({
     error: fetchError,
     refetch,
   } = useFetchConnectorDetailsQuery(overlayData?.id ?? '')
-  const [openDeleteConnector, setOpenDeleteConnector] = useState(false)
-  const [deleteConnectorSuccess, setDeleteConnectorSuccess] = useState(false)
-  const [deleteConnector] = useDeleteConnectorMutation()
-  const [deleteLoading, setDeleteLoading] = useState<boolean>(false)
   const [enableConnectorUrl, setEnableConnectorUrl] = useState(true)
   const [updateConnectorUrl] = useUpdateConnectorUrlMutation()
   const [confirmLoading, setConfirmLoading] = useState(false)
@@ -147,33 +142,6 @@ const ConnectorDetailsOverlay = ({
         error(t('content.edcconnector.details.errormessage'), '', '')
       }
     }
-  }
-
-  const handleDeleteConnector = async (status: boolean) => {
-    setDeleteLoading(true)
-    // Include the deleteServiceAccount query only if the connector is linked to a technical user account
-    await deleteConnector({
-      connectorID: fetchConnectorDetails?.id ?? '',
-      deleteServiceAccount: fetchConnectorDetails?.technicalUser
-        ? status
-        : undefined,
-    })
-      .unwrap()
-      .then(() => {
-        setDeleteConnectorSuccess(true)
-        setDeleteLoading(false)
-      })
-      .catch((err) => {
-        setDeleteConnectorSuccess(false)
-        setDeleteLoading(false)
-        error(
-          err.status === 409
-            ? err.data.title
-            : t('content.edcconnector.details.errormessage'),
-          '',
-          err
-        )
-      })
   }
 
   const handleUrlSubmit = async () => {
@@ -309,86 +277,6 @@ const ConnectorDetailsOverlay = ({
         </Dialog>
       )}
 
-      {openDeleteConnector && (
-        <Dialog
-          open
-          sx={{
-            '.MuiDialog-paper': {
-              maxWidth: '45%',
-            },
-          }}
-        >
-          <DialogHeader
-            title={t('content.edcconnector.details.deleteConnector')}
-            intro={fetchConnectorDetails?.name ?? ''}
-          />
-          <DialogContent
-            sx={{
-              textAlign: 'center',
-              marginBottom: '25px',
-              padding: '0px 80px 20px 80px',
-            }}
-          >
-            <Typography variant="body2" sx={{ textAlign: 'center' }}>
-              {deleteConnectorSuccess
-                ? t('content.edcconnector.details.connectorDeletedSuccessfully')
-                : t('content.edcconnector.details.wantToDeleteConnector')}
-            </Typography>
-          </DialogContent>
-          <DialogActions>
-            {deleteConnectorSuccess ? (
-              <Button
-                variant="outlined"
-                onClick={(e) => {
-                  handleOverlayClose(e)
-                  setOpenDeleteConnector(false)
-                }}
-              >
-                {t('global.actions.close')}
-              </Button>
-            ) : (
-              <Button
-                variant="outlined"
-                onClick={() => {
-                  setOpenDeleteConnector(false)
-                }}
-              >
-                {t('global.actions.cancel')}
-              </Button>
-            )}
-
-            {deleteLoading ? (
-              <Box
-                sx={{
-                  width: '110px',
-                  display: 'flex',
-                  justifyContent: 'center',
-                }}
-              >
-                <CircleProgress
-                  size={40}
-                  step={1}
-                  interval={0.1}
-                  colorVariant={'primary'}
-                  variant={'indeterminate'}
-                  thickness={8}
-                />
-              </Box>
-            ) : (
-              !deleteConnectorSuccess && (
-                <Button
-                  variant="outlined"
-                  onClick={() => {
-                    handleDeleteConnector(false)
-                  }}
-                >
-                  {t('content.edcconnector.details.delete')}
-                </Button>
-              )
-            )}
-          </DialogActions>
-        </Dialog>
-      )}
       <Dialog
         open={openDialog}
         sx={{
@@ -628,17 +516,6 @@ const ConnectorDetailsOverlay = ({
                 </Grid>
               </Grid>
               <Divider sx={{ margin: '20px auto', color: 'black' }} />
-              <Button
-                variant="outlined"
-                onClick={() => {
-                  setOpenDeleteConnector(true)
-                }}
-                disabled={!UserService.hasRole(ROLES.DELETE_CONNECTORS)}
-                size="small"
-                sx={{ float: 'right' }}
-              >
-                {t('content.edcconnector.details.deleteConnector')}
-              </Button>
             </>
           )}
         </DialogContent>

--- a/src/components/pages/EdcConnector/DeleteConfirmationOverlay/DeleteConfirmationOverlay.tsx
+++ b/src/components/pages/EdcConnector/DeleteConfirmationOverlay/DeleteConfirmationOverlay.tsx
@@ -35,7 +35,7 @@ import Box from '@mui/material/Box'
 interface DeleteConfirmationOverlayProps {
   openDialog?: boolean
   handleOverlayClose: React.MouseEventHandler
-  handleConfirmClick: React.MouseEventHandler
+  handleConfirmClick: (status: boolean) => void
   loading?: boolean
   techUser?: {
     id: string
@@ -138,9 +138,8 @@ const DeleteConfirmationOverlay = ({
           {!loading && (
             <Button
               variant="contained"
-              disabled={techUser ? !checkBoxSelected : false}
-              onClick={(e) => {
-                handleConfirmClick(e)
+              onClick={() => {
+                handleConfirmClick(checkBoxSelected)
               }}
             >
               {t('global.actions.confirm')}

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -539,7 +539,9 @@ const EdcConnector = () => {
           title={getSuccessTitle()}
           intro={getSuccessIntro()}
           dialogOpen
-          handleCallback={() => { resetSuccessErrorOverlayState() }}
+          handleCallback={() => {
+            resetSuccessErrorOverlayState()
+          }}
         >
           <Typography variant="body2"></Typography>
         </ServerResponseOverlay>
@@ -552,7 +554,9 @@ const EdcConnector = () => {
           iconComponent={
             <ErrorOutlineIcon sx={{ fontSize: 60 }} color="error" />
           }
-          handleCallback={() => { resetSuccessErrorOverlayState() }}
+          handleCallback={() => {
+            resetSuccessErrorOverlayState()
+          }}
         >
           <Typography variant="body2"></Typography>
         </ServerResponseOverlay>

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -237,6 +237,10 @@ const EdcConnector = () => {
     setNewUserLoading(false)
   }
 
+  const resetSuccessErrorOverlayState = () => {
+    if (response) setResponse(false)
+    else if (error) setError(false)
+  }
   const showOverlay = (result: boolean) => {
     setLoading(false)
     closeAndResetModalState()
@@ -252,21 +256,19 @@ const EdcConnector = () => {
     setAction('delete')
     setLoading(true)
 
-    // Include the deleteServiceAccount query only if the connector is linked to a technical user account
     await deleteConnector({
       connectorID: selectedConnector.id ?? '',
-      deleteServiceAccount: selectedConnector.technicalUser
-        ? status
-        : undefined,
+      deleteServiceAccount: status,
     })
       .unwrap()
       .then(() => {
-        setDeleteConnectorConfirmModalOpen(false)
         showOverlay(true)
       })
       .catch(() => {
-        setDeleteConnectorConfirmModalOpen(false)
         showOverlay(false)
+      })
+      .finally(() => {
+        setDeleteConnectorConfirmModalOpen(false)
       })
   }
 
@@ -362,15 +364,17 @@ const EdcConnector = () => {
         }}
         overlayData={overlayData}
       />
-      <DeleteConfirmationOverlay
-        openDialog={deleteConnectorConfirmModalOpen}
-        handleOverlayClose={() => {
-          setDeleteConnectorConfirmModalOpen(false)
-        }}
-        handleConfirmClick={(s) => deleteSelectedConnector(s)}
-        loading={loading}
-        techUser={selectedConnector?.technicalUser}
-      />
+      {deleteConnectorConfirmModalOpen && (
+        <DeleteConfirmationOverlay
+          openDialog
+          handleOverlayClose={() => {
+            setDeleteConnectorConfirmModalOpen(false)
+          }}
+          handleConfirmClick={(s) => deleteSelectedConnector(s)}
+          loading={loading}
+          techUser={selectedConnector?.technicalUser}
+        />
+      )}
       <AddConnectorOverlay
         openDialog={addConnectorOverlayOpen}
         handleOverlayClose={closeAndResetModalState}
@@ -534,10 +538,8 @@ const EdcConnector = () => {
         <ServerResponseOverlay
           title={getSuccessTitle()}
           intro={getSuccessIntro()}
-          dialogOpen={true}
-          handleCallback={() => {
-            // do nothing
-          }}
+          dialogOpen
+          handleCallback={() => { resetSuccessErrorOverlayState() }}
         >
           <Typography variant="body2"></Typography>
         </ServerResponseOverlay>
@@ -546,13 +548,11 @@ const EdcConnector = () => {
         <ServerResponseOverlay
           title={getErrorTitle()}
           intro={getErrorIntro()}
-          dialogOpen={true}
+          dialogOpen
           iconComponent={
             <ErrorOutlineIcon sx={{ fontSize: 60 }} color="error" />
           }
-          handleCallback={() => {
-            // do nothing
-          }}
+          handleCallback={() => { resetSuccessErrorOverlayState() }}
         >
           <Typography variant="body2"></Typography>
         </ServerResponseOverlay>

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -248,10 +248,17 @@ const EdcConnector = () => {
     }
   }
 
-  const deleteSelectedConnector = async () => {
+  const deleteSelectedConnector = async (status: boolean) => {
     setAction('delete')
     setLoading(true)
-    await deleteConnector(selectedConnector.id ?? '')
+
+    // Include the deleteServiceAccount query only if the connector is linked to a technical user account
+    await deleteConnector({
+      connectorID: selectedConnector.id ?? '',
+      deleteServiceAccount: selectedConnector.technicalUser
+        ? status
+        : undefined,
+    })
       .unwrap()
       .then(() => {
         setDeleteConnectorConfirmModalOpen(false)
@@ -360,7 +367,7 @@ const EdcConnector = () => {
         handleOverlayClose={() => {
           setDeleteConnectorConfirmModalOpen(false)
         }}
-        handleConfirmClick={() => deleteSelectedConnector()}
+        handleConfirmClick={(s) => deleteSelectedConnector(s)}
         loading={loading}
         techUser={selectedConnector?.technicalUser}
       />

--- a/src/features/connector/connectorApiSlice.ts
+++ b/src/features/connector/connectorApiSlice.ts
@@ -108,6 +108,11 @@ export type updateConnectorUrlType = {
   }
 }
 
+type deleteConnectorArgs = {
+  connectorID: string
+  deleteServiceAccount?: boolean
+}
+
 export const apiSlice = createApi({
   reducerPath: 'rtk/admin/connector',
   baseQuery: fetchBaseQuery(apiBaseQuery()),
@@ -129,11 +134,17 @@ export const apiSlice = createApi({
     fetchConnectorDetails: builder.query<ConnectorDetailsType, string>({
       query: (connectorID) => `/api/administration/Connectors/${connectorID}`,
     }),
-    deleteConnector: builder.mutation<void, string>({
-      query: (connectorID) => ({
-        url: `/api/administration/Connectors/${connectorID}`,
-        method: 'DELETE',
-      }),
+    deleteConnector: builder.mutation<void, deleteConnectorArgs>({
+      query: ({ connectorID, deleteServiceAccount }) => {
+        let queryString = ''
+        if (deleteServiceAccount !== undefined) {
+          queryString = `?deleteServiceAccount=${deleteServiceAccount}`
+        }
+        return {
+          url: `/api/administration/Connectors/${connectorID + '123'}${queryString}`,
+          method: 'DELETE',
+        }
+      },
     }),
     fetchConnectors: builder.query<
       PaginResult<ConnectorResponseBody>,

--- a/src/features/connector/connectorApiSlice.ts
+++ b/src/features/connector/connectorApiSlice.ts
@@ -110,7 +110,7 @@ export type updateConnectorUrlType = {
 
 type deleteConnectorArgs = {
   connectorID: string
-  deleteServiceAccount?: boolean
+  deleteServiceAccount: boolean
 }
 
 export const apiSlice = createApi({
@@ -136,12 +136,8 @@ export const apiSlice = createApi({
     }),
     deleteConnector: builder.mutation<void, deleteConnectorArgs>({
       query: ({ connectorID, deleteServiceAccount }) => {
-        let queryString = ''
-        if (deleteServiceAccount !== undefined) {
-          queryString = `?deleteServiceAccount=${deleteServiceAccount}`
-        }
         return {
-          url: `/api/administration/Connectors/${connectorID}${queryString}`,
+          url: `/api/administration/Connectors/${connectorID}?deleteServiceAccount=${deleteServiceAccount}`,
           method: 'DELETE',
         }
       },

--- a/src/features/connector/connectorApiSlice.ts
+++ b/src/features/connector/connectorApiSlice.ts
@@ -141,7 +141,7 @@ export const apiSlice = createApi({
           queryString = `?deleteServiceAccount=${deleteServiceAccount}`
         }
         return {
-          url: `/api/administration/Connectors/${connectorID + '123'}${queryString}`,
+          url: `/api/administration/Connectors/${connectorID}${queryString}`,
           method: 'DELETE',
         }
       },


### PR DESCRIPTION
## Description

- Updated the title text in overlay popup.
- Modified the logic for keeping the `confirm` delete button enabled in the delete confirmation overlay for the EDC connector.
- Adjusted the API call to include query parameters `deleteServiceAccount` based on checkbox selection
- Removed the delete connector button from the ConnectorManagement Detail overlay page anymore

## Why

- This change improves the functionality of connector deletion. 
- The user should be able to delete the connector without removing the technical user, but we still need to provide the option to delete both

## Issue

#1065  

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have commented my code, particularly in hard-to-understand areas
