### PR TITLE
fix: Display invited company name in OSP consent form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - **App Release Process**:
   - Fixed role upload does not work using Firefox [#1003](https://github.com/eclipse-tractusx/portal-frontend/pull/1003)
     **OSP Consent form**
-  - Display invited company name in OSP consent form (Previously hard coded with 'BMW') [#1083] https://github.com/eclipse-tractusx/portal-frontend/pull/1083
+  - Display invited company name in OSP consent form (Previously hard coded with 'BMW') [#1083](https://github.com/eclipse-tractusx/portal-frontend/pull/1083)
 
 ## 2.2.0-RC2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
   - Fixed 'activeTab' conditions to load data for Tab-2(Registration Process) [#1050](https://github.com/eclipse-tractusx/portal-frontend/pull/1050)
 - **App Release Process**:
   - Fixed role upload does not work using Firefox [#1003](https://github.com/eclipse-tractusx/portal-frontend/pull/1003)
-    **OSP Consent form**
+- **OSP Consent form**
   - Display invited company name in OSP consent form (Previously hard coded with 'BMW') [#1083](https://github.com/eclipse-tractusx/portal-frontend/pull/1083)
 
 ## 2.2.0-RC2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - **App Release Process**:
   - Fixed role upload does not work using Firefox [#1003](https://github.com/eclipse-tractusx/portal-frontend/pull/1003)
     **OSP Consent form**
-  - Display invited company name in OSP consent form (Previous hard coded with 'BMW') [#1083] https://github.com/eclipse-tractusx/portal-frontend/pull/1083
+  - Display invited company name in OSP consent form (Previously hard coded with 'BMW') [#1083] https://github.com/eclipse-tractusx/portal-frontend/pull/1083
 
 ## 2.2.0-RC2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
   - Fixed 'activeTab' conditions to load data for Tab-2(Registration Process) [#1050](https://github.com/eclipse-tractusx/portal-frontend/pull/1050)
 - **App Release Process**:
   - Fixed role upload does not work using Firefox [#1003](https://github.com/eclipse-tractusx/portal-frontend/pull/1003)
+    **OSP Consent form**
+  - Display invited company name in OSP consent form (Previous hard coded with 'BMW') [#1083] https://github.com/eclipse-tractusx/portal-frontend/pull/1083
 
 ## 2.2.0-RC2
 

--- a/src/components/pages/OSPConsent/CompanyDetails.tsx
+++ b/src/components/pages/OSPConsent/CompanyDetails.tsx
@@ -207,7 +207,7 @@ export const CompanyDetails = ({
   }
 
   const tableData: TableType = {
-    head: [t('osp.companyName'), t('osp.bmw')],
+    head: [t('osp.companyName'), companyDetails?.name ?? ''],
     body: [
       [t('osp.street'), companyDetails?.streetName ?? ''],
       [t('osp.zip'), companyDetails?.zipCode ?? ''],


### PR DESCRIPTION
## Description

Company name in OSP form was hardcoded with "BMW"

## Why

Company name in OSP company details form should reflect the actual company

## Issue

#1080 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
