### PR TITLE
feat: add Usertype column to technical user management list

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2327,7 +2327,9 @@
       "alias": "Alias",
       "authMethod": "Auth Method",
       "progress": "Progress",
-      "action": "Action"
+      "action": "Action",
+      "ownership": "Ownership",
+      "userType": "Usertype"
     },
     "actions": {
       "cancel": "Abbrechen",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2302,7 +2302,9 @@
       "alias": "Alias",
       "authMethod": "Auth Method",
       "progress": "Progress",
-      "action": "Action"
+      "action": "Action",
+      "ownership": "Ownership",
+      "userType": "Usertype"
     },
     "actions": {
       "cancel": "Cancel",

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -30,6 +30,7 @@ import {
   ServiceAccountStatus,
   ServiceAccountStatusFilter,
   useFetchServiceAccountListQuery,
+  UserType,
 } from 'features/admin/serviceApiSlice'
 import { useSelector } from 'react-redux'
 import { PAGES } from 'types/Constants'
@@ -49,6 +50,11 @@ type StatusTagColor =
   | 'label'
   | 'deleted'
   | undefined
+
+const userTypeMapping = {
+  [UserType.INTERNAL]: 'INTERNAL',
+  [UserType.EXTERNAL]: 'EXTERNAL',
+}
 
 export const TechnicalUserTable = () => {
   const { t } = useTranslation()
@@ -128,36 +134,43 @@ export const TechnicalUserTable = () => {
           {
             field: 'name',
             headerName: t('global.field.userName'),
-            flex: 2,
+            flex: 1.8,
           },
           {
             field: 'clientId',
             headerName: t('global.field.clientId'),
-            flex: 1,
+            flex: 1.1,
           },
           {
             field: 'serviceAccountType',
-            headerName: t('global.field.type'),
+            headerName: t('global.field.ownership'),
+            flex: 1.15,
+          },
+          {
+            field: 'usertype',
+            headerName: t('global.field.userType'),
             flex: 1.2,
+            valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
+              userTypeMapping[row.usertype] || '-',
           },
           {
             field: 'offer',
             headerName: t('global.field.offerLink'),
-            flex: 1.5,
+            flex: 1.2,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.offer ? row.offer?.name : '',
           },
           {
             field: 'isOwner',
             headerName: t('global.field.owner'),
-            flex: 0.8,
+            flex: 0.9,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.isOwner ? 'Yes' : 'No',
           },
           {
             field: 'status',
             headerName: t('global.field.status'),
-            flex: 1.2,
+            flex: 1.25,
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <StatusTag
                 color={statusColorMap[row.status]}
@@ -170,7 +183,7 @@ export const TechnicalUserTable = () => {
           {
             field: 'details',
             headerName: t('global.field.details'),
-            flex: 1,
+            flex: 0.9,
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <>
                 <IconButton

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -56,12 +56,17 @@ export enum ServiceAccountStatus {
   PENDING_DELETION = 'PENDING_DELETION',
 }
 
+export enum UserType {
+  INTERNAL = 'internal',
+  EXTERNAL = 'external',
+}
 export interface ServiceAccountListEntry {
   serviceAccountId: string
   clientId: string
   name: string
   status: ServiceAccountStatus
   isOwner?: boolean
+  usertype: UserType
   offer?: {
     name?: string
   }


### PR DESCRIPTION
## Description

This PR introduces a new column named `Usertype` in the `technicalUserManagement` table. The column is positioned between `Type` (renamed to `Ownership`) and `Offer Link`.

**Key Changes:**
- Added the `Usertype` column to display the usertype value.
- Updated the `Type` column to `Ownership`.
- Ensured the layout remains responsive after the addition of the `Usertype` column.
- Ensured that the page gracefully handles missing or incorrect data without breaking functionality.

**Dependency:**
This change depends on the backend update to include the **`usertype`** field in the API response from **`GET: api/administration/serviceaccount/owncompany/serviceaccounts`**. The backend implementation for this feature is tracked under [sig#789 - API Expansion for Technical User Information portal-backend#976](https://github.com/eclipse-tractusx/portal-backend/issues/976).


 **⚠️ Please review and merge once the backend implementation is complete and the `Usertype` data is available.**
## Why

To enhance clarity by adding a `Usertype` column and renaming `Type` to `Ownership` in the technical user management list. 
## Issue

[1082](https://github.com/eclipse-tractusx/portal-frontend/issues/1082)

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally