### PR TITLE
fix(company data): disable csv upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Fix broken title and description section
 - Company data
   - Fix translation error
+  - Disable csv upload
 
 ### Change
 

--- a/src/components/pages/CompanyData/components/CompanyAddressList.tsx
+++ b/src/components/pages/CompanyData/components/CompanyAddressList.tsx
@@ -45,9 +45,6 @@ import {
   setSharingStateInfo,
 } from 'features/companyData/slice'
 import { statusColorMap } from 'utils/dataMapper'
-import { show } from 'features/control/overlay'
-import { OVERLAYS } from 'types/Constants'
-import UploadIcon from '@mui/icons-material/Upload'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 
 export const CompanyAddressList = ({
@@ -197,11 +194,6 @@ export const CompanyAddressList = ({
                 handleSecondButtonClick()
               },
               icon: <AddCircleOutlineIcon />,
-            },
-            {
-              title: t('content.companyData.csvUploadBtn'),
-              click: () => dispatch(show(OVERLAYS.CSV_UPLOAD_OVERLAY)),
-              icon: <UploadIcon />,
             },
           ]}
           autoFocus={false}


### PR DESCRIPTION
## Description

disable csv upload button in company data page

## Why

csv upload is not fully functional

## Issue

after upload, sites/address are moving to INITIAL state

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
