### PR TITLE
fix(OSP): Consent form 400 submission error 

### DIFF
--- a/src/components/pages/OSPConsent/CompanyDetails.tsx
+++ b/src/components/pages/OSPConsent/CompanyDetails.tsx
@@ -35,6 +35,7 @@ import {
   type companyRole,
   useFetchAgreementConsentsQuery,
   type AgreementData,
+  type SubmitData,
 } from 'features/registration/registrationApiSlice'
 import { getApiBase } from 'services/EnvironmentService'
 import UserService from 'services/UserService'
@@ -46,6 +47,7 @@ interface CompanyDetailsProps {
   loading: boolean
   handleSubmit: () => void
   submitError: boolean
+  updateConsents: (data: SubmitData) => void
 }
 
 export const CompanyDetails = ({
@@ -53,6 +55,7 @@ export const CompanyDetails = ({
   loading,
   handleSubmit,
   submitError,
+  updateConsents,
 }: CompanyDetailsProps) => {
   const tm = useTranslation().t
   const { t } = useTranslation('registration')
@@ -75,6 +78,13 @@ export const CompanyDetails = ({
   const { data: consentData } = useFetchAgreementConsentsQuery(
     applicationId ?? ''
   )
+
+  useEffect(() => {
+    updateConsents({
+      roles: companyRoleChecked,
+      consents: agreementChecked,
+    })
+  }, [companyRoleChecked, agreementChecked])
 
   useEffect(() => {
     updateSelectedRolesAndAgreement()

--- a/src/components/pages/OSPConsent/index.tsx
+++ b/src/components/pages/OSPConsent/index.tsx
@@ -26,6 +26,7 @@ import {
   useFetchAgreementConsentsQuery,
   useUpdateAgreementConsentsMutation,
   CONSENT_STATUS,
+  type SubmitData,
 } from 'features/registration/registrationApiSlice'
 import './style.scss'
 import { SuccessRegistration } from './SuccessRegistration'
@@ -76,6 +77,11 @@ export const OSPConsent = () => {
           return { ...prev, [next.agreementId]: true }
         }, {})
       )
+  }
+
+  const setConsents = (data: SubmitData) => {
+    setCompanyRoleChecked(data.roles)
+    setAgreementChecked(data.consents)
   }
 
   const handleSubmit = async () => {
@@ -131,6 +137,7 @@ export const OSPConsent = () => {
           loading={loading}
           handleSubmit={handleSubmit}
           submitError={submitError}
+          updateConsents={setConsents}
         />
       )
     }

--- a/src/features/registration/registrationApiSlice.ts
+++ b/src/features/registration/registrationApiSlice.ts
@@ -111,6 +111,11 @@ export type companyRole = {
   descriptions: { de: string; en: string }
 }
 
+export type SubmitData = {
+  roles: { [key: string]: boolean }
+  consents: { [key: string]: boolean }
+}
+
 export enum CONSENT_STATUS {
   ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',


### PR DESCRIPTION
## Description

- Updated companyDetails component to return data to parent
- Added new type

## Why

OSP invitee could not submit consent from due to 400 error. Check box data in child component was not being passed back into parent where submission api was being called,  resulting in a request being sent without the correct data. 

## Issue

#1079 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
