### PR TITLE
fix(serviceAdminBoard): detail page responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   - Display technicalUserManagement button based on role validation [#1073](https://github.com/eclipse-tractusx/portal-frontend/pull/1073)
 - **OSP Consent form**
   - Display invited company name in OSP consent form (Previously hard coded with 'BMW') [#1083](https://github.com/eclipse-tractusx/portal-frontend/pull/1083)
+- **Admin Service Management**
+  - Resolved service title overlap and improved responsiveness on the admin service detail page [#1112](https://github.com/eclipse-tractusx/portal-frontend/pull/1112)
 
 ## 2.2.0
 

--- a/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
+++ b/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
@@ -17,29 +17,48 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+@import 'src/components/styles/_breakpoints';
+
 .service-admin-board-detail {
-  min-width: 1440px;
+  max-width: 1000px;
+  margin: 60px auto 0;
+  width: calc(100% - 30px);
+
+  @include media-breakpoint-up(minDesktop) {
+    margin-top: 0;
+    width: 100%;
+  }
+
   .service-back {
     height: 140px;
-    padding: 48px 256px 48px 160px;
+    padding: 48px 0px;
+    @include media-breakpoint-up(minDesktop) {
+      margin-left: -75px;
+    }
   }
   .service-content {
-    padding: 0px 256px 0px 256px;
     .divider-height {
       height: 39px;
     }
     .service-board-header {
-      width: 928px;
-      height: 288px;
       display: flex;
       flex-wrap: wrap;
+      align-items: center;
+      justify-content: center;
+      gap: 48px;
+
+      @include media-breakpoint-up(lg) {
+        min-width: 928px;
+        height: 288px;
+        gap: 56px;
+      }
+
       .lead-image > img {
         border-radius: 16px;
+        max-width: 100%;
         width: 412px;
-        height: 288px;
       }
       .service-app-content {
-        padding: 68px 0 68px 56px;
         flex: 1;
       }
     }

--- a/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
+++ b/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
@@ -17,14 +17,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+
 @import 'src/components/styles/_breakpoints';
+@import 'src/components/styles/_colors';
 
 .service-admin-board-detail {
   max-width: 1000px;
   margin: 60px auto 0;
-  width: calc(100% - 30px);
+  width: calc(100% - 40px);
 
-  @include media-breakpoint-up(minDesktop) {
+  @include media-breakpoint-up(xxl-sm) {
     margin-top: 0;
     width: 100%;
   }
@@ -32,7 +34,7 @@
   .service-back {
     height: 140px;
     padding: 48px 0px;
-    @include media-breakpoint-up(minDesktop) {
+    @include media-breakpoint-up(xxl-sm) {
       margin-left: -75px;
     }
   }
@@ -64,7 +66,7 @@
     }
     .service-documents {
       padding: 10px 18px;
-      color: #0f71cb !important;
+      color: color('primary') !important;
       display: flex;
     }
     .document-button-link {
@@ -74,7 +76,7 @@
       cursor: pointer;
       line-height: 20px;
       padding: 0;
-      color: #0f71cb !important;
+      color: color('primary') !important;
     }
   }
 }

--- a/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
+++ b/src/components/pages/AdminBoardDetail/AdminBoardDetail.scss
@@ -40,6 +40,7 @@
       }
       .service-app-content {
         padding: 68px 0 68px 56px;
+        flex: 1;
       }
     }
     .service-documents {

--- a/src/components/styles/_breakpoints.scss
+++ b/src/components/styles/_breakpoints.scss
@@ -25,6 +25,7 @@ $breakpoints: (
   lg: 1056px,
   xl: 1312px,
   xxl: 1584px,
+  minDesktop: 1500px,
 );
 
 @mixin media-breakpoint-up($name) {

--- a/src/components/styles/_breakpoints.scss
+++ b/src/components/styles/_breakpoints.scss
@@ -24,8 +24,8 @@ $breakpoints: (
   md: 627px,
   lg: 1056px,
   xl: 1312px,
+  xxl-sm: 1500px,
   xxl: 1584px,
-  minDesktop: 1500px,
 );
 
 @mixin media-breakpoint-up($name) {


### PR DESCRIPTION
## Description

ServiceAdminBoardDetails page : 
- Resolved UI issue on the ServiceAdminBoardDetails page where long service titles caused layout distortion.
- Refined styling to ensure the page remains fully responsive across different screen sizes.

## Why

- To enhance the page's responsiveness and ensure a better user experience across devices.

## Issue

#1107 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally