### PR TITLE
fix: update type issues caused by the removal of 'any' type in shared components

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -601,7 +601,7 @@ npm/npmjs/@babel/template/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@babel/traverse/7.24.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13926
 npm/npmjs/@babel/types/7.24.0, MIT, approved, clearlydefined
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/3.5.2, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #16079
+npm/npmjs/@catena-x/portal-shared-components/3.6.1, Apache-2.0 AND CC-BY-4.0 AND OFL-1.1, approved, #16144
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
 npm/npmjs/@date-io/core/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/@date-io/date-fns/3.0.0, MIT, approved, #14023

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^3.5.1",
+    "@catena-x/portal-shared-components": "^3.6.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@hookform/error-message": "^2.0.1",

--- a/src/components/overlays/OSPRegister/OSPRegisterContent.tsx
+++ b/src/components/overlays/OSPRegister/OSPRegisterContent.tsx
@@ -338,7 +338,7 @@ const OSPRegisterForm = ({
             variant: 'filled',
             clearText: 'clear',
             keyTitle: 'id',
-            onChangeItem: (value: ItemType): void => {
+            onChangeItem: (value): void => {
               updateData({
                 ...data,
                 uniqueIds: [

--- a/src/components/overlays/UpdateCertificate/index.tsx
+++ b/src/components/overlays/UpdateCertificate/index.tsx
@@ -259,7 +259,7 @@ export default function UpdateCertificate() {
                               )
                         }
                         onChangeItem={(e) => {
-                          setSelectedCertificate(e.title)
+                          setSelectedCertificate(e.title as string)
                         }}
                         keyTitle={'title'}
                         disabled={certificatetypesArr.length === 1}

--- a/src/components/pages/CompanyCertificates/UploadCompanyCerificate.tsx
+++ b/src/components/pages/CompanyCertificates/UploadCompanyCerificate.tsx
@@ -155,8 +155,8 @@ export default function UploadCompanyCertificate({
                       'content.companyCertificate.upload.certificateTypePlaceholder'
                     )
               }
-              onChangeItem={(e: CertificateTypes) => {
-                setSelectedCertificateType(e)
+              onChangeItem={(e) => {
+                setSelectedCertificateType(e as CertificateTypes)
               }}
               keyTitle={'certificateType'}
               disabled={certificateTypes?.length === 1}

--- a/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
@@ -748,7 +748,7 @@ export default function AppMarketCard() {
                   'content.apprelease.appMarketCard.salesManagerPlaceholder'
                 )}
                 onChangeItem={(e) => {
-                  e && onSalesManagerChange(e.userId)
+                  e && onSalesManagerChange(e.userId as string)
                 }}
                 keyTitle={'fullName'}
               />

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/index.tsx
@@ -500,7 +500,7 @@ export default function TechnicalIntegration() {
                       'content.apprelease.technicalIntegration.encoding'
                     )}
                     onChangeItem={(e) => {
-                      setSelectedEncoding(e.value)
+                      setSelectedEncoding(e.value as string)
                     }}
                     keyTitle={'title'}
                     disableClearable={true}

--- a/src/components/shared/basic/ReleaseProcess/components/ConnectorFormInputField.tsx
+++ b/src/components/shared/basic/ReleaseProcess/components/ConnectorFormInputField.tsx
@@ -136,9 +136,7 @@ any) => {
               value={value}
               items={items}
               keyTitle={keyTitle}
-              // Add an ESLint exception until there is a solution
-              // eslint-disable-next-line
-              onAddItem={(items: any[]) => {
+              onAddItem={(items) => {
                 trigger(name)
                 onChange(items?.map((item) => item[saveKeyTitle]))
               }}

--- a/src/components/shared/templates/StaticTemplateResponsive/Cards/RenderImage.tsx
+++ b/src/components/shared/templates/StaticTemplateResponsive/Cards/RenderImage.tsx
@@ -20,8 +20,8 @@
 
 import { ImageItem } from '@catena-x/portal-shared-components'
 import { useMediaQuery } from '@mui/material'
+import { type CSSProperties } from 'react'
 import '../StaticTemplate.scss'
-import { type SxProps } from '@mui/system'
 
 export default function RenderImage({
   url,
@@ -30,7 +30,7 @@ export default function RenderImage({
   width,
 }: Readonly<{
   url: string
-  additionalStyles?: SxProps
+  additionalStyles?: CSSProperties
   height?: string
   width?: string
 }>) {

--- a/src/features/companyCertification/companyCertificateApiSlice.tsx
+++ b/src/features/companyCertification/companyCertificateApiSlice.tsx
@@ -45,7 +45,7 @@ export interface UploadDocumentType {
   expiryDate: string | undefined
 }
 
-export interface CertificateTypes {
+export type CertificateTypes = {
   certificateType: string
   certificateVersion: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -329,10 +329,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-3.5.1.tgz#d2caf4acf4c0197bca392054e0b9f8f1b451b704"
-  integrity sha512-xWAqM2FuTTBF3Koyjkvf1ZJi36DDwDuXin3nlkbB8hRwBKKV5fWLGQN+3bcwCoA6quNK/Juj7PQ2BYYqrQEDRw==
+"@catena-x/portal-shared-components@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-3.6.1.tgz#750438522b65d4c59976404044cd75fd5883649c"
+  integrity sha512-mmOETT9z3vDSa/xyM1i+F2N9k20GuqXuW54oF/I7FB7iHAegJbNedj0gaFH4E7LHJQGP9vHtGQ6J4X73ndrsRg==
   dependencies:
     "@date-io/date-fns" "^3.0.0"
     "@emotion/react" "^11.11.4"


### PR DESCRIPTION
## Description

Fix type errors caused by type changes in shared components.

**Reference:**
- Removal of `any` type: [PR #312](https://github.com/eclipse-tractusx/portal-shared-components/pull/312)

## Why

- The shared components now use stricter types for improved type safety.
- Updating the code ensures consistency and prevents type-related issues with the shared components.
- Avoids runtime errors and ensures the app functions correctly after the shared component updates.

## Issue

[1110](https://github.com/eclipse-tractusx/portal-frontend/issues/1110)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally