### PR TITLE
fix: filter out roles not defined by OSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - Display technicalUserManagement button based on role validation [#1073](https://github.com/eclipse-tractusx/portal-frontend/pull/1073)
 - **OSP Consent form**
   - Display invited company name in OSP consent form (Previously hard coded with 'BMW') [#1083](https://github.com/eclipse-tractusx/portal-frontend/pull/1083)
+  - Filter out roles not defined by OSP [#1114](https://github.com/eclipse-tractusx/portal-frontend/pull/1114)
 
 ## 2.2.0
 

--- a/src/components/pages/OSPConsent/CompanyDetails.tsx
+++ b/src/components/pages/OSPConsent/CompanyDetails.tsx
@@ -237,37 +237,45 @@ export const CompanyDetails = ({
           {t('osp.companyRole.subTitle')}
         </Typography>
         <div className="rolesList">
-          {allConsentData?.companyRoles.map((role) => (
-            <div
-              className="companyRole-section"
-              key={uniqueId(role.companyRole)}
-            >
-              <div className="role-checkbox-row">
-                <div className="role-checkbox">
-                  <Checkbox
-                    label=""
-                    onChange={() => {
-                      handleCompanyRoleCheck(role.companyRole)
-                    }}
-                    checked={companyRoleChecked?.[role.companyRole]}
-                  />
-                </div>
-                <div className="role-checkbox-text">
-                  <Typography
-                    variant={isMobile ? 'label2' : 'label1'}
-                    className="company-heading"
-                  >
-                    {t(`osp.companyRole.${role.companyRole}`)}
-                  </Typography>
-                  <Typography variant={isMobile ? 'body3' : 'body2'}>
-                    {role.descriptions['en' as keyof typeof role.descriptions]}
-                  </Typography>
-                  {companyRoleChecked?.[role.companyRole] &&
-                    renderTermsSection(role)}
+          {allConsentData?.companyRoles
+            .filter((role) =>
+              consentData?.companyRoles.includes(role.companyRole)
+            )
+            .map((role) => (
+              <div
+                className="companyRole-section"
+                key={uniqueId(role.companyRole)}
+              >
+                <div className="role-checkbox-row">
+                  <div className="role-checkbox">
+                    <Checkbox
+                      label=""
+                      onChange={() => {
+                        handleCompanyRoleCheck(role.companyRole)
+                      }}
+                      checked={companyRoleChecked?.[role.companyRole]}
+                    />
+                  </div>
+                  <div className="role-checkbox-text">
+                    <Typography
+                      variant={isMobile ? 'label2' : 'label1'}
+                      className="company-heading"
+                    >
+                      {t(`osp.companyRole.${role.companyRole}`)}
+                    </Typography>
+                    <Typography variant={isMobile ? 'body3' : 'body2'}>
+                      {
+                        role.descriptions[
+                          'en' as keyof typeof role.descriptions
+                        ]
+                      }
+                    </Typography>
+                    {companyRoleChecked?.[role.companyRole] &&
+                      renderTermsSection(role)}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            ))}
         </div>
         {submitError && (
           <Typography variant="body3" className="submitError">


### PR DESCRIPTION
## Description

- Added filter function to only show pre-selected roles from OSP

## Why

User should not be able to select roles that were not pre-selected by the OSP

## Issue

#1109 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

