### PR TITLE
fix(UI): remove tag from app detail component

### DIFF
--- a/src/components/pages/AppDetail/AppDetailContentDetails.tsx
+++ b/src/components/pages/AppDetail/AppDetailContentDetails.tsx
@@ -30,7 +30,6 @@ import AppDetailHeader from './components/AppDetailHeader'
 import AppDetailPrivacy from './components/AppDetailPrivacy'
 import AppDetailDocuments from './components/AppDetailDocuments'
 import AppDetailProvider from './components/AppDetailProvider'
-import AppDetailTags from './components/AppDetailTags'
 import type { AppDetails } from 'features/apps/types'
 import './AppDetail.scss'
 import CommonService from 'services/CommonService'
@@ -76,10 +75,6 @@ export default function AppDetailContentDetails({
     {
       href: '#provider-info',
       title: t('content.appdetail.providerInformation.heading'),
-    },
-    {
-      href: '#tags',
-      title: t('content.appdetail.tags'),
     },
   ]
 
@@ -137,7 +132,6 @@ export default function AppDetailContentDetails({
           <AppDetailTechUserSetup item={item} />
           <AppDetailProvider item={item} />
           <div className="divider-height" />
-          <AppDetailTags item={item} />
           <div className="divider-height" />
         </div>
       </>


### PR DESCRIPTION
## Description
The Tag title for the Tag section in App detail component need to be remove because of no any functional need to display.

## Why
we don't have any functional data to display and as per UX request this section need to be removed.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1121


## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
