### PR TITLE
fix(connector management): fix details overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bugfixes
+
+- **Connector Management**
+  - fixed overaly enabling on click of managed connectors(details)
+
 ## 2.2.0-alpha.1
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugfixes
 
 - **Connector Management**
-  - fixed overaly enabling on click of managed connectors(details)
+  - fixed overlay enabling on click of managed connectors(details) [#1142](https://github.com/eclipse-tractusx/portal-frontend/pull/1142)
 
 ## 2.2.0-alpha.1
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -759,8 +759,8 @@ npm/npmjs/@types/lodash/4.17.7, MIT, approved, clearlydefined
 npm/npmjs/@types/node/20.11.30, MIT, approved, #13826
 npm/npmjs/@types/papaparse/5.3.14, MIT, approved, #10964
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.11, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.11, MIT, approved, #16176
+npm/npmjs/@types/prop-types/15.7.12, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.15, MIT, approved, #14071
 npm/npmjs/@types/react-dom/18.2.22, MIT, approved, #8256
 npm/npmjs/@types/react-redux/7.1.33, MIT, approved, #10970

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -158,16 +158,12 @@ const EdcConnector = () => {
     setAddConnectorOverlayOpen(false)
   }
 
-  const onTableCellClick = (params: GridCellParams, title: string) => {
+  const onTableCellClick = (params: GridCellParams) => {
     // Show overlay only when detail field clicked
-    if (
-      params.field === 'details' &&
-      title === t('content.edcconnector.tabletitle')
-    ) {
+    if (params.field === 'details') {
       setOpenDetailsOverlay(true)
       setOverlayData(params.row)
     }
-
     setSelectedConnector(params.row as ConnectorContentAPIResponse)
   }
 
@@ -508,7 +504,7 @@ const EdcConnector = () => {
               getRowId={(row: { [key: string]: string }) => row.id}
               columns={ownConnectorCols}
               onCellClick={(params: GridCellParams) => {
-                onTableCellClick(params, t('content.edcconnector.tabletitle'))
+                onTableCellClick(params)
               }}
             />
           </div>
@@ -525,10 +521,7 @@ const EdcConnector = () => {
               columns={managedConnectorCols}
               noRowsMsg={t('content.edcconnector.noConnectorsMessage')}
               onCellClick={(params: GridCellParams) => {
-                onTableCellClick(
-                  params,
-                  t('content.edcconnector.managedtabletitle')
-                )
+                onTableCellClick(params)
               }}
             />
           </div>


### PR DESCRIPTION
## Description

Fixed overlay enabling on click of managed connectors(details)

## Why

When user clicks on managed connectors(details), overlay should open to display further connector details

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1014

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
