### PR TITLE
feat(company data): re-enable csv upload and revert setting of ready state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - **Company Subscriptions**
   - update API query parameters and fix tab UI scroll [#1131](https://github.com/eclipse-tractusx/portal-frontend/pull/1131)
 - **Customer Data**
-  - re-enable CSV upload [#1144](https://github.com/eclipse-tractusx/portal-frontend/pull/1144)
+  - re-enabled CSV upload [#1144](https://github.com/eclipse-tractusx/portal-frontend/pull/1144)
   - reverted manual intervention with ready state api [#1144](https://github.com/eclipse-tractusx/portal-frontend/pull/1144)
 - **Onboarding Service Provider**
   - enhanced permission and company role validation for Onboarding Service Provider [#1176](https://github.com/eclipse-tractusx/portal-frontend/pull/1176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Customer Data**
+  - Enable CSV upload
+
 ## 2.2.0-alpha.1
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - **Company Subscriptions**
   - update API query parameters and fix tab UI scroll [#1131](https://github.com/eclipse-tractusx/portal-frontend/pull/1131)
 - **Customer Data**
-  - Enable CSV upload
-  - Revert manual intervention of ready state api
+  - re-enable CSV upload [#1144](https://github.com/eclipse-tractusx/portal-frontend/pull/1144)
+  - reverted manual intervention with ready state api [#1144](https://github.com/eclipse-tractusx/portal-frontend/pull/1144)
 - **Onboarding Service Provider**
   - enhanced permission and company role validation for Onboarding Service Provider [#1176](https://github.com/eclipse-tractusx/portal-frontend/pull/1176)
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -759,8 +759,8 @@ npm/npmjs/@types/lodash/4.17.7, MIT, approved, clearlydefined
 npm/npmjs/@types/node/20.11.30, MIT, approved, #13826
 npm/npmjs/@types/papaparse/5.3.14, MIT, approved, #10964
 npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.11, MIT, approved, clearlydefined
-npm/npmjs/@types/prop-types/15.7.12, MIT, approved, clearlydefined
+npm/npmjs/@types/prop-types/15.7.11, MIT, approved, #16176
+npm/npmjs/@types/prop-types/15.7.12, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.15, MIT, approved, #14071
 npm/npmjs/@types/react-dom/18.2.22, MIT, approved, #8256
 npm/npmjs/@types/react-redux/7.1.33, MIT, approved, #10970

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -609,16 +609,16 @@ npm/npmjs/@emotion/babel-plugin/11.11.0, MIT, approved, #8386
 npm/npmjs/@emotion/cache/11.11.0, MIT, approved, #8401
 npm/npmjs/@emotion/hash/0.9.1, MIT, approved, #8394
 npm/npmjs/@emotion/hash/0.9.2, MIT, approved, #8394
-npm/npmjs/@emotion/is-prop-valid/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/is-prop-valid/1.3.0, MIT AND (BSD-2-Clause AND MIT), approved, #16339
 npm/npmjs/@emotion/memoize/0.8.1, MIT, approved, #8408
 npm/npmjs/@emotion/memoize/0.9.0, MIT, approved, clearlydefined
 npm/npmjs/@emotion/react/11.11.4, MIT AND (BSD-3-Clause AND MIT), approved, #8931
-npm/npmjs/@emotion/serialize/1.3.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/serialize/1.3.0, MIT AND (BSD-2-Clause AND MIT), approved, #16340
 npm/npmjs/@emotion/sheet/1.2.2, MIT, approved, #8389
 npm/npmjs/@emotion/styled/11.11.5, MIT, approved, clearlydefined
 npm/npmjs/@emotion/unitless/0.9.0, MIT, approved, clearlydefined
 npm/npmjs/@emotion/use-insertion-effect-with-fallbacks/1.0.1, MIT, approved, #8419
-npm/npmjs/@emotion/utils/1.4.0, MIT, approved, clearlydefined
+npm/npmjs/@emotion/utils/1.4.0, MIT AND (BSD-2-Clause AND MIT), approved, #16344
 npm/npmjs/@emotion/weak-memoize/0.3.1, MIT, approved, #8402
 npm/npmjs/@esbuild/aix-ppc64/0.20.2, MIT, approved, clearlydefined
 npm/npmjs/@esbuild/android-arm/0.20.2, Apache-2.0 AND MIT AND BSD-3-Clause AND (BSD-2-Clause AND BSD-3-Clause), approved, #15302

--- a/src/components/pages/CompanyData/components/CompanyAddressList.tsx
+++ b/src/components/pages/CompanyData/components/CompanyAddressList.tsx
@@ -46,6 +46,9 @@ import {
 } from 'features/companyData/slice'
 import { statusColorMap } from 'utils/dataMapper'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
+import { show } from 'features/control/overlay'
+import { OVERLAYS } from 'types/Constants'
+import UploadIcon from '@mui/icons-material/Upload'
 
 export const CompanyAddressList = ({
   handleButtonClick,
@@ -194,6 +197,11 @@ export const CompanyAddressList = ({
                 handleSecondButtonClick()
               },
               icon: <AddCircleOutlineIcon />,
+            },
+            {
+              title: t('content.companyData.csvUploadBtn'),
+              click: () => dispatch(show(OVERLAYS.CSV_UPLOAD_OVERLAY)),
+              icon: <UploadIcon />,
             },
           ]}
           autoFocus={false}

--- a/src/components/pages/CompanyData/components/EditForm.tsx
+++ b/src/components/pages/CompanyData/components/EditForm.tsx
@@ -35,7 +35,6 @@ import {
   type CompanyDataType,
   useUpdateCompanySiteAndAddressMutation,
   type CompanyDataFieldsType,
-  useUpdateCompanyStatusToReadyMutation,
 } from 'features/companyData/companyDataApiSlice'
 import { useSelector } from 'react-redux'
 import {
@@ -68,7 +67,6 @@ export default function EditForm({
   const [loading, setLoading] = useState<boolean>(false)
   const [isValid, setIsValid] = useState<boolean>(false)
   const [updateData] = useUpdateCompanySiteAndAddressMutation()
-  const [updateReadyState] = useUpdateCompanyStatusToReadyMutation()
   const companyData = useSelector(companyDataSelector)
   const [success, setSuccess] = useState<boolean>(false)
   const [error, setError] = useState<boolean>(false)
@@ -123,11 +121,9 @@ export default function EditForm({
     }
   }
 
-  const updateStateToReady = async (response: CompanyDataType[]) => {
+  const handleCreation = async () => {
     try {
-      await updateReadyState({
-        externalIds: [response[0].externalId],
-      })
+      await updateData([input])
         .unwrap()
         .then(() => {
           setSuccess(true)
@@ -136,19 +132,6 @@ export default function EditForm({
       setError(true)
     }
     setLoading(false)
-  }
-
-  const handleCreation = async () => {
-    try {
-      await updateData([input])
-        .unwrap()
-        .then((response) => {
-          updateStateToReady(response)
-        })
-    } catch (e) {
-      setError(true)
-      setLoading(false)
-    }
   }
 
   const getTitle = () => {


### PR DESCRIPTION
## Description

enable csv upload in company data page and reverted manual intervention with ready state api introduced with https://github.com/eclipse-tractusx/portal-frontend/pull/958

## Why

enabled feature is needed for R24.12 and setting of ready state is now taken care of from BDPM side due to changed configuration

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/955

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
