### PR TITLE
fix: display technical role description correctly on small screen

### DIFF
--- a/src/components/overlays/AddTechnicalUser/TechnicalUserAddForm.scss
+++ b/src/components/overlays/AddTechnicalUser/TechnicalUserAddForm.scss
@@ -37,7 +37,6 @@
   display: grid;
 
   .roleDescription {
-    line-height: 0;
-    margin: 5px 27px 20px;
+    margin: -5px 27px 10px;
   }
 }


### PR DESCRIPTION
## Description

Fixed the issue where the technical role description was overlapping on small screens by adjusting the CSS to ensure proper text wrapping.

## Why

To prevent text from overlapping and ensure a clean, readable layout on smaller screens.

## Issue

[1146](https://github.com/eclipse-tractusx/portal-frontend/issues/1146)
## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally