### PR TITLE
fix(technical user table): prevent overlap between text and sort icon

### DIFF
--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -110,7 +110,7 @@ export const TechnicalUserTable = () => {
                 paddingLeft: '32px',
               },
               '&:last-child': {
-                paddingRight: '28px',
+                paddingRight: '25px',
               },
             },
         }}
@@ -139,12 +139,12 @@ export const TechnicalUserTable = () => {
           {
             field: 'clientId',
             headerName: t('global.field.clientId'),
-            flex: 1.1,
+            flex: 1.15,
           },
           {
             field: 'serviceAccountType',
             headerName: t('global.field.ownership'),
-            flex: 1.15,
+            flex: 1.2,
           },
           {
             field: 'usertype',
@@ -156,21 +156,21 @@ export const TechnicalUserTable = () => {
           {
             field: 'offer',
             headerName: t('global.field.offerLink'),
-            flex: 1.3,
+            flex: 1.25,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.offer ? row.offer?.name : '',
           },
           {
             field: 'isOwner',
             headerName: t('global.field.owner'),
-            flex: 1.1,
+            flex: 1,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.isOwner ? 'Yes' : 'No',
           },
           {
             field: 'status',
             headerName: t('global.field.status'),
-            flex: 1.25,
+            flex: 1,
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <StatusTag
                 color={statusColorMap[row.status]}
@@ -183,7 +183,7 @@ export const TechnicalUserTable = () => {
           {
             field: 'details',
             headerName: t('global.field.details'),
-            flex: 1,
+            flex: 1.1,
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <>
                 <IconButton

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -102,6 +102,18 @@ export const TechnicalUserTable = () => {
         searchExpr={expr}
         hasBorder={false}
         rowHeight={80}
+        sx={{
+          '.MuiDataGrid-columnHeader, .MuiDataGrid-row .MuiDataGrid-cell[role="cell"]':
+            {
+              padding: '0 15px',
+              '&:first-child': {
+                paddingLeft: '32px',
+              },
+              '&:last-child': {
+                paddingRight: '28px',
+              },
+            },
+        }}
         defaultFilter={group}
         columnHeadersBackgroundColor={'transparent'}
         toolbarVariant={'searchAndFilter'}
@@ -144,14 +156,14 @@ export const TechnicalUserTable = () => {
           {
             field: 'offer',
             headerName: t('global.field.offerLink'),
-            flex: 1.2,
+            flex: 1.3,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.offer ? row.offer?.name : '',
           },
           {
             field: 'isOwner',
             headerName: t('global.field.owner'),
-            flex: 0.9,
+            flex: 1.1,
             valueGetter: ({ row }: { row: ServiceAccountListEntry }) =>
               row.isOwner ? 'Yes' : 'No',
           },
@@ -171,7 +183,7 @@ export const TechnicalUserTable = () => {
           {
             field: 'details',
             headerName: t('global.field.details'),
-            flex: 0.9,
+            flex: 1,
             renderCell: ({ row }: { row: ServiceAccountListEntry }) => (
               <>
                 <IconButton


### PR DESCRIPTION
## Description

The following changes have been made:
- Adjusted the **column width** to ensure that the header text displays with an ellipsis (...) when necessary.
- Ensured that the **sort icon** remains visible and properly aligned next to the truncated text without any overlap.
- Tooltip functionality remains intact to display the full header text on hover.

## Why

The previous layout caused the sort icon to overlap with the column header, making both the text and the sort icon difficult to read and use. By adjusting the width and ensuring proper alignment, we maintain the clean and professional appearance of the UI while also improving the usability of the column sorting feature
## Issue

[#1158](https://github.com/eclipse-tractusx/portal-frontend/issues/1158)
## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally