### PR TITLE
fix: disable My Apps button for users without permission

### DIFF
--- a/src/components/pages/Home/components/StageSection/index.tsx
+++ b/src/components/pages/Home/components/StageSection/index.tsx
@@ -22,6 +22,8 @@ import { useTranslation } from 'react-i18next'
 import { getAssetBase } from 'services/EnvironmentService'
 import { SlidingMainHeader } from 'components/shared/frame/SlidingMainHeader/SlidingMainHeader'
 import { useNavigate } from 'react-router-dom'
+import { userHasPortalRole } from 'services/AccessService'
+import { ROLES } from 'types/Constants'
 
 export default function StageSection() {
   const { t } = useTranslation()
@@ -39,6 +41,7 @@ export default function StageSection() {
             handleClick: () => {
               navigate(t('content.home.stage.slider1.navigation'))
             },
+            hasAccess: userHasPortalRole(ROLES.APPMANAGEMENT_VIEW),
           },
           {
             title: t('content.home.stage.slider2.title'),
@@ -57,6 +60,7 @@ export default function StageSection() {
             handleClick: () => {
               navigate(t('content.home.stage.slider3.navigation'))
             },
+            hasAccess: userHasPortalRole(ROLES.APPSTORE_VIEW),
           },
           {
             title: t('content.home.stage.slider4.title'),
@@ -66,6 +70,7 @@ export default function StageSection() {
             handleClick: () => {
               navigate(t('content.home.stage.slider4.navigation'))
             },
+            hasAccess: userHasPortalRole(ROLES.USERMANAGEMENT_VIEW),
           },
         ]}
         stageHeaderInfo={[

--- a/src/components/shared/frame/SlidingMainHeader/Header.tsx
+++ b/src/components/shared/frame/SlidingMainHeader/Header.tsx
@@ -31,6 +31,7 @@ export interface HeaderProps {
   subTitleTextVariant?: 'h1' | 'h2' | 'h3'
   buttonText?: string
   handleClick: () => void
+  hasAccess?: boolean
 }
 
 //TO-DO - Move this component to cx-shared repo after the yarn upgrade
@@ -44,6 +45,7 @@ export const Header = ({
   subTitleTextVariant = 'h2',
   buttonText,
   handleClick,
+  hasAccess,
 }: HeaderProps) => {
   return (
     <Box
@@ -91,6 +93,7 @@ export const Header = ({
                 onClick={() => {
                   handleClick()
                 }}
+                disabled={!(hasAccess ?? true)}
               >
                 {buttonText}
               </Button>

--- a/src/components/shared/frame/SlidingMainHeader/SlidingMainHeader.tsx
+++ b/src/components/shared/frame/SlidingMainHeader/SlidingMainHeader.tsx
@@ -28,6 +28,7 @@ export interface SlidingMainHeaderProps {
     subTitle: string
     imagePath: string
     buttonText: string
+    hasAccess?: boolean
     handleClick: () => void
   }[]
   autoplay?: boolean


### PR DESCRIPTION
## Description

This PR addresses the issue where users without the required permissions could still see and click buttons in the home page slider, which would lead to **Unauthorized** pages. 

The following changes have been made:
- **Disabled buttons** in the slider (including **"My Apps"**) for users who do not have the necessary permissions.
- Ensured that these buttons remain visible but non-clickable for unauthorized users, providing a clear visual indicator that they do not have access.
- The change prevents the display of error pages when users attempt to click on restricted sections.

## Why

This change improves the user experience by preventing unauthorized access pages for users without permission.

## Issue

[#1157](https://github.com/eclipse-tractusx/portal-frontend/issues/1157)

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally