### PR TITLE
fix(service management): fix 400 issue when clicking 'Load More' button

### DIFF
--- a/src/features/adminBoard/serviceAdminBoardApiSlice.ts
+++ b/src/features/adminBoard/serviceAdminBoardApiSlice.ts
@@ -92,15 +92,13 @@ export const apiSlice = createApi({
   endpoints: (builder) => ({
     fetchInReviewServices: builder.query<ServiceResponse, ServiceRequestBody>({
       query: (body) => {
-        const statusId = `&status=${body.statusId}`
-        const sortingType = `&sorting=${body.sortingType}`
-        const expr = `&serviceName=${body.expr}`
+        const statusId = body.statusId ? `&status=${body.statusId}` : ''
+        const sortingType = body.sortingType
+          ? `&sorting=${body.sortingType}`
+          : ''
+        const expr = body.expr ? `&serviceName=${body.expr}` : ''
         return {
-          url: `/api/services/serviceRelease/inReview?size=${PAGE_SIZE}&page=${
-            body.page
-          }${body.statusId && statusId}${body.sortingType && sortingType}${
-            body.expr && expr
-          }`,
+          url: `/api/services/serviceRelease/inReview?size=${PAGE_SIZE}&page=${body.page}${statusId}${sortingType}${expr}`,
         }
       },
     }),


### PR DESCRIPTION
## Description
- In the Service Request Management section, clicking the 'Load More' button generates a 400 Bad Request error, preventing additional service requests from being loaded.

- A 400 Bad Request error is generated when attempting to load more service requests.
## Issue
- Github Issue: https://github.com/eclipse-tractusx/portal-frontend/issues/1168

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes

![image](https://github.com/user-attachments/assets/41127f50-f74b-431d-a911-268c41f63beb)

## CHANGELOG
- Service Management | 400 Bad Request when Clicking 'Load More' Button [#1168](https://github.com/eclipse-tractusx/portal-frontend/issues/1168)

