### PR TITLE
fix: align notification page search field color with other pages

### DIFF
--- a/src/components/pages/NotificationCenter/Notifications.scss
+++ b/src/components/pages/NotificationCenter/Notifications.scss
@@ -193,9 +193,6 @@
 
   .searchContainer .MuiBox-root {
     width: 40%;
-    svg {
-      color: #0f71cb;
-    }
   }
   .searchContainer .MuiBox-root svg:hover {
     background-color: rgb(176 206 235 / 40%);
@@ -203,8 +200,6 @@
   }
 
   .searchContainer .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline {
-    border-color: #fdb943 !important;
-    border-width: 2px;
     border-radius: 16px;
   }
 


### PR DESCRIPTION
## Description

Align search input color on the notification page with other portal pages for UI consistency.

## Why

To maintain consistent UI across the portal.

## Issue

[#1169](https://github.com/eclipse-tractusx/portal-frontend/issues/1169)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally