### PR TITLE
fix(my company): fix text overlap issue at company roles

### DIFF
--- a/src/components/pages/Organization/MyCompanyInfoComponent.tsx
+++ b/src/components/pages/Organization/MyCompanyInfoComponent.tsx
@@ -47,18 +47,15 @@ export default function MyCompanyInfoComponent({
     {
       key: '',
       value: (
-        <>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
           {companyDetails?.companyRole.map((item: string) => (
             <StatusTag
               key={item}
               color="label"
               label={t(`content.companyRolesUpdate.${item}`)}
-              sx={{
-                marginRight: '8px',
-              }}
             />
           ))}
-        </>
+        </Box>
       ),
     },
   ]


### PR DESCRIPTION
## Description

Fix text overlap issue in the Company Roles section on the My Company page

## Why

To ensure the text in the Company Roles section is readable and not overlapped.

## Issue

#1172

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally