### PR TITLE
fix(file upload): change error text of uploaded file from byte to mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,9 +241,6 @@
 - fixed unchanged text of button when user requests subscription [#985](https://github.com/eclipse-tractusx/portal-frontend/pull/985)
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
 
-- **Display Uplaoded file error text in MB**:
-  - Fixed error text of uplaoded file from Byte to MB [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/1185)
-
 ### Known Knowns
 
 - Technical Issues and Limitations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,7 +242,7 @@
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
 
 - **Display Uplaoded file error text in MB**:
-  - Fixed error text of uplaoded file from Byte to MB [#866](https://github.com/eclipse-tractusx/portal-frontend/issues/1184)
+  - Fixed error text of uplaoded file from Byte to MB [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/1185)
 
 ### Known Knowns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,9 @@
 - fixed unchanged text of button when user requests subscription [#985](https://github.com/eclipse-tractusx/portal-frontend/pull/985)
 - fixed height for "Admin Service Detail" page content [#1001](https://github.com/eclipse-tractusx/portal-frontend/pull/1001)
 
+- **Display Uplaoded file error text in MB**:
+  - Fixed error text of uplaoded file from Byte to MB [#866](https://github.com/eclipse-tractusx/portal-frontend/issues/1184)
+
 ### Known Knowns
 
 - Technical Issues and Limitations

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -446,7 +446,7 @@ npm/npmjs/-/resolve/1.22.8, MIT AND ISC, approved, #15315
 npm/npmjs/-/resolve/2.0.0-next.5, MIT AND ISC, approved, #3078
 npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/rollup/4.24.0, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/4.24.0, MIT AND (ISC AND MIT), approved, #16917
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/safe-array-concat/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/safe-regex-test/1.0.3, MIT, approved, clearlydefined
@@ -690,22 +690,22 @@ npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/@reduxjs/toolkit/2.2.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
 npm/npmjs/@remix-run/router/1.19.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/pluginutils/5.1.2, MIT, approved, #16428
-npm/npmjs/@rollup/rollup-android-arm-eabi/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-arm64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-x64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-musl/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-musl/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-android-arm-eabi/4.24.0, MIT AND (ISC AND MIT), approved, #16904
+npm/npmjs/@rollup/rollup-android-arm64/4.24.0, MIT AND (ISC AND MIT), approved, #16918
+npm/npmjs/@rollup/rollup-darwin-arm64/4.24.0, MIT AND (ISC AND MIT), approved, #16908
+npm/npmjs/@rollup/rollup-darwin-x64/4.24.0, MIT AND (ISC AND MIT), approved, #16901
+npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.24.0, MIT AND (ISC AND MIT), approved, #16906
+npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.24.0, MIT AND (ISC AND MIT), approved, #16914
+npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16910
+npm/npmjs/@rollup/rollup-linux-arm64-musl/4.24.0, MIT AND (ISC AND MIT), approved, #16912
+npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16916
+npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16907
+npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16919
+npm/npmjs/@rollup/rollup-linux-x64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16915
+npm/npmjs/@rollup/rollup-linux-x64-musl/4.24.0, MIT AND (ISC AND MIT), approved, #16911
+npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16909
+npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16913
+npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16902
 npm/npmjs/@rtsao/scc/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, clearlydefined
 npm/npmjs/@sinonjs/commons/3.0.1, BSD-3-Clause, approved, #12905

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2310,7 +2310,10 @@
       "placeholder": "",
       "uploadError": "Not Uploaded",
       "uploadSuccess": "Uploaded",
-      "uploadProgess": "Uploaded % of % files"
+      "uploadProgess": "Uploaded % of % files",
+      "error": {
+        "fileTooLarge": "Datei ist größer als"
+      }
     },
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2286,7 +2286,7 @@
       "uploadSuccess": "Uploaded",
       "uploadProgess": "Uploaded % of % files",
       "error": {
-        "fileTooLarge": "File is Larger than"
+        "fileTooLarge": "File is larger than"
       }
     },
     "userRoles": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2284,7 +2284,10 @@
       "placeholder": "",
       "uploadError": "Not Uploaded",
       "uploadSuccess": "Uploaded",
-      "uploadProgess": "Uploaded % of % files"
+      "uploadProgess": "Uploaded % of % files",
+      "error": {
+        "fileTooLarge": "File is Larger than"
+      }
     },
     "userRoles": {
       "title": "Assigned Catena-X Portal Roles",

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -111,6 +111,19 @@ export const Dropzone = ({
     [currentFiles, onChange, handleDelete]
   )
 
+  const handleFileSizeValidator = (file: File) => {
+    if (maxFileSize) {
+      if (file.size > maxFileSize) {
+        return {
+          code: 'size-too-large',
+          message: `File is larger than ${(maxFileSize / 1048576).toFixed(2)} MB`,
+        }
+      }
+      return null
+    }
+    return null
+  }
+
   const {
     getRootProps,
     getInputProps,
@@ -123,7 +136,7 @@ export const Dropzone = ({
     maxFiles: isSingleUpload ? 0 : maxFilesToUpload,
     accept: acceptFormat,
     multiple: !isSingleUpload,
-    maxSize: maxFileSize,
+    validator: handleFileSizeValidator,
   })
 
   let DropAreaComponent = DefaultDropArea

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -118,7 +118,7 @@ export const Dropzone = ({
     return file.size > maxFileSize
       ? {
           code: 'size-too-large',
-          message: `File is larger than ${fileSizeInMB} MB`,
+          message: `${t('shared.dropzone.error.fileTooLarge')} ${fileSizeInMB} MB`,
         }
       : null
   }

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -32,6 +32,7 @@ import {
 import { type FunctionComponent, useCallback, useState } from 'react'
 import { type Accept, useDropzone } from 'react-dropzone'
 import { useTranslation } from 'react-i18next'
+import { CONVERT_TO_MB } from 'types/Constants'
 
 export type DropzoneFile = File & Partial<UploadFile>
 
@@ -112,16 +113,14 @@ export const Dropzone = ({
   )
 
   const handleFileSizeValidator = (file: File) => {
-    if (maxFileSize) {
-      if (file.size > maxFileSize) {
-        return {
+    if (!maxFileSize) return null
+    const fileSizeInMB = (file.size / CONVERT_TO_MB).toFixed(2)
+    return file.size > maxFileSize
+      ? {
           code: 'size-too-large',
-          message: `File is larger than ${(maxFileSize / 1048576).toFixed(2)} MB`,
+          message: `File is larger than ${fileSizeInMB} MB`,
         }
-      }
-      return null
-    }
-    return null
+      : null
   }
 
   const {

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -241,3 +241,5 @@ export enum HINTS {
   COMING_SOON = 'coming_soon',
   NEW = 'new',
 }
+
+export const CONVERT_TO_MB = 1048576


### PR DESCRIPTION
## Description
converted file size from Bytes to Mega-Byte of uploaded document for better UX.
![Screenshot 2024-09-30 at 17 13 39](https://github.com/user-attachments/assets/f2b46247-0fea-453d-a901-8db011d8be45)

Changelog entry:
```
- **File Upload**:
  - changed error text of uploaded file from Byte to MB [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/1185)
```


## Why
It is hard for user to understand long digits in Bytes and easier to read in mega byte size for better understanding and usually the size of the file either comes in KB or MB.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1184

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
