### PR TITLE
feat(file upload): increase size limit for uploaded documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,7 +346,7 @@
   - UI improvements such as table headers, joint table columns, type updates, etc. [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/866)
 
 - **Increase Upload File Limit**:
-  - Allowed uplaoded document file limit increase to 5 mb [#866](https://github.com/eclipse-tractusx/portal-frontend/issues/1186)
+  - Allowed uplaoded document file limit increase to 5 mb [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/1187)
 
 ### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,11 +342,7 @@
 - **Scroll Integration**:
   - integrated now scroll-to-top component from shared components for all pages [#872](https://github.com/eclipse-tractusx/portal-frontend/pull/872)
 - **Credential Request**:
-
   - UI improvements such as table headers, joint table columns, type updates, etc. [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/866)
-
-- **Increase Upload File Limit**:
-  - Allowed uplaoded document file limit increase to 5 mb [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/1187)
 
 ### Feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,7 +342,11 @@
 - **Scroll Integration**:
   - integrated now scroll-to-top component from shared components for all pages [#872](https://github.com/eclipse-tractusx/portal-frontend/pull/872)
 - **Credential Request**:
+
   - UI improvements such as table headers, joint table columns, type updates, etc. [#866](https://github.com/eclipse-tractusx/portal-frontend/pull/866)
+
+- **Increase Upload File Limit**:
+  - Allowed uplaoded document file limit increase to 5 mb [#866](https://github.com/eclipse-tractusx/portal-frontend/issues/1186)
 
 ### Feature
 

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -121,6 +121,7 @@ export const Dropzone = ({
         : sizeInMB.toFixed(1)
     }
 
+    if (!maxFileSize) return null
     return file.size > maxFileSize
       ? {
           code: 'size-too-large',

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -114,11 +114,17 @@ export const Dropzone = ({
 
   const handleFileSizeValidator = (file: File) => {
     if (!maxFileSize) return null
-    const fileSizeInMB = (file.size / CONVERT_TO_MB).toFixed(2)
+    const formatFileSize = (bytes: number): string => {
+      const sizeInMB = bytes / CONVERT_TO_MB
+      return Number.isInteger(sizeInMB)
+        ? sizeInMB.toString()
+        : sizeInMB.toFixed(1)
+    }
+
     return file.size > maxFileSize
       ? {
           code: 'size-too-large',
-          message: `${t('shared.dropzone.error.fileTooLarge')} ${fileSizeInMB} MB`,
+          message: `${t('shared.dropzone.error.fileTooLarge')} ${formatFileSize(maxFileSize)} MB`,
         }
       : null
   }

--- a/src/components/shared/basic/Dropzone/index.tsx
+++ b/src/components/shared/basic/Dropzone/index.tsx
@@ -121,7 +121,6 @@ export const Dropzone = ({
         : sizeInMB.toFixed(1)
     }
 
-    if (!maxFileSize) return null
     return file.size > maxFileSize
       ? {
           code: 'size-too-large',

--- a/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
@@ -68,6 +68,7 @@ import {
 import { ButtonLabelTypes } from '..'
 import { PrivacyPolicyType } from 'features/adminBoard/adminBoardApiSlice'
 import { phone } from 'phone'
+import { ALLOWED_MAX_SIZE_DOCUMENT } from 'types/Constants'
 
 type FormDataType = {
   longDescriptionEN: string
@@ -547,7 +548,7 @@ export default function AppPage() {
                     'image/jpeg': [],
                   }}
                   maxFilesToUpload={3}
-                  maxFileSize={819200}
+                  maxFileSize={ALLOWED_MAX_SIZE_DOCUMENT}
                   DropArea={renderDropArea}
                   handleDelete={(documentId: string) => {
                     setDeleteSuccess(false)

--- a/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
@@ -54,6 +54,7 @@ import type { LanguageStatusType } from 'features/appManagement/types'
 import { DocumentTypeId } from 'features/appManagement/apiSlice'
 import { ButtonLabelTypes } from '..'
 import { success, error } from 'services/NotifyService'
+import { ALLOWED_MAX_SIZE_DOCUMENT } from 'types/Constants'
 
 type FormDataType = {
   longDescriptionEN: string
@@ -347,7 +348,7 @@ export default function OfferPage({
                     'application/pdf': ['.pdf'],
                   }}
                   maxFilesToUpload={1}
-                  maxFileSize={5242880}
+                  maxFileSize={ALLOWED_MAX_SIZE_DOCUMENT}
                   handleDelete={(documentId: string) => {
                     documentId && deleteDocument(documentId)
                   }}

--- a/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
@@ -347,7 +347,7 @@ export default function OfferPage({
                     'application/pdf': ['.pdf'],
                   }}
                   maxFilesToUpload={1}
-                  maxFileSize={819200}
+                  maxFileSize={5242880}
                   handleDelete={(documentId: string) => {
                     documentId && deleteDocument(documentId)
                   }}

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -245,6 +245,7 @@ export enum HINTS {
 }
 
 export const CONVERT_TO_MB = 1048576
+export const ALLOWED_MAX_SIZE_DOCUMENT = 5242880
 
 export const serviceTypeMapping: Record<string, ServiceTypeIdsEnum> = {
   // en


### PR DESCRIPTION
## Description
previously handling the uploaded pdf documents with maximum size of 0.8 mb and now the allowed limit has increased to 5 mb.

Changelog entry:
```
- **File Upload**:
  - increased size limit for uploaded documents to 5 mb [#1187](https://github.com/eclipse-tractusx/portal-frontend/pull/1187)
```

## Why
Files like Contract & concern, Agreements could have bigger sizes then 0.8 mb so suggested limit was 5mb.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1186

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
