### PR TITLE
fix: add notification on copy action in technical user detail page

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2363,7 +2363,8 @@
       "exit": "exit",
       "loading": "Loading...",
       "unsubscribe": "Unsubscribe",
-      "edit": "Edit"
+      "edit": "Edit",
+      "copyInfoSuccessMessage": "Information erfolgreich kopiert"
     },
     "state": {
       "enabled": "aktiv",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2337,7 +2337,8 @@
       "exit": "exit",
       "loading": "Loading...",
       "unsubscribe": "Unsubscribe",
-      "edit": "Edit"
+      "edit": "Edit",
+      "copyInfoSuccessMessage": "Information copied successfully"
     },
     "state": {
       "enabled": "enabled",

--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -20,10 +20,12 @@
 
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { Box } from '@mui/material'
 import { Typography } from '@catena-x/portal-shared-components'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
+import { success } from 'services/NotifyService'
 
 type DataValue = string | number | JSX.Element | string[]
 
@@ -63,6 +65,7 @@ export const KeyValueView = ({
   editLink,
 }: KeyValueViewProps) => {
   const [copied, setCopied] = useState<string>('')
+  const { t } = useTranslation()
 
   const renderValueItem = (item: ValueItem) =>
     item.copy ? (
@@ -79,6 +82,7 @@ export const KeyValueView = ({
           const value = item.value ?? ''
           await navigator.clipboard.writeText(value as string)
           setCopied(value as string)
+          success(t('global.actions.copyInfoSuccessMessage'))
           setTimeout(() => {
             setCopied('')
           }, 1000)

--- a/src/components/shared/basic/ReadOnlyValue/index.tsx
+++ b/src/components/shared/basic/ReadOnlyValue/index.tsx
@@ -18,15 +18,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+import { useTranslation } from 'react-i18next'
 import { Box } from '@mui/material'
 import { Typography, Tooltips } from '@catena-x/portal-shared-components'
 import type { IHashMap } from 'types/MainTypes'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { useState } from 'react'
+import { success } from 'services/NotifyService'
 
 const CopyValue = ({ value }: { value: string }) => {
   const [copied, setCopied] = useState<boolean>(false)
+  const { t } = useTranslation()
 
   return (
     <Box
@@ -42,6 +45,7 @@ const CopyValue = ({ value }: { value: string }) => {
       onClick={async () => {
         await navigator.clipboard.writeText(value)
         setCopied(true)
+        success(t('global.actions.copyInfoSuccessMessage'))
         setTimeout(() => {
           setCopied(false)
         }, 1000)


### PR DESCRIPTION
## Description

Display snackbar notification when user click on copy icon in the configure IDP overlay redirect URL and Technical user detail page 

## Why

To inform user with a notification when the content is copied

## Issue

#1183 

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally