### PR TITLE
fix: harmonize notification translation keys with constants

### DIFF
--- a/src/assets/locales/de/notification.json
+++ b/src/assets/locales/de/notification.json
@@ -108,11 +108,13 @@
     "appAdminBoard": "Get there",
     "technicaluser": "Get there",
     "companyRolesServiceProvider": "Get there",
-    "usermanagement": "Get there",
+    "userManagement": "Get there",
     "serviceSubscription": "Get there",
     "serviceAdminBoard": "Get there",
     "roleDetails": "Open Role Matrix",
-    "servicemarketplace": "Get there"
+    "serviceMarketplace": "Get there",
+    "connectorManagement": "Get there",
+    "technicalUserManagement": "Get there"
   },
   "due": "fällig",
   "search": "...suchen",

--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -108,11 +108,13 @@
     "appAdminBoard": "Get there",
     "technicaluser": "Get there",
     "companyRolesServiceProvider": "Get there",
-    "usermanagement": "Get there",
+    "userManagement": "Get there",
     "serviceSubscription": "Get there",
     "serviceAdminBoard": "Get there",
     "roleDetails": "Open Role Matrix",
-    "servicemarketplace": "Get there"
+    "serviceMarketplace": "Get there",
+    "connectorManagement": "Get there",
+    "technicalUserManagement": "Get there"
   },
   "due": "due",
   "search": "Enter your search value",


### PR DESCRIPTION
## Description

Harmonized the translation keys in notifications with the constants file to ensure consistency and prevent mismatched key values.

## Why

To resolves issues caused by inconsistent casing in translation keys, ensuring the correct values are returned instead of the keys.

## Issue

#1163 

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally