### PR TITLE
fix: replace OSP callback hardcode with variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   - fixed customer link selection and fixed resetting values [#1119](https://github.com/eclipse-tractusx/portal-frontend/pull/1119)
 - **Technical User Management**
   - fixed error message scenario post technical user deletion action
+- **OSP Managament**
+  - fixed hardcoded OSP callback url [#1201](https://github.com/eclipse-tractusx/portal-frontend/pull/1201)
 
 ## 2.2.0-alpha.1
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -15,7 +15,7 @@ npm/npmjs/-/arg/4.1.3, MIT, approved, clearlydefined
 npm/npmjs/-/argparse/1.0.10, MIT, approved, #2174
 npm/npmjs/-/argparse/2.0.1, Python-2.0, approved, CQ22954
 npm/npmjs/-/aria-query/5.1.3, Apache-2.0, approved, clearlydefined
-npm/npmjs/-/aria-query/5.3.0, Apache-2.0, approved, clearlydefined
+npm/npmjs/-/aria-query/5.3.0, Apache-2.0, approved, #16427
 npm/npmjs/-/array-buffer-byte-length/1.0.1, MIT, approved, #7548
 npm/npmjs/-/array-includes/3.1.8, MIT, approved, #4577
 npm/npmjs/-/array-union/2.1.0, MIT, approved, clearlydefined
@@ -696,7 +696,7 @@ npm/npmjs/@react-hook/cache/1.1.1, MIT, approved, clearlydefined
 npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/@reduxjs/toolkit/2.2.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
 npm/npmjs/@remix-run/router/1.15.3, MIT, approved, clearlydefined
-npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/pluginutils/5.1.0, MIT, approved, #16428
 npm/npmjs/@rollup/rollup-android-arm-eabi/4.17.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/rollup-android-arm64/4.17.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/rollup-darwin-arm64/4.17.2, MIT, approved, clearlydefined

--- a/src/components/pages/OnboardingServiceProvider/OnboardingServiceProvider.tsx
+++ b/src/components/pages/OnboardingServiceProvider/OnboardingServiceProvider.tsx
@@ -286,7 +286,7 @@ const OnboardingServiceProvider = () => {
                 {t('content.onboardingServiceProvider.subDesc1')}
               </Typography>
               <Typography variant="body3">
-                {t('content.onboardingServiceProvider.subDesc2')}
+                {callbackData?.callbackUrl ?? data?.callbackUrl}
               </Typography>
             </Box>
             <IconButton


### PR DESCRIPTION
## Description

- Remove hardcoded OSP callback url string and replace with OSP callback variable

## Why

The URL does not get updated with the current URL or does not update when being changed. Instead, a dummy URL is displayed. 

## Issue

#1196 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
