### PR TITLE
feat: don't show overlay for submitted application to operator

### DIFF
--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -72,11 +72,18 @@ export const Header = ({
   const { data } = useFetchApplicationsQuery()
   const companyData = data?.[0]
   const { data: companyDetails } = useFetchOwnCompanyDetailsQuery('')
-  const [submittedOverlayOpen, setSubmittedOverlayOpen] = useState(
-    companyData?.applicationStatus === ApplicationStatus.SUBMITTED
-  )
+  const [submittedOverlayOpen, setSubmittedOverlayOpen] =
+    useState<boolean>(false)
   const [headerNote, setHeaderNote] = useState(false)
   const [pages, setPages] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!(companyData && companyDetails)) return
+    setSubmittedOverlayOpen(
+      !companyDetails?.companyRole.includes('OPERATOR') &&
+        companyData?.applicationStatus === ApplicationStatus.SUBMITTED
+    )
+  }, [companyData, companyDetails])
 
   useEffect(() => {
     if (companyDetails?.companyRole.includes('ONBOARDING_SERVICE_PROVIDER')) {


### PR DESCRIPTION
## Description

don't show overlay for submitted application to operator

## Why

Unlike other companies, the operator company needs to be able to act within the Portal from the start independently from the application approval process, relates to https://github.com/eclipse-tractusx/portal-backend/issues/1003#issuecomment-2391717366

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1203

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
