### PR TITLE
fix(UI): app and service searchbox translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,12 @@
 - **User Management**
   - fixed displaying of user management navigation button based on role validation [#1073](https://github.com/eclipse-tractusx/portal-frontend/pull/1073)
 - **App Management**
+
   - fixed 400 Bad Request error due to search filter [#1057](https://github.com/eclipse-tractusx/portal-frontend/pull/1058)
   - added load more button app overview [#1009](https://github.com/eclipse-tractusx/portal-frontend/pull/1009)
+
+- **Search Translation for App and Service Subsciption**
+  - fixed DE translation for search input in App and Service Subsciption [#1211](https://github.com/eclipse-tractusx/portal-frontend/pull/1211)
 
 ## 2.2.0
 

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1475,7 +1475,7 @@
       "description": "Do you wan't to rather use the autosetup; connect your service to automate marketplace subscription build",
       "readMore": "Read More",
       "registerURL": "RegisterURL",
-      "search": "...search by entering the company name here.",
+      "search": "Suche nach Firmennamen",
       "noDataMessage": "No data available",
       "subscriptionHeading": ">> there are already active subscriptions for the service {serviceName}",
       "subscribeSuccessMsg": "Subscribed Successfully",

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -153,7 +153,7 @@
     "description": "Do you wan't to rather use the autosetup; connect your service to automate marketplace subscription build",
     "readMore": "Read More",
     "registerURL": "RegisterURL",
-    "search": "...search by entering the company name here.",
+    "search": "Suche nach Firmennamen",
     "noDataMessage": "No data available",
     "subscriptionHeading": ">> there are already active subscriptions for the service {serviceName}",
     "subscribeSuccessMsg": "Subscribed Successfully",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1443,7 +1443,7 @@
       "description": "Do you wan't to rather use the autosetup; connect your service to automate marketplace subscription build",
       "readMore": "Read More",
       "registerURL": "RegisterURL",
-      "search": "...search by entering the company name here.",
+      "search": "Search for company name",
       "noDataMessage": "No data available",
       "subscriptionHeading": ">> there are already active subscriptions for the service {serviceName}",
       "subscribeSuccessMsg": "Subscribed Successfully",

--- a/src/assets/locales/en/servicerelease.json
+++ b/src/assets/locales/en/servicerelease.json
@@ -153,7 +153,7 @@
     "description": "Do you wan't to rather use the autosetup; connect your service to automate marketplace subscription build",
     "readMore": "Read More",
     "registerURL": "RegisterURL",
-    "search": "...search by entering the company name here.",
+    "search": "Search for company name",
     "noDataMessage": "No data available",
     "subscriptionHeading": ">> there are already active subscriptions for the service {serviceName}",
     "subscribeSuccessMsg": "Subscribed Successfully",


### PR DESCRIPTION
## Description
App and Service subscription search box translations doesn't work with DE so I introduced new translation keys for the search.

## Why
In order to get the correct translation for like the rest of the elements, I updated the translation file for the searchbox in App and Service subscription.

## Issue

Link to Github issue.
https://github.com/eclipse-tractusx/portal-frontend/issues/1210

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have updated changelog file for my change.
