### PR TITLE
fix: retain "None" Selection for Technical Integration in Service Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 ### Change
 
 - **Service Subscriptions**
+
   - rename 'Configure' button to 'Activate' button [#1150](https://github.com/eclipse-tractusx/portal-frontend/pull/1150)
+
+  ### Bugfixes
+
+- **Service Release Process**
+  - Fixed "None" selection issue in Technical Integration [#1161](https://github.com/eclipse-tractusx/portal-frontend/issues/1161)
 
 ## 2.3.0-alpha.2
 

--- a/src/components/shared/basic/ReleaseProcess/OfferTechnicalIntegration/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferTechnicalIntegration/index.tsx
@@ -72,7 +72,11 @@ export default function OfferTechnicalIntegration() {
   )
 
   useEffect(() => {
-    setServiceTechUserProfiles(userProfiles)
+    // Set default value as "None" when user profiles don't have any roles
+    // Initially, value is "None"
+    setServiceTechUserProfiles(
+      userProfiles.length > 0 ? userProfiles : [serviceTechnicalUserNone]
+    )
   }, [userProfiles])
 
   const defaultValues = {


### PR DESCRIPTION
## Description
- **Context:** Service Release Process -> Step 4: Technical Integration.
- **Change:** Added an `if` condition in `useEffect` to verify if the user has assigned roles. If no roles are found, the "None" option is automatically selected.


## Why
- **Issue:** The "None" option in the Technical Integration was not retaining its selection after submission.
- **Solution:** This fix ensures that the "None" option remains selected when the user revisits the "Technical Integration" step, providing a more consistent and user-friendly experience.

## Issue
Github Issue: [#1161](https://github.com/eclipse-tractusx/portal-frontend/issues/1161)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas


https://github.com/user-attachments/assets/b6a2bbf1-b8f3-42d5-9a24-c902f74510d9