### PR TITLE
fix: introduced inreview filter for in the service overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,8 @@
   - enabled showing of appropriate error information to the user along with refetch button [#917](https://github.com/eclipse-tractusx/portal-frontend/pull/917)
 - **Admin Board**:
   - fixed role to hide admin board page for service manager [#937](https://github.com/eclipse-tractusx/portal-frontend/pull/937)
+- **Service Overview Inreview filter**:
+  - Introduced filter of in-review in service overview page [#1218](https://github.com/eclipse-tractusx/portal-frontend/pull/1218)
 
 ### Known Knowns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,8 +247,6 @@
   - enabled showing of appropriate error information to the user along with refetch button [#917](https://github.com/eclipse-tractusx/portal-frontend/pull/917)
 - **Admin Board**:
   - fixed role to hide admin board page for service manager [#937](https://github.com/eclipse-tractusx/portal-frontend/pull/937)
-- **Service Overview Inreview filter**:
-  - Introduced filter of in-review in service overview page [#1218](https://github.com/eclipse-tractusx/portal-frontend/pull/1218)
 
 ### Known Knowns
 

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -125,7 +125,8 @@
       "all": "Alle",
       "active": "Aktiv",
       "inactive": "Inaktiv",
-      "wip": "In Arbeit"
+      "wip": "In Arbeit",
+      "inreview": "wird überprüft"
     },
     "headerTitle": "Service Overview - Own managed service offers",
     "inputPlaceholder": "Suchen Sie nach Services",

--- a/src/assets/locales/en/servicerelease.json
+++ b/src/assets/locales/en/servicerelease.json
@@ -127,7 +127,8 @@
       "all": "All",
       "active": "Active",
       "inactive": "Inactive",
-      "wip": "WIP"
+      "wip": "WIP",
+      "inreview": "Inreview"
     },
     "addbtn": "Register your Service",
     "submenuNotAvailable": "Sub-Menu is not available.",

--- a/src/components/pages/ServiceReleaseProcess/components/ServiceListOverview.tsx
+++ b/src/components/pages/ServiceReleaseProcess/components/ServiceListOverview.tsx
@@ -145,6 +145,11 @@ export default function ServiceListOverview() {
       onButtonClick: setView,
     },
     {
+      buttonText: t('serviceOverview.filter.inreview'),
+      buttonValue: StatusIdEnum.InReview,
+      onButtonClick: setView,
+    },
+    {
       buttonText: t('serviceOverview.filter.wip'),
       buttonValue: StatusIdEnum.WIP,
       onButtonClick: setView,


### PR DESCRIPTION
## Description
I introduced new entry in the object for the `IN_REVIEW` status and its translation to make it visible in Service Overview Page.

Changelog entry:
```
- **Service Overview Inreview filter**:
  - Introduced filter of in-review in service overview page [#1218](https://github.com/eclipse-tractusx/portal-frontend/pull/1218)
```

## Why
we also need this filter to see the services which are currently in-review like we see for `ACTIVE` and for `INACTIVE` status.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1217

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have updated the changelog of my change
