### PR TITLE
fix(company subscriptions): wrong hyperlink and role in subscription details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - **Service Subscriptions**
   - rename 'Configure' button to 'Activate' button [#1150](https://github.com/eclipse-tractusx/portal-frontend/pull/1150)
 
+### Bugfixes
+
+- **Company Subscriptions**
+  - fixed wrong hyperlink and role requirement for technical user details in company subscription details [#1220](https://github.com/eclipse-tractusx/portal-frontend/pull/1220)
+
 ## 2.3.0-alpha.2
 
 ### Change

--- a/src/components/pages/CompanySubscriptions/components/CompanySubscriptionTechnical/index.tsx
+++ b/src/components/pages/CompanySubscriptions/components/CompanySubscriptionTechnical/index.tsx
@@ -52,9 +52,9 @@ export default function CompanySubscriptionTechnical({
         {
           icon: false,
           clickableLink:
-            userHasPortalRole(ROLES.VIEW_USER_ACCOUNT) &&
+            userHasPortalRole(ROLES.TECH_USER_VIEW) &&
             detail.technicalUserData.length
-              ? `/${PAGES.USER_DETAILS}/${detail.technicalUserData[0].id}`
+              ? `/${PAGES.TECH_USER_DETAILS}/${detail.technicalUserData[0].id}`
               : undefined,
         },
       ],


### PR DESCRIPTION
## Description

Change role and path for technical user details in companySubscriptionDetails.
- view_tech_user_management (instead of view_user_account)
- techUserDetails (instead of userdetails)

## Why

The section is showing a list of technical users instead of portal user. Links and roles do not fit the intended purpose.

## Issue

Closes: eclipse-tractusx/portal-frontend#1219

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
