### PR TITLE
fix: add hint for display name at idp creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,8 +155,6 @@
   - aligned notification page search field color with other pages [#1178](https://github.com/eclipse-tractusx/portal-frontend/issues/1178)
 - **Home**
   - disabled My Apps button for users without permission [#1165](https://github.com/eclipse-tractusx/portal-frontend/issues/1165)
-- **IDP Creation**
-  - display error message for invalid input of displayName [#1264](https://github.com/eclipse-tractusx/portal-frontend/issues/1264)
 
 ## 2.3.0-alpha.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@
   - aligned notification page search field color with other pages [#1178](https://github.com/eclipse-tractusx/portal-frontend/issues/1178)
 - **Home**
   - disabled My Apps button for users without permission [#1165](https://github.com/eclipse-tractusx/portal-frontend/issues/1165)
+- **IDP Creation**
+  - display error message for invalid input of displayName [#1264](https://github.com/eclipse-tractusx/portal-frontend/issues/1264)
 
 ## 2.3.0-alpha.2
 

--- a/src/assets/locales/de/idp.json
+++ b/src/assets/locales/de/idp.json
@@ -195,7 +195,12 @@
   "field": {
     "display": {
       "name": "Display name",
-      "hint": "The name how this IdP is shown in the Central IdP selection (usually your company name)"
+      "hint": "The name how this IdP is shown in the Central IdP selection (usually your company name)",
+      "mandatoryMessage": "Display name ist obligatorisch",
+      "minimum": "Mindestens",
+      "maximum": "Maximal",
+      "charactersRequired": " Zeichen erforderlich",
+      "validCharactersIncludes": "Only Alphabetic characters and single space are allowed"
     },
     "alias": {
       "name": "Alias",

--- a/src/assets/locales/de/idp.json
+++ b/src/assets/locales/de/idp.json
@@ -200,7 +200,7 @@
       "minimum": "Mindestens",
       "maximum": "Maximal",
       "charactersRequired": " Zeichen erforderlich",
-      "validCharactersIncludes": "Allowed characters: a-zA-Z0-9!?@&#\"()_-=/*.,;: (single spaces only, no double spacing)"
+      "validCharactersIncludes": "Erlaubte Zeichen: a-z, A-Z, 0-9, !?@&#\"()_-=/*.,;: (einfache Leerzeichen, keine doppelten Leerzeichen)"
     },
     "alias": {
       "name": "Alias",

--- a/src/assets/locales/de/idp.json
+++ b/src/assets/locales/de/idp.json
@@ -200,7 +200,7 @@
       "minimum": "Mindestens",
       "maximum": "Maximal",
       "charactersRequired": " Zeichen erforderlich",
-      "validCharactersIncludes": "Only Alphabetic characters and single space are allowed"
+      "validCharactersIncludes": "Allowed characters: a-zA-Z0-9!?@&#\"()_-=/*.,;: (single spaces only, no double spacing)"
     },
     "alias": {
       "name": "Alias",

--- a/src/assets/locales/en/idp.json
+++ b/src/assets/locales/en/idp.json
@@ -203,7 +203,7 @@
       "minimum": "Minimum",
       "maximum": "Maximum",
       "charactersRequired": " characters required",
-      "validCharactersIncludes": "Only Alphabetic characters and single space are allowed"
+      "validCharactersIncludes": "Allowed characters: a-zA-Z0-9!?@&#\"()_-=/*.,;: (single spaces only, no double spacing)"
     },
     "alias": {
       "name": "Alias",

--- a/src/assets/locales/en/idp.json
+++ b/src/assets/locales/en/idp.json
@@ -198,7 +198,12 @@
   "field": {
     "display": {
       "name": "Display name",
-      "hint": "The name how this IdP is shown in the Central IdP selection (usually your company name)"
+      "hint": "The name how this IdP is shown in the Central IdP selection (usually your company name)",
+      "mandatoryMessage": "Display name field is mandatory",
+      "minimum": "Minimum",
+      "maximum": "Maximum",
+      "charactersRequired": " characters required",
+      "validCharactersIncludes": "Only Alphabetic characters and single space are allowed"
     },
     "alias": {
       "name": "Alias",

--- a/src/assets/locales/en/idp.json
+++ b/src/assets/locales/en/idp.json
@@ -203,7 +203,7 @@
       "minimum": "Minimum",
       "maximum": "Maximum",
       "charactersRequired": " characters required",
-      "validCharactersIncludes": "Allowed characters: a-zA-Z0-9!?@&#\"()_-=/*.,;: (single spaces only, no double spacing)"
+      "validCharactersIncludes": "Allowed characters: a-z, A-Z, 0-9, !?@&#\"()_-=/*.,;: (single spaces only, no double spacing)"
     },
     "alias": {
       "name": "Alias",

--- a/src/types/Patterns.test.ts
+++ b/src/types/Patterns.test.ts
@@ -51,8 +51,22 @@ const TESTDATA = {
     ],
   },
   IDP: {
-    valid: ['Tractusx', 'Tract Usx', 'BPN lannn', 'Foo Bar'],
-    invalid: ['Foo  Bar', ' Foo', 'Bar ', 'Foo@Bar', '1234', '  ', ''],
+    valid: [
+      'Tractusx',
+      '0000001234',
+      'Tract Usx123@!',
+      'BPN lannn',
+      'Foo Bar@!',
+    ],
+    invalid: [
+      'Foo  Bar  ',
+      'Foo   Bar',
+      '  FooBar',
+      '   ',
+      'FooBar%',
+      'FooBar$',
+      '0000001234$%',
+    ],
   },
   MAIL: {
     valid: [
@@ -375,7 +389,7 @@ describe('Input Pattern Tests', () => {
     TESTDATA.IDP.valid.forEach((expr) => {
       expect(isValidIDPName(expr)).toBe(true)
     })
-    TESTDATA.CLIENTID.invalid.forEach((expr) => {
+    TESTDATA.IDP.invalid.forEach((expr) => {
       expect(isValidIDPName(expr)).toBe(false)
     })
   })

--- a/src/types/Patterns.test.ts
+++ b/src/types/Patterns.test.ts
@@ -31,6 +31,7 @@ import {
   isPersonName,
   isSearchUserEmail,
   isValidAppOverviewSearch,
+  isValidIDPName,
 } from './Patterns'
 
 const TESTDATA = {
@@ -48,6 +49,10 @@ const TESTDATA = {
       'BPNL00000000000015OHJ',
       'BPNL01',
     ],
+  },
+  IDP: {
+    valid: ['Tractusx', 'Tract Usx', 'BPN lannn', 'Foo Bar'],
+    invalid: ['Foo  Bar', ' Foo', 'Bar ', 'Foo@Bar', '1234', '  ', ''],
   },
   MAIL: {
     valid: [
@@ -350,7 +355,6 @@ describe('Input Pattern Tests', () => {
       expect(isClientID(expr)).toBe(false)
     })
   })
-
   it('Validate email search for users', () => {
     TESTDATA.EMAIL_SEARCH.valid.forEach((expr) => {
       expect(isSearchUserEmail(expr)).toBe(true)
@@ -365,6 +369,14 @@ describe('Input Pattern Tests', () => {
     })
     TESTDATA.appOverview.invalid.forEach((expr) => {
       expect(isValidAppOverviewSearch(expr)).toBe(false)
+    })
+  })
+  it('validate idp displayName', () => {
+    TESTDATA.IDP.valid.forEach((expr) => {
+      expect(isValidIDPName(expr)).toBe(true)
+    })
+    TESTDATA.CLIENTID.invalid.forEach((expr) => {
+      expect(isValidIDPName(expr)).toBe(false)
     })
   })
 })

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -92,6 +92,7 @@ export const Patterns = {
   idp: {
     clientId: /^[a-zA-Z0-9-_]{2,80}$/,
     clientSecret: /^.{1,200}$/,
+    displayName: /^[A-Za-z]+(?:\s[A-Za-z]+)*$/,
   },
   connectors: {
     NAME: /^[^-\s()'"#@.&](?!.*[%&?,';:!\s-]{2}).{1,19}$/,
@@ -213,5 +214,7 @@ export const isSearchUserEmail = (expr: string) =>
   Patterns.EMAIL_SEARCH.test(expr)
 export const isValidAppOverviewSearch = (expr: string) =>
   Patterns.appOverview.SEARCH.test(expr)
+export const isValidIDPName = (expr: string) =>
+  Patterns.idp.displayName.test(expr)
 
 export default Patterns

--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -92,7 +92,7 @@ export const Patterns = {
   idp: {
     clientId: /^[a-zA-Z0-9-_]{2,80}$/,
     clientSecret: /^.{1,200}$/,
-    displayName: /^[A-Za-z]+(?:\s[A-Za-z]+)*$/,
+    displayName: /^(?!.*\s{2,})[a-zA-Z0-9!?@&#'"()_\-=/*.,;: ]*$/,
   },
   connectors: {
     NAME: /^[^-\s()'"#@.&](?!.*[%&?,';:!\s-]{2}).{1,19}$/,


### PR DESCRIPTION
## Description
Updated regex for the allowed characters for displayName in idp creation. Previously we were not showing any error message against violation of regex. Updated regex and error translations bases on certain violation.

Changelog entry:
```
- **IdP Creation**
  - added hint for invalid input of display name [#1264](https://github.com/eclipse-tractusx/portal-frontend/issues/1264)
```

## Why
To have better UX to let the user know what he is doing wrong and what is expected for displayName and what type of string value BE expects for displayName.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1264

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have updated the changelog of my change
