### PR TITLE
fix(user management): allow user to view added roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **App Subscription Management**
   - fixed 'read more' link by adding link [#1200](https://github.com/eclipse-tractusx/portal-frontend/pull/1200)
+- **User Management**
+  - user table - allow user to scroll horizontally in roles column to view all the added information
 
 ### Feature
 

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -130,7 +130,7 @@ export const UserList = ({
           {
             field: 'name',
             headerName: t('global.field.name'),
-            flex: 3,
+            flex: 2,
             valueGetter: ({ row }: { row: TenantUser }) =>
               `${row.firstName} ${row.lastName}`,
           },
@@ -138,7 +138,7 @@ export const UserList = ({
           {
             field: 'status',
             headerName: t('global.field.status'),
-            flex: 3,
+            flex: 1.5,
             renderCell: ({ value: status }) => {
               return (
                 <StatusTag color="label" label={t(`global.field.${status}`)} />
@@ -148,25 +148,33 @@ export const UserList = ({
           {
             field: 'roles',
             headerName: t('global.field.role'),
-            flex: 4,
-            renderCell: ({ value: roles }) =>
-              roles.length
-                ? roles.map((role: RoleType | string) => (
-                    <StatusTag
-                      key={typeof role === 'string' ? role : role.roleId}
-                      color="label"
-                      label={typeof role === 'string' ? role : role.roleName}
-                      className="statusTag"
-                    />
-                  ))
-                : '',
+            flex: 5,
+            renderCell: ({ value: roles }) => (
+              <span
+                style={{
+                  overflowX: 'scroll',
+                  scrollbarWidth: 'none',
+                }}
+              >
+                {roles.length
+                  ? roles.map((role: RoleType | string) => (
+                      <StatusTag
+                        key={typeof role === 'string' ? role : role.roleId}
+                        color="label"
+                        label={typeof role === 'string' ? role : role.roleName}
+                        className="statusTag"
+                      />
+                    ))
+                  : ''}
+              </span>
+            ),
           },
           {
             field: 'details',
             headerName: isDetail
               ? t('global.field.details')
               : t('global.field.edit'),
-            flex: 2,
+            flex: 1.5,
             renderCell: ({ row }: { row: TenantUser }) => (
               <IconButton
                 disabled={onDetailsClick === undefined}


### PR DESCRIPTION
## Description

user table - allow user to scroll horizontally in roles column to view all the added information

## Why

added roles are truncated

## Issue

#1159 

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
