### PR TITLE
fix(user management): Prevent admins from proceeding further without user

### DIFF
--- a/src/components/overlays/AddAppUserRoles/index.tsx
+++ b/src/components/overlays/AddAppUserRoles/index.tsx
@@ -44,7 +44,10 @@ import {
   type UserRoleRequest,
   SuccessErrorType,
 } from 'features/admin/appuserApiSlice'
-import { setRolesToAdd } from 'features/admin/userDeprecated/actions'
+import {
+  setRolesToAdd,
+  setSelectedUserToAdd,
+} from 'features/admin/userDeprecated/actions'
 import { Box } from '@mui/material'
 import { useState } from 'react'
 
@@ -71,6 +74,7 @@ export default function AddAppUserRoles() {
       try {
         await updateUserRoles(data).unwrap()
         dispatch(setUserRoleResp(SuccessErrorType.SUCCESS))
+        clearUsersAndRoles()
       } catch (err) {
         dispatch(setUserRoleResp(SuccessErrorType.ERROR))
       }
@@ -80,7 +84,12 @@ export default function AddAppUserRoles() {
 
   const handleCancel = () => {
     dispatch(show(OVERLAYS.NONE, ''))
+    clearUsersAndRoles()
+  }
+
+  const clearUsersAndRoles = () => {
     dispatch(setRolesToAdd([]))
+    dispatch(setSelectedUserToAdd([]))
   }
 
   const AddStepsList = [


### PR DESCRIPTION
## Description
- Once the user/admin has completed the role assignment process, the system allows an admin to proceed to the role assignment section without selecting a user when revisiting the assignment screen. If no new user is chosen, the system defaults to previously selected users.
- The system should display an error message indicating a user must be selected for the role assignment if no new user is chosen.
- Or Admin can not process further if a user is not selected.

## Issue
- https://github.com/eclipse-tractusx/portal-frontend/issues/1267

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

- [x] I have checked that new and existing tests pass locally with my changes

## CHANGELOG
- Fixed: Prevented admins from proceeding with role assignment without selecting a user. [#1267](https://github.com/eclipse-tractusx/portal-frontend/issues/1267)

