### PR TITLE
Draft:fix: hide delete button for technical user deletion for app manager

### DIFF
--- a/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
+++ b/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
@@ -32,7 +32,7 @@ import {
   type ServiceAccountRole,
   useResetCredentialMutation,
 } from 'features/admin/serviceApiSlice'
-import { OVERLAYS } from 'types/Constants'
+import { OVERLAYS, ROLES } from 'types/Constants'
 import { useDispatch } from 'react-redux'
 import { show } from 'features/control/overlay'
 import { KeyValueView } from 'components/shared/basic/KeyValueView'
@@ -41,6 +41,7 @@ import { type ComponentProps, useState } from 'react'
 import { error, success } from 'services/NotifyService'
 import { ServiceAccountStatus } from 'features/admin/serviceApiSlice'
 import Info from '@mui/icons-material/Info'
+import { userHasPortalRole } from 'services/AccessService'
 
 export const statusColorMap: Record<
   ServiceAccountStatus,
@@ -194,19 +195,22 @@ export default function TechnicalUserDetailsContent({
     setLoading(false)
   }
 
+  const deleteTechnicalButton = userHasPortalRole(ROLES.TECH_USER_DELETE) && (
+    <Button
+      size="small"
+      variant="outlined"
+      startIcon={<HighlightOffIcon />}
+      onClick={() =>
+        dispatch(show(OVERLAYS.DELETE_TECH_USER, newData.serviceAccountId))
+      }
+    >
+      {t('content.usermanagement.technicalUser.delete')}
+    </Button>
+  )
+
   return (
     <section>
-      <Button
-        size="small"
-        variant="outlined"
-        startIcon={<HighlightOffIcon />}
-        onClick={() =>
-          dispatch(show(OVERLAYS.DELETE_TECH_USER, newData.serviceAccountId))
-        }
-      >
-        {t('content.usermanagement.technicalUser.delete')}
-      </Button>
-
+      {deleteTechnicalButton}
       <Button
         size="small"
         variant="outlined"


### PR DESCRIPTION
## Description

Please include a summary of the change.

## Why

Please include an explanation of why this change is necessary as well as relevant motivation and context. List any dependencies that are required for this change.

## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
