### PR TITLE
fix(semantic hub): fix filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Bugfixes
 
 - **Semantic Hub**
-  - Fixed semantic hub data on click of filters
+  - Fixed semantic hub data on click of filters [#1273](https://github.com/eclipse-tractusx/portal-frontend/pull/1273)
 
 ## 2.3.0-alpha.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - **Onboarding Service Provider**
   - removed deprecated page onboardingServiceProvider and every related link [#1261](https://github.com/eclipse-tractusx/portal-frontend/pull/1261)
 
+### Bugfixes
+
+- **Semantic Hub**
+  - Fixed semantic hub data on click of filters
+
 ## 2.3.0-alpha.3
 
 ### Change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Bugfixes
 
 - **Semantic Hub**
-  - Fixed semantic hub data on click of filters [#1273](https://github.com/eclipse-tractusx/portal-frontend/pull/1273)
+  - Fixed semantic hub data on click of filters and on click on refresh icon [#1273](https://github.com/eclipse-tractusx/portal-frontend/pull/1273)
 
 ## 2.3.0-alpha.3
 

--- a/src/components/pages/SemanticHub/ModelTable.tsx
+++ b/src/components/pages/SemanticHub/ModelTable.tsx
@@ -193,7 +193,13 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
         error={errorObj}
         reload={() =>
           dispatch(
-            fetchSemanticModels({ filter: { page: 0, pageSize: rowCount } })
+            fetchSemanticModels({
+              filter: {
+                page: 0,
+                pageSize: rowCount,
+                status: selectedFilter.status[0],
+              },
+            })
           )
         }
         noRowsMsg={t('global.noData.heading')}


### PR DESCRIPTION
## Description

Fixed semantic hub data on click of filters and on refresh icon

## Why

On click on filters and on click of refresh icon, the data should load correctly

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1148

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally