### PR TITLE
chore: exclude .yaml file inside doc folder from sonar analysis

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.cpd.exclusions = **/*.test.*, **/*.stories.*, src/assets/locales/**/*
+sonar.exclusions = docs/**/*.yaml


### PR DESCRIPTION
## Description

- Updated sonarcloud.properties to exclude all .yaml files within the docs folder and subdirectories.

## Why
This change prevents non-code files from affecting the SonarCloud quality gate checks.

## Issue

#1274 

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code