### PR TITLE
fix(app registration process): wrong api calling to download documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bugfixes
+
+- **App Registration Process**
+  - fixed wrong api calling to download documents
+
 ## 2.3.0-RC2
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugfixes
 
 - **App Registration Process**
-  - fixed wrong api calling to download documents
+  - fixed wrong api calling to download documents [#1299](https://github.com/eclipse-tractusx/portal-frontend/pull/1299)
 
 ## 2.3.0-RC2
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -446,7 +446,7 @@ npm/npmjs/-/resolve/1.22.8, MIT AND ISC, approved, #15315
 npm/npmjs/-/resolve/2.0.0-next.5, MIT AND ISC, approved, #3078
 npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/rollup/4.24.0, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/4.24.0, MIT AND (ISC AND MIT), approved, #16917
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/safe-array-concat/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/safe-regex-test/1.0.3, MIT, approved, clearlydefined
@@ -690,22 +690,22 @@ npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/@reduxjs/toolkit/2.2.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
 npm/npmjs/@remix-run/router/1.19.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/pluginutils/5.1.2, MIT, approved, #16428
-npm/npmjs/@rollup/rollup-android-arm-eabi/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-arm64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-x64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-musl/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-musl/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-android-arm-eabi/4.24.0, MIT AND (ISC AND MIT), approved, #16904
+npm/npmjs/@rollup/rollup-android-arm64/4.24.0, MIT AND (ISC AND MIT), approved, #16918
+npm/npmjs/@rollup/rollup-darwin-arm64/4.24.0, MIT AND (ISC AND MIT), approved, #16908
+npm/npmjs/@rollup/rollup-darwin-x64/4.24.0, MIT AND (ISC AND MIT), approved, #16901
+npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.24.0, MIT AND (ISC AND MIT), approved, #16906
+npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.24.0, MIT AND (ISC AND MIT), approved, #16914
+npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16910
+npm/npmjs/@rollup/rollup-linux-arm64-musl/4.24.0, MIT AND (ISC AND MIT), approved, #16912
+npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16916
+npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16907
+npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16919
+npm/npmjs/@rollup/rollup-linux-x64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16915
+npm/npmjs/@rollup/rollup-linux-x64-musl/4.24.0, MIT AND (ISC AND MIT), approved, #16911
+npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16909
+npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16913
+npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16902
 npm/npmjs/@rtsao/scc/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, clearlydefined
 npm/npmjs/@sinonjs/commons/3.0.1, BSD-3-Clause, approved, #12905

--- a/src/components/shared/basic/ReleaseProcess/ContractAndConsent/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/ContractAndConsent/index.tsx
@@ -28,12 +28,12 @@ import {
   useUpdateAgreementConsentsMutation,
   useFetchAppStatusQuery,
   useUpdateDocumentUploadMutation,
-  useFetchNewDocumentByIdMutation,
   useFetchFrameDocumentByIdMutation,
 } from 'features/appManagement/apiSlice'
 import { setAppStatus } from 'features/appManagement/actions'
 import CommonContractAndConsent from '../components/CommonContractAndConsent'
 import { ReleaseProcessTypes } from 'features/serviceManagement/apiSlice'
+import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 
 export default function ContractAndConsent() {
   const { t } = useTranslation()
@@ -48,7 +48,7 @@ export default function ContractAndConsent() {
   const { data: fetchAppStatus } = useFetchAppStatusQuery(appId ?? '', {
     refetchOnMountOrArgChange: true,
   })
-  const [getDocumentById] = useFetchNewDocumentByIdMutation()
+  const [fetchDocumentById] = useFetchDocumentByIdMutation()
   const [fetchFrameDocumentById] = useFetchFrameDocumentByIdMutation()
 
   useEffect(() => {
@@ -92,7 +92,7 @@ export default function ContractAndConsent() {
         updateAgreementConsents={updateAgreementConsents}
         updateDocumentUpload={updateDocumentUpload}
         fetchStatusData={fetchAppStatus ?? undefined}
-        getDocumentById={getDocumentById}
+        getDocumentById={fetchDocumentById}
         fetchFrameDocumentById={fetchFrameDocumentById}
         helpUrl={
           '/documentation/?path=user%2F04.+App%28s%29%2F02.+App+Release+Process%2F03.+Terms%26Conditions.md'

--- a/src/components/shared/basic/ReleaseProcess/components/CommonContractAndConsent.tsx
+++ b/src/components/shared/basic/ReleaseProcess/components/CommonContractAndConsent.tsx
@@ -106,7 +106,7 @@ type CommonConsentType = {
   fetchStatusData: AppStatusDataState | ServiceStatusDataState | undefined
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
-  getDocumentById?: (id: string) => any
+  getDocumentById?: (data: { appId: string; documentId: string }) => any
   // Add an ESLint exception until there is a solution
   // eslint-disable-next-line
   fetchFrameDocumentById?: (id: string) => any
@@ -413,7 +413,10 @@ export default function CommonContractAndConsent({
   const handleDownload = async (documentName: string, documentId: string) => {
     if (getDocumentById)
       try {
-        const response = await getDocumentById(documentId).unwrap()
+        const response = await getDocumentById({
+          appId: id,
+          documentId,
+        }).unwrap()
 
         const fileType = response.headers.get('content-type')
         const file = response.data


### PR DESCRIPTION
## Description

fix wrong api is called in the registration process of an app

## Why

Correct api should be called for download documents in the registration process of an app to make it functional.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1226

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
