### PR TITLE
fix: connector url edit error message in detail overlay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,11 +71,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f779452ac5af1c261dce0346a8f964149f49322b # v2.227
+        uses: github/codeql-action/init@662472033e021d55d94146f66f6058822b0b39fd # v2.227
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -89,7 +89,7 @@ jobs:
       # Automates dependency installation for Python, Ruby, and JavaScript, optimizing the CodeQL analysis setup.
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f779452ac5af1c261dce0346a8f964149f49322b # v2.227
+        uses: github/codeql-action/autobuild@662472033e021d55d94146f66f6058822b0b39fd # v2.227
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -102,6 +102,6 @@ jobs:
       #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f779452ac5af1c261dce0346a8f964149f49322b # v2.227
+        uses: github/codeql-action/analyze@662472033e021d55d94146f66f6058822b0b39fd # v2.227
         with:
           category: '/language:${{matrix.language}}'

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -32,13 +32,13 @@ jobs:
 
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@b36c23c0d998641eff861008f374ee103c25ac73 # v4.4.0
+        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b # v4.5.0
         with:
           distribution: 'temurin'
           java-version: '17'
 
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Generate Dependencies file
         run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.1.1.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -42,7 +42,7 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: KICS scan
         uses: checkmarx/kics-github-action@94469746ec2c43de89a42fb9d2a80070f5d25b16 # v2.1.3
@@ -67,6 +67,6 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         with:
           sarif_file: kicsResults/results.sarif

--- a/.github/workflows/release-release_candidate.yml
+++ b/.github/workflows/release-release_candidate.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
@@ -140,7 +140,7 @@ jobs:
         run: echo "RELEASE_VERSION=${{ env.REF_NAME }}" >> $GITHUB_ENV
 
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check for hotfix version
         id: hf-check

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/trivy-main.yml
+++ b/.github/workflows/trivy-main.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
@@ -63,7 +63,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         if: always()
         with:
           sarif_file: 'trivy-results1.sarif'
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # It's also possible to scan your private registry with Trivy's built-in image scan.
       # All you have to do is set ENV vars.
@@ -96,6 +96,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         with:
           sarif_file: 'trivy-results2.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run Trivy vulnerability scanner in repo mode
         uses: aquasecurity/trivy-action@915b19bbe73b92a6cf82a1bc12b087c9a19a5fe2 # v0.28.0
@@ -63,7 +63,7 @@ jobs:
           vuln-type: 'os,library'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         if: always()
         with:
           sarif_file: 'trivy-results1.sarif'
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # It's also possible to scan your private registry with Trivy's built-in image scan.
       # All you have to do is set ENV vars.
@@ -96,6 +96,6 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@f779452ac5af1c261dce0346a8f964149f49322b # v3.26.13
+        uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
         with:
           sarif_file: 'trivy-results2.sarif'

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0 # Ensure full clone for pull request workflows
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@b66c1670749c06f8d18f96bcbc5a6b80f7a7108e #v3.82.11
+        uses: trufflesecurity/trufflehog@1aa1871f9ae24a8c8a3a48a9345514acf42beb39 #v3.82.13
         continue-on-error: true
         with:
           path: ./ # Scan the entire repository

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -199,6 +199,7 @@ const ConnectorDetailsOverlay = ({
             closeWithIcon={true}
             onCloseWithIcon={(e) => {
               setOpenApiErrorModal(false)
+              setEnableUrlApiErrorMsg(false)
               handleOverlayClose(e)
             }}
           />
@@ -243,6 +244,7 @@ const ConnectorDetailsOverlay = ({
               variant="outlined"
               onClick={(e) => {
                 setOpenApiErrorModal(false)
+                setEnableUrlApiErrorMsg(false)
                 handleOverlayClose(e)
               }}
             >
@@ -483,11 +485,41 @@ const ConnectorDetailsOverlay = ({
                     </Grid>
                   )
                 })}
-                <Grid container sx={{ mt: 0, alignContent: 'left' }}>
-                  <Grid item sx={{ ml: 0, mr: 0 }} xs={3}>
-                    <Typography variant="body2" sx={{ textAlign: 'left' }}>
-                      {t('content.edcconnector.details.SdDocument')}
-                    </Typography>
+                <>
+                  <Grid container sx={{ mt: 0, alignContent: 'left' }}>
+                    <Grid item sx={{ ml: 0, mr: 0 }} xs={3}>
+                      <Typography variant="body2" sx={{ textAlign: 'left' }}>
+                        {t('content.edcconnector.details.SdDocument')}
+                      </Typography>
+                    </Grid>
+                    <Grid item sx={{ ml: 0, mr: 0 }} xs={8}>
+                      <Typography variant="body2" sx={{ textAlign: 'left' }}>
+                        {fetchConnectorDetails?.selfDescriptionDocumentId ===
+                        null ? (
+                          t('content.edcconnector.details.noDocumentAvailable')
+                        ) : (
+                          <Box sx={{ display: 'flex' }}>
+                            <ArticleOutlinedIcon
+                              sx={{ color: '#9c9c9c', mr: 1 }}
+                            />
+                            <button
+                              className="document-button-link"
+                              onClick={() =>
+                                fetchConnectorDetails?.selfDescriptionDocumentId &&
+                                handleDownloadFn(
+                                  fetchConnectorDetails?.selfDescriptionDocumentId,
+                                  t('content.edcconnector.details.SdDocument')
+                                )
+                              }
+                            >
+                              {t(
+                                'content.edcconnector.details.selfDescriptionDocument'
+                              )}
+                            </button>
+                          </Box>
+                        )}
+                      </Typography>
+                    </Grid>
                   </Grid>
                   <Grid item sx={{ ml: 0, mr: 0 }} xs={8}>
                     <Typography variant="body2" sx={{ textAlign: 'left' }}>
@@ -517,7 +549,7 @@ const ConnectorDetailsOverlay = ({
                       )}
                     </Typography>
                   </Grid>
-                </Grid>
+                </>
                 <Divider sx={{ margin: '20px auto', color: 'black' }} />
               </>
             )}
@@ -528,6 +560,7 @@ const ConnectorDetailsOverlay = ({
               onClick={(e) => {
                 handleOverlayClose(e)
                 setUrlErrorMsg('')
+                setEnableUrlApiErrorMsg(false)
               }}
             >
               {t('global.actions.close')}


### PR DESCRIPTION
## Description
Error persists of not-permitted edit URL in Connector configuration UI on different overlay of Connector configuration.

Changelog entry:

```
- **Connector Management**
  - Edit URL error message persists in Connector configuration [#1301](https://github.com/eclipse-tractusx/portal-frontend/issues/1301)
```

## Why
we didn't handle the case where we have to make error message state to false on Overlay close of first Overlay Modal before opening second overlay modal of Connector configuration.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1301

## Checklist
Please delete options that are not relevant.
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
