### PR TITLE
feat(technical user management): enhance creation page by role type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Change
 
 - **Technical Uaer Management**
-  - enhanced technical user management creation page by role type
+  - enhanced technical user management creation page by role type [#1303](https://github.com/eclipse-tractusx/portal-frontend/pull/1303)
 
 ## 2.3.0-RC2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Change
+
+- **Technical Uaer Management**
+  - enhanced technical user management creation page by role type
+
 ## 2.3.0-RC2
 
 ### Bugfixes

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -446,7 +446,7 @@ npm/npmjs/-/resolve/1.22.8, MIT AND ISC, approved, #15315
 npm/npmjs/-/resolve/2.0.0-next.5, MIT AND ISC, approved, #3078
 npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/rollup/4.24.0, MIT, approved, clearlydefined
+npm/npmjs/-/rollup/4.24.0, MIT AND (ISC AND MIT), approved, #16917
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/safe-array-concat/1.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/safe-regex-test/1.0.3, MIT, approved, clearlydefined
@@ -690,22 +690,22 @@ npm/npmjs/@react-hook/latest/1.0.3, MIT, approved, clearlydefined
 npm/npmjs/@reduxjs/toolkit/2.2.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND Apache-2.0, approved, #14170
 npm/npmjs/@remix-run/router/1.19.2, MIT, approved, clearlydefined
 npm/npmjs/@rollup/pluginutils/5.1.2, MIT, approved, #16428
-npm/npmjs/@rollup/rollup-android-arm-eabi/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-android-arm64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-arm64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-darwin-x64/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-arm64-musl/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-gnu/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-linux-x64-musl/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT, approved, clearlydefined
-npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT, approved, clearlydefined
+npm/npmjs/@rollup/rollup-android-arm-eabi/4.24.0, MIT AND (ISC AND MIT), approved, #16904
+npm/npmjs/@rollup/rollup-android-arm64/4.24.0, MIT AND (ISC AND MIT), approved, #16918
+npm/npmjs/@rollup/rollup-darwin-arm64/4.24.0, MIT AND (ISC AND MIT), approved, #16908
+npm/npmjs/@rollup/rollup-darwin-x64/4.24.0, MIT AND (ISC AND MIT), approved, #16901
+npm/npmjs/@rollup/rollup-linux-arm-gnueabihf/4.24.0, MIT AND (ISC AND MIT), approved, #16906
+npm/npmjs/@rollup/rollup-linux-arm-musleabihf/4.24.0, MIT AND (ISC AND MIT), approved, #16914
+npm/npmjs/@rollup/rollup-linux-arm64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16910
+npm/npmjs/@rollup/rollup-linux-arm64-musl/4.24.0, MIT AND (ISC AND MIT), approved, #16912
+npm/npmjs/@rollup/rollup-linux-powerpc64le-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16916
+npm/npmjs/@rollup/rollup-linux-riscv64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16907
+npm/npmjs/@rollup/rollup-linux-s390x-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16919
+npm/npmjs/@rollup/rollup-linux-x64-gnu/4.24.0, MIT AND (ISC AND MIT), approved, #16915
+npm/npmjs/@rollup/rollup-linux-x64-musl/4.24.0, MIT AND (ISC AND MIT), approved, #16911
+npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16909
+npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16913
+npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16902
 npm/npmjs/@rtsao/scc/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, clearlydefined
 npm/npmjs/@sinonjs/commons/3.0.1, BSD-3-Clause, approved, #12905

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1096,15 +1096,19 @@
       "technicalUser": {
         "addOverlay": {
           "service": "Technical User Role",
-          "serviceSubHeading": "Select one of the following service roles:",
+          "note": "<strong>Notiz:</strong> Die Auswahl sowohl interner als auch externer Benutzer für denselben Dienst ist nicht möglich.",
+          "internalRoles": "Interne Rollen:",
+          "externalRoles": "Externe Rollen:",
           "username": "Username*",
           "description": "Beschreibung*",
           "spocHeadline": "Single Point of Contact (SPoC)",
           "org": "Organization name",
           "email": "E-Mail Address",
           "name": "Username",
+          "roleMandatory": "Die Rolle des technischen Benutzers ist obligatorisch",
           "error": {
             "select": "Bitte wählen Sie einen Wert.",
+            "username": "Bitte geben Sie den Benutzernamen ein.",
             "description": "Bitte geben Sie eine Beschreibung ein."
           }
         }

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1101,16 +1101,20 @@
       "technicalUser": {
         "addOverlay": {
           "service": "Technical User Role",
-          "serviceSubHeading": "Select one of the following service roles:",
+          "note": "<strong>Note:</strong> Selection of both internal and external users for the same service is not possible.",
+          "internalRoles": "Internal Roles :",
+          "externalRoles": "External Roles :",
           "username": "Username*",
           "description": "Description*",
           "spocHeadline": "Single Point of Contact (SPoC)",
           "org": "Organization name",
           "email": "E-Mail Address",
           "name": "Username",
+          "roleMandatory": "Technical user Role is mandatory",
           "error": {
             "select": "Please select a value.",
-            "description": "Please enter a description."
+            "username": "Please enter username.",
+            "description": "Please enter description."
           }
         }
       }

--- a/src/components/overlays/AddTechnicalUser/TechnicalUserAddForm.tsx
+++ b/src/components/overlays/AddTechnicalUser/TechnicalUserAddForm.tsx
@@ -96,36 +96,45 @@ const TechnicalUserAddFormSelect = ({
   const [roleError, setRoleError] = useState<boolean>(false)
   const [selectedRoles, setSelectedRoles] = useState<string[]>([])
 
-  const selectCheckboxRoles = (
-    role: string,
-    select: boolean,
-    type?: string
-  ) => {
+  const selectCheckboxRoles = (role: string, select: boolean) => {
     if (selectedRoles && selectedRoles[0] === externalRoles?.[0].roleId) {
-      if (type === 'checkbox') setSelectedRoles([...[], role])
-      else return [...[], role]
+      setSelectedRoles([...[], role])
     } else {
       const isSelected = selectedRoles?.includes(role)
       if (isSelected && selectedRoles.length === 1) setRoleError(true)
       if (!isSelected && select) {
-        if (type === 'checkbox') setSelectedRoles([...selectedRoles, role])
-        else return [...selectedRoles, role]
+        setSelectedRoles([...selectedRoles, role])
       } else if (isSelected && !select) {
         const oldRoles = [...selectedRoles]
         oldRoles.splice(oldRoles.indexOf(role), 1)
-        if (type === 'checkbox') setSelectedRoles([...oldRoles])
-        else return [...oldRoles]
+        setSelectedRoles([...oldRoles])
       }
     }
   }
 
   const selectRoles = (role: string, select: boolean, type: string) => {
     if (type === 'checkbox') {
-      selectCheckboxRoles(role, select, type)
+      selectCheckboxRoles(role, select)
     } else if (type === 'radio') {
       setSelectedRoles([...[], role])
     }
     if (selectedRoles.length === 0) setRoleError(false)
+  }
+
+  const selectCheckboxOnChange = (role: string, select: boolean) => {
+    if (selectedRoles && selectedRoles[0] === externalRoles?.[0].roleId) {
+      return [...[], role]
+    } else {
+      const isSelected = selectedRoles?.includes(role)
+      if (isSelected && selectedRoles.length === 1) setRoleError(true)
+      if (!isSelected && select) {
+        return [...selectedRoles, role]
+      } else if (isSelected && !select) {
+        const oldRoles = [...selectedRoles]
+        oldRoles.splice(oldRoles.indexOf(role), 1)
+        return [...oldRoles]
+      }
+    }
   }
 
   return (
@@ -158,7 +167,9 @@ const TechnicalUserAddFormSelect = ({
                   onChange={(e) => {
                     selectRoles(role.roleId, e.target.checked, 'checkbox')
                     trigger(name)
-                    onChange(selectCheckboxRoles(role.roleId, e.target.checked))
+                    onChange(
+                      selectCheckboxOnChange(role.roleId, e.target.checked)
+                    )
                   }}
                   size="small"
                   value={selectedRoles}

--- a/src/components/overlays/AddTechnicalUser/index.tsx
+++ b/src/components/overlays/AddTechnicalUser/index.tsx
@@ -61,7 +61,7 @@ export const AddTechnicalUser = () => {
         name: formValues.TechnicalUserName,
         description: formValues.TechnicalUserDescription,
         authenticationType: ServiceAccountType.SECRET,
-        roleIds: [formValues.TechnicalUserService],
+        roleIds: formValues.TechnicalUserService,
       }).unwrap()
       setResponse(result)
       setLoading(false)
@@ -77,7 +77,7 @@ export const AddTechnicalUser = () => {
 
   const defaultFormFieldValues = {
     TechnicalUserName: '',
-    TechnicalUserService: 'none',
+    TechnicalUserService: [''],
     TechnicalUserDescription: '',
   }
   const {

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -39,6 +39,7 @@ export interface ServiceAccountRole {
   roleId: string
   roleDescription: string
   roleName: string
+  roleType: string
 }
 
 export interface ServiceAccountCreate {


### PR DESCRIPTION
## Description

Enhanced technical user management creation page by role type

## Why

As a Frontend Developer, I need to update the technical user self-service creation UI to include:
- fields for technical user type
- fields for service endpoint so that operators can specify and view this information during user setup.
- clear separation of internal / external users
- logic adjustment to ensure that the simultaneous selection of internal users and external users is not possible

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1077

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally