### PR TITLE
fix: connector url edit error message in detail overlay

### DIFF
--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -200,6 +200,7 @@ const ConnectorDetailsOverlay = ({
             onCloseWithIcon={(e) => {
               setOpenApiErrorModal(false)
               handleOverlayClose(e)
+              setEnableUrlApiErrorMsg(false)
             }}
           />
           <DialogContent
@@ -244,6 +245,7 @@ const ConnectorDetailsOverlay = ({
               onClick={(e) => {
                 setOpenApiErrorModal(false)
                 handleOverlayClose(e)
+                setEnableUrlApiErrorMsg(false)
               }}
             >
               {t('global.actions.close')}
@@ -528,6 +530,7 @@ const ConnectorDetailsOverlay = ({
               onClick={(e) => {
                 handleOverlayClose(e)
                 setUrlErrorMsg('')
+                setEnableUrlApiErrorMsg(false)
               }}
             >
               {t('global.actions.close')}


### PR DESCRIPTION
## Description
Error persists of not-permitted edit URL in Connector configuration UI on different overlay of Connector configuration.

Changelog entry:

```
- **Connector Management**
  - Edit URL error message persists in Connector configuration [#1301](https://github.com/eclipse-tractusx/portal-frontend/issues/1301)
```

## Why
we didn't handle the case where we have to make error message state to false on Overlay close of first Overlay Modal before opening second overlay modal of Connector configuration.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1301

## Checklist
Please delete options that are not relevant.
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
