### PR TITLE
fix(service marketplace detail): add providerUri in the provider details page

### DIFF
--- a/src/components/pages/ServiceMarketplaceDetail/components/MarketplaceProvider/index.tsx
+++ b/src/components/pages/ServiceMarketplaceDetail/components/MarketplaceProvider/index.tsx
@@ -38,7 +38,12 @@ export default function MarketplaceProvider({
 
   const tableData: TableType = {
     head: [t('appProvider'), t('website'), t('email'), t('phone')],
-    body: [[item.provider], [item.website], [item.contactEmail], [item.phone]],
+    body: [
+      [item.provider],
+      [item.providerUri],
+      [item.contactEmail],
+      [item.phone],
+    ],
   }
 
   return (

--- a/src/features/serviceMarketplace/serviceApiSlice.ts
+++ b/src/features/serviceMarketplace/serviceApiSlice.ts
@@ -49,6 +49,7 @@ export type ServiceRequest = {
   serviceTypes: string[]
   serviceTypeIds?: string[]
   provider: string
+  providerUri: string
   leadPictureUri: string
   contactEmail: string
   description: string


### PR DESCRIPTION
## Description

The 'Provider Homepage' field should display the URL provided during the service creation process on the Service details page.

## Why

The 'Provider Homepage' field on the Service Details page is displayed as blank, even though a URL was added during the service creation process.

**Reference:** https://github.com/eclipse-tractusx/portal-backend/pull/1126/files

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1326

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

## Changelog Entry

- **Service Marketplace Detail**
  - add providerUri in the provider details page [#1326](https://github.com/eclipse-tractusx/portal-frontend/issues/1326)


