### PR TITLE
fix: text message not shown when no data is available

### DIFF
--- a/src/components/pages/CertificateCredentials/CertificateElements.tsx
+++ b/src/components/pages/CertificateCredentials/CertificateElements.tsx
@@ -17,9 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useTranslation } from 'react-i18next'
 import { Grid } from '@mui/material'
-import { Typography } from '@catena-x/portal-shared-components'
 import type { CertificateResponse } from 'features/certification/certificationApiSlice'
 import { CertificateCard } from 'components/shared/basic/CertificateCard'
 import './CertificateCredentials.scss'
@@ -29,16 +27,6 @@ export default function CertificateElements({
 }: Readonly<{
   data: CertificateResponse[]
 }>) {
-  const { t } = useTranslation()
-
-  if (data && data.length === 0) {
-    return (
-      <Typography variant="body1" className="noData">
-        {t('content.certificates.noData')}
-      </Typography>
-    )
-  }
-
   return (
     <Grid container spacing={2} className="certificate-section">
       {data?.map((item: CertificateResponse) =>

--- a/src/components/pages/CertificateCredentials/index.tsx
+++ b/src/components/pages/CertificateCredentials/index.tsx
@@ -116,7 +116,7 @@ export default function CertificateCredentials() {
   const dispatch = useDispatch()
   const { t } = useTranslation()
 
-  const { data } = useFetchCertificatesQuery()
+  const { data, isFetching } = useFetchCertificatesQuery()
   const { data: certificateTypes } = useFetchCertificateTypesQuery()
 
   const [{ searchExpr, showModal, selected, sortOption }, setState] =
@@ -260,7 +260,15 @@ export default function CertificateCredentials() {
                 />
               )}
             </div>
-            {data && <CertificateElements data={data} />}
+            {data?.length ? (
+              <CertificateElements data={data} />
+            ) : (
+              !isFetching && (
+                <Typography variant="body1" className="noData">
+                  {t('content.certificates.noData')}
+                </Typography>
+              )
+            )}
           </div>
 
           <div style={{ height: '66px' }}></div>


### PR DESCRIPTION
## Description

Added a default message on the Certificate Credentials page to inform users when no certificate data is available.

## Why

To display a default message when no certificate data is available.

## Issue
#1319 

## Checklist

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally