### PR TITLE
fix(idp-config): fix shared IdP to remove configure option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - **App Marketplace**
   - fixed updating of favorites in app marketplace [#1345](https://github.com/eclipse-tractusx/portal-frontend/pull/1345)
+- **IDP Management**
+  - fixed shared IdP to remove 'configure' option
 
 ## 2.3.0-RC4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - **App Marketplace**
   - fixed updating of favorites in app marketplace [#1345](https://github.com/eclipse-tractusx/portal-frontend/pull/1345)
 - **IDP Management**
-  - fixed shared IdP to remove 'configure' option
+  - fixed shared IdP to remove 'configure' option as its not viable [#1356](https://github.com/eclipse-tractusx/portal-frontend/pull/1356)
 
 ## 2.3.0-RC4
 

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -263,7 +263,8 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
     return (
       <div className="action-menu">
         <DropdownMenu buttonText={ti('action.actions')}>
-          {menuItems.configure}
+          {idp.identityProviderTypeId !== IDPCategory.SHARED &&
+            menuItems.configure}
           {isManaged && idp.enabled && menuItems.register}
           {idp.oidc?.clientId && menuItems.enableToggle}
           {!isManaged && (idp.enabled ? menuItems.addUsers : menuItems.delete)}


### PR DESCRIPTION
## Description

Fixed shared IdP to remove 'configure' option as its not viable

## Why

For Identity Provider with identityProviderTypeId SHARED the configure option and the according overlay should not be displayed because the SHARED IdP can't be configured.  Also, the user shouldn't be shown a option that's not viable

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1350

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/developer/Technical%20Documentation/Dev%20Process/How%20to%20contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
