### PR TITLE
fix: resolve style issue on app permission chip button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - fixed updating of favorites in app marketplace [#1345](https://github.com/eclipse-tractusx/portal-frontend/pull/1345)
 - **IDP Management**
   - fixed shared IdP to remove 'configure' option as its not viable [#1356](https://github.com/eclipse-tractusx/portal-frontend/pull/1356)
+- **User Management Details**
+  - fixed truncated chip button issue in the app permissions section
 
 ## 2.3.0-RC4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
   - fixed updating of favorites in app marketplace [#1345](https://github.com/eclipse-tractusx/portal-frontend/pull/1345)
 - **IDP Management**
   - fixed shared IdP to remove 'configure' option as its not viable [#1356](https://github.com/eclipse-tractusx/portal-frontend/pull/1356)
-- **User Management Details**
-  - fixed truncated chip button issue in the app permissions section
 
 ## 2.3.0-RC4
 

--- a/src/components/shared/frame/AppPermissions/index.tsx
+++ b/src/components/shared/frame/AppPermissions/index.tsx
@@ -62,7 +62,7 @@ export const AppPermissions = ({ user }: { user: TenantUserDetails }) => {
           type="plain"
           variant="filled"
           withIcon={false}
-          sx={{ marginLeft: '10px' }}
+          sx={{ marginLeft: '10px', marginTop: '5px' }}
         />
       ))}
     </>


### PR DESCRIPTION
## Description

resolved truncated chip button issue in the app permissions section

```
**User Management Details**
  - fixed truncated chip button issue in the app permissions section [#1372] (https://github.com/eclipse-tractusx/portal-frontend/pull/1372)
```

## Why

permissions are truncated

## Issue

#1358 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
