### PR TITLE
fix(connector-management): fix URL update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
   - fixed updating of favorites in app marketplace [#1345](https://github.com/eclipse-tractusx/portal-frontend/pull/1345)
 - **IDP Management**
   - fixed shared IdP to remove 'configure' option as its not viable [#1356](https://github.com/eclipse-tractusx/portal-frontend/pull/1356)
-- **Connector Management**
-  - fixed URL update in connector details [#1373](https://github.com/eclipse-tractusx/portal-frontend/pull/1373)
 
 ## 2.3.0-RC4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - fixed updating of favorites in app marketplace [#1345](https://github.com/eclipse-tractusx/portal-frontend/pull/1345)
 - **IDP Management**
   - fixed shared IdP to remove 'configure' option as its not viable [#1356](https://github.com/eclipse-tractusx/portal-frontend/pull/1356)
+- **Connector Management**
+  - fixed URL update in connector details
 
 ## 2.3.0-RC4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **IDP Management**
   - fixed shared IdP to remove 'configure' option as its not viable [#1356](https://github.com/eclipse-tractusx/portal-frontend/pull/1356)
 - **Connector Management**
-  - fixed URL update in connector details
+  - fixed URL update in connector details [#1373](https://github.com/eclipse-tractusx/portal-frontend/pull/1373)
 
 ## 2.3.0-RC4
 

--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -156,6 +156,7 @@ const ConnectorDetailsOverlay = ({
         .unwrap()
         .then(() => {
           success(t('content.edcconnector.details.urlUpdatedSuccessfully'))
+          refetch()
           setEnableConnectorUrl(true)
         })
         .catch(() => {


### PR DESCRIPTION
## Description

Fixed URL update in connector details

Changelog entry:

```
- **Connector Management**
  - fixed URL update in connector details [#1373](https://github.com/eclipse-tractusx/portal-frontend/pull/1373)
 ```

## Why

Updated URL is not reflecting in connector details page until page refresh

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1366

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
