### PR TITLE
fix(service release process): fix download document

### DIFF
--- a/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -66,6 +66,7 @@ import RetryOverlay from '../components/RetryOverlay'
 import { success, error } from 'services/NotifyService'
 import { DocumentTypeId } from 'features/appManagement/apiSlice'
 import { PAGES } from 'types/Constants'
+import { download } from 'utils/downloadUtils'
 
 type FormDataType = {
   title: string
@@ -178,6 +179,23 @@ export default function OfferCard() {
     },
     [fetchDocumentById, serviceId, setValue]
   )
+
+  const handleDownload = async (documentName: string, documentId: string) => {
+    if (fetchDocumentById)
+      try {
+        const response = await fetchDocumentById({
+          appId: serviceId,
+          documentId,
+        }).unwrap()
+
+        const fileType = response.headers.get('content-type')
+        const file = response.data
+
+        download(file, fileType, documentName)
+      } catch (error) {
+        console.error(error, 'ERROR WHILE FETCHING DOCUMENT')
+      }
+  }
 
   useEffect(() => {
     if (serviceStatusData?.documents?.SERVICE_LEADIMAGE?.[0].documentId) {
@@ -497,6 +515,7 @@ export default function OfferCard() {
               note={t('serviceReleaseForm.note')}
               requiredText={t('serviceReleaseForm.fileUploadIsMandatory')}
               isRequired={false}
+              handleDownload={handleDownload}
               handleDelete={(documentId: string) => {
                 setImageData({})
                 documentId && deleteDocument(documentId)

--- a/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferCard/index.tsx
@@ -67,6 +67,7 @@ import { success, error } from 'services/NotifyService'
 import { DocumentTypeId } from 'features/appManagement/apiSlice'
 import { PAGES } from 'types/Constants'
 import { download } from 'utils/downloadUtils'
+import { extractFileData } from 'utils/fileUtils'
 
 type FormDataType = {
   title: string
@@ -188,8 +189,7 @@ export default function OfferCard() {
           documentId,
         }).unwrap()
 
-        const fileType = response.headers.get('content-type')
-        const file = response.data
+        const { fileType, file } = extractFileData(response)
 
         download(file, fileType, documentName)
       } catch (error) {

--- a/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferPage/index.tsx
@@ -58,6 +58,7 @@ import { success, error } from 'services/NotifyService'
 import { download } from 'utils/downloadUtils'
 import { type FileState } from 'features/serviceManagement/types'
 import { ALLOWED_MAX_SIZE_DOCUMENT } from 'types/Constants'
+import { extractFileData } from 'utils/fileUtils'
 
 type FormDataType = {
   longDescriptionEN: string
@@ -282,8 +283,7 @@ export default function OfferPage({
           documentId,
         }).unwrap()
 
-        const fileType = response.headers.get('content-type')
-        const file = response.data
+        const { fileType, file } = extractFileData(response)
 
         download(file, fileType, documentName)
       } catch (error) {

--- a/src/features/serviceManagement/types.ts
+++ b/src/features/serviceManagement/types.ts
@@ -75,6 +75,11 @@ export enum SORTING_TYPE {
   PROVIDER_DESC = 'ProviderDesc',
 }
 
+export interface FileState {
+  id: string
+  name: string
+}
+
 export const initialState: ServiceManagementState = {
   serviceReleaseActiveStep: 1,
   serviceId: '',


### PR DESCRIPTION
## Description

fix wrong api is called in the service release process for all steps.

Changelog entry:

```
- **Service Release Process**:
  - fixed wrong api calling to download documents for all steps [#1384](https://github.com/eclipse-tractusx/portal-frontend/pull/1384)
```

## Why

Correct api should be called for download documents in the service release process to make it functional.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1225

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
