### PR TITLE
fix(company data): show error message in edit company data overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## Unreleased
 
-### Change
-
-- **Company Data**
-  - show error message in company data edit overlay screen [#1385] (https://github.com/eclipse-tractusx/portal-frontend/pull/1385)
-
 ### Bugfixes
 
 - **Onboarding Service Provider**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Change
+
+- **Company Data**
+  - show error message in company data edit overlay screen [#1385] (https://github.com/eclipse-tractusx/portal-frontend/pull/1385)
+
 ### Bugfixes
 
 - **Onboarding Service Provider**

--- a/src/components/pages/CompanyData/components/DetailsOverlay.tsx
+++ b/src/components/pages/CompanyData/components/DetailsOverlay.tsx
@@ -95,6 +95,7 @@ export default function DetailsOverlay({
           handleClose={handleClose}
           open={edit}
           handleConfirm={handleConfirm}
+          errorInfo={sharingStateErrorInfo}
         />
       )}
     </Box>

--- a/src/components/pages/CompanyData/components/EditForm.tsx
+++ b/src/components/pages/CompanyData/components/EditForm.tsx
@@ -35,6 +35,7 @@ import {
   type CompanyDataType,
   useUpdateCompanySiteAndAddressMutation,
   type CompanyDataFieldsType,
+  type SharingStateType,
 } from 'features/companyData/companyDataApiSlice'
 import { useSelector } from 'react-redux'
 import {
@@ -53,6 +54,7 @@ interface FormDetailsProps {
   readonly isAddress?: boolean
   readonly handleConfirm: () => void
   readonly newForm?: boolean
+  readonly errorInfo?: SharingStateType
 }
 
 export default function EditForm({
@@ -62,6 +64,7 @@ export default function EditForm({
   isAddress = false,
   newForm = false,
   handleConfirm,
+  errorInfo,
 }: FormDetailsProps) {
   const { t } = useTranslation()
   const [loading, setLoading] = useState<boolean>(false)
@@ -165,6 +168,17 @@ export default function EditForm({
             }}
             isAddress={isAddress}
           />
+          {errorInfo && (
+            <Typography
+              variant="body1"
+              sx={{
+                fontSize: '18px',
+                color: '#d32f2f',
+              }}
+            >
+              {errorInfo.sharingErrorMessage}
+            </Typography>
+          )}
         </DialogContent>
         <DialogActions>
           <Button variant="outlined" onClick={handleClose}>


### PR DESCRIPTION
## Description

show error message in edit company data overlay in error scenario

```
**Company Data**
   - fixed displaying of error message in company data edit overlay screen [#1385] (https://github.com/eclipse-tractusx/portal-frontend/pull/1385)
```

## Why

Current behaviour does not show up what is the error in the edit overlay page. User has to close the overlay to have a relook on the error message in the company data page. So allow user to view the same error info in the edit page which helps him to fix the issues in the form

## Issue

#1383 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
