### PR TITLE
fix(app registration process): fix wrong api calling to download documents

### DIFF
--- a/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
@@ -74,6 +74,7 @@ import {
   type UseCaseType,
 } from 'features/appManagement/types'
 import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
+import { download } from 'utils/downloadUtils'
 
 type FormDataType = {
   title: string
@@ -450,6 +451,23 @@ export default function AppMarketCard() {
     await updateDocumentUpload(data).unwrap()
   }
 
+  const handleDownload = async (documentName: string, documentId: string) => {
+    if (fetchDocumentById)
+      try {
+        const response = await fetchDocumentById({
+          appId: appId,
+          documentId,
+        }).unwrap()
+
+        const fileType = response.headers.get('content-type')
+        const file = response.data
+
+        download(file, fileType, documentName)
+      } catch (error) {
+        console.error(error, 'ERROR WHILE FETCHING DOCUMENT')
+      }
+  }
+
   return (
     <div className="app-market-card">
       <RetryOverlay
@@ -811,6 +829,7 @@ export default function AppMarketCard() {
               requiredText={t(
                 'content.apprelease.appReleaseForm.fileUploadIsMandatory'
               )}
+              handleDownload={handleDownload}
               handleDelete={(documentId: string) => {
                 setCardImage(LogoGrayData)
                 documentId && deleteAppReleaseDocument(documentId)

--- a/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
@@ -75,6 +75,7 @@ import {
 } from 'features/appManagement/types'
 import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 import { download } from 'utils/downloadUtils'
+import { extractFileData } from 'utils/fileUtils'
 
 type FormDataType = {
   title: string
@@ -459,8 +460,7 @@ export default function AppMarketCard() {
           documentId,
         }).unwrap()
 
-        const fileType = response.headers.get('content-type')
-        const file = response.data
+        const { fileType, file } = extractFileData(response)
 
         download(file, fileType, documentName)
       } catch (error) {

--- a/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppMarketCard/index.tsx
@@ -455,7 +455,7 @@ export default function AppMarketCard() {
     if (fetchDocumentById)
       try {
         const response = await fetchDocumentById({
-          appId: appId,
+          appId,
           documentId,
         }).unwrap()
 

--- a/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
@@ -64,14 +64,13 @@ import {
   ErrorType,
   type LanguageStatusType,
   type UseCaseType,
-  type FileState,
 } from 'features/appManagement/types'
 import { ButtonLabelTypes } from '..'
 import { PrivacyPolicyType } from 'features/adminBoard/adminBoardApiSlice'
 import { phone } from 'phone'
 import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 import { download } from 'utils/downloadUtils'
-import { extractFileData } from 'utils/fileUtils'
+import { type FileState, extractFileData } from 'utils/fileUtils'
 import { ALLOWED_MAX_SIZE_DOCUMENT } from 'types/Constants'
 
 type FormDataType = {
@@ -476,16 +475,10 @@ export default function AppPage() {
     documentName: FileState[] | string,
     documentId?: string
   ) => {
-    let docId: string
-    let docName: string
-
-    if (Array.isArray(documentName)) {
-      docName = documentName[0].name
-      docId = documentName[0].id
-    } else {
-      docName = documentName
-      docId = documentId!
-    }
+    const docId = Array.isArray(documentName) ? documentName[0].id : documentId!
+    const docName = Array.isArray(documentName)
+      ? documentName[0].name
+      : documentName
 
     if (fetchDocumentById) {
       try {

--- a/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
@@ -70,7 +70,7 @@ import { PrivacyPolicyType } from 'features/adminBoard/adminBoardApiSlice'
 import { phone } from 'phone'
 import { useFetchDocumentByIdMutation } from 'features/apps/apiSlice'
 import { download } from 'utils/downloadUtils'
-import { type FileState, extractFileData } from 'utils/fileUtils'
+import { extractFileData } from 'utils/fileUtils'
 import { ALLOWED_MAX_SIZE_DOCUMENT } from 'types/Constants'
 
 type FormDataType = {
@@ -471,10 +471,7 @@ export default function AppPage() {
     }
   }
 
-  const handleDownload = async (
-    documentName: FileState[] | string,
-    documentId?: string
-  ) => {
+  const handleDownload = async (documentName: string, documentId?: string) => {
     const docId = Array.isArray(documentName) ? documentName[0].id : documentId!
     const docName = Array.isArray(documentName)
       ? documentName[0].name

--- a/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/AppPage/index.tsx
@@ -476,7 +476,7 @@ export default function AppPage() {
     if (fetchDocumentById)
       try {
         const response = await fetchDocumentById({
-          appId: appId,
+          appId,
           documentId,
         }).unwrap()
 
@@ -496,7 +496,7 @@ export default function AppPage() {
     if (fetchDocumentById)
       try {
         const response = await fetchDocumentById({
-          appId: appId,
+          appId,
           documentId,
         }).unwrap()
 

--- a/src/features/appManagement/types.ts
+++ b/src/features/appManagement/types.ts
@@ -83,11 +83,6 @@ export interface DescriptionState {
   shortDescription: string
 }
 
-export interface FileState {
-  id: string
-  name: string
-}
-
 export interface AgreementState {
   id: string
   name: string

--- a/src/features/appManagement/types.ts
+++ b/src/features/appManagement/types.ts
@@ -83,6 +83,11 @@ export interface DescriptionState {
   shortDescription: string
 }
 
+export interface FileState {
+  id: string
+  name: string
+}
+
 export interface AgreementState {
   id: string
   name: string

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+interface FileResponse {
+  headers: Headers
+  data: Blob
+}
+
+export const extractFileData = (response: FileResponse) => {
+  const fileType = response.headers.get('content-type')!
+  const file = response?.data
+  return { fileType, file }
+}

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -17,6 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+export interface FileState {
+  id: string
+  name: string
+}
+
 interface FileResponse {
   headers: Headers
   data: Blob

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -17,17 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-export interface FileState {
-  id: string
-  name: string
-}
-
-interface FileResponse {
-  headers: Headers
-  data: Blob
-}
-
-export const extractFileData = (response: FileResponse) => {
+export const extractFileData = (response: { headers: Headers; data: Blob }) => {
   const fileType = response.headers.get('content-type')!
   const file = response?.data
   return { fileType, file }


### PR DESCRIPTION
## Description

fix wrong api is called in the registration process of an app

Changelog entry:

```
- **App Registration Process**:
  - fixed wrong api calling to download documents [#1386](https://github.com/eclipse-tractusx/portal-frontend/pull/1386)
```

## Why

Correct api should be called for download documents in the registration process of an app to make it functional.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1226

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
