### PR TITLE
fix(Connector Registration): fix confirm button without mandatory fields

### DIFF
--- a/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -111,7 +111,7 @@ const AddConnectorOverlay = ({
     control,
     resetField,
     trigger,
-    formState: { errors },
+    formState: { errors, isValid },
     reset,
   } = useForm({
     defaultValues: formFields,
@@ -247,7 +247,7 @@ const AddConnectorOverlay = ({
           {!loading && (
             <Button
               variant="contained"
-              disabled={selected?.id ? false : true}
+              disabled={selected?.id && isValid ? false : true}
               onClick={() => {
                 connectorStep === 0 && selected?.id
                   ? handleConfirmClick(selected)

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -247,7 +247,7 @@ const AddConnectorOverlay = ({
           {!loading && (
             <Button
               variant="contained"
-              disabled={selected?.id && isValid ? false : true}
+              disabled={!(selected?.id && isValid)}
               onClick={() => {
                 connectorStep === 0 && selected?.id
                   ? handleConfirmClick(selected)


### PR DESCRIPTION
## Description

Confirm button is enabled Mandatory fields not being entered.

Changelog entry:

```
- **Connector Registration**:
  - fixed confirm button is enabled mandatory fields not being entered [#1389](https://github.com/eclipse-tractusx/portal-frontend/pull/1389)
```

## Why

Confirm button should not be enabled Mandatory fields not being entered

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1334

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
