### PR TITLE
refactor(osp): use new company role check

### DIFF
--- a/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorTypeSelection.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/components/ConnectorTypeSelection.tsx
@@ -22,11 +22,9 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Typography, Checkbox } from '@catena-x/portal-shared-components'
 import { Box, Grid } from '@mui/material'
-import {
-  type CompanyDetails,
-  CompanyRoleEnum,
-} from 'features/admin/userApiSlice'
+import { type CompanyDetails } from 'features/admin/userApiSlice'
 import { ConnectType } from 'features/connector/connectorApiSlice'
+import { COMPANY_ROLES } from 'types/Constants'
 
 // Static content
 // Add Connector Button action modal first step content
@@ -62,11 +60,9 @@ const ConnectorTypeSelection = ({
         !ownCompanyDetails?.companyRole ||
         ownCompanyDetails?.companyRole?.length === 0 ||
         (!ownCompanyDetails?.companyRole.includes(
-          CompanyRoleEnum.SERVICE_PROVIDER
+          COMPANY_ROLES.SERVICE_PROVIDER
         ) &&
-          !ownCompanyDetails?.companyRole.includes(
-            CompanyRoleEnum.APP_PROVIDER
-          )),
+          !ownCompanyDetails?.companyRole.includes(COMPANY_ROLES.APP_PROVIDER)),
       disableDescription: t(
         'content.edcconnector.modal.managed.disableDescription'
       ),

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -53,7 +53,6 @@ import {
   CompanyRoleEnum,
   useFetchOwnCompanyDetailsQuery,
 } from 'features/admin/userApiSlice'
-import { PAGES } from 'types/Constants'
 
 export const Header = ({
   main,
@@ -78,7 +77,6 @@ export const Header = ({
   const [submittedOverlayOpen, setSubmittedOverlayOpen] =
     useState<boolean>(false)
   const [headerNote, setHeaderNote] = useState(false)
-  const [pages, setPages] = useState<string[]>([])
 
   useEffect(() => {
     if (!(companyData && companyDetails)) return
@@ -87,22 +85,6 @@ export const Header = ({
         companyData?.applicationStatus === ApplicationStatus.SUBMITTED
     )
   }, [companyData, companyDetails])
-
-  useEffect(() => {
-    if (
-      companyDetails?.companyRole.includes(
-        CompanyRoleEnum.ONBOARDING_SERVICE_PROVIDER
-      )
-    ) {
-      setPages(user)
-    } else {
-      setPages(
-        user.filter(
-          (item) => item !== PAGES.ONBOARDING_SERVICE_PROVIDER_MANAGEMENT
-        )
-      )
-    }
-  }, [companyDetails?.companyRole])
 
   const addTitle = (items: Tree[] | undefined) =>
     items?.map(
@@ -216,7 +198,7 @@ export const Header = ({
             >
               {t('pages.help')}
             </Button>
-            <UserInfo pages={pages} />
+            <UserInfo pages={user} />
           </div>
         </MainNavigation>
       </header>

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -49,10 +49,8 @@ import RegistrationReviewOverlay from './RegistrationReviewOverlay'
 import './Header.scss'
 import RegistrationReviewContent from './RegistrationReviewOverlay/RegistrationReviewContent'
 import RegistrationDeclinedOverlay from './RegistrationDeclinedOverlay'
-import {
-  CompanyRoleEnum,
-  useFetchOwnCompanyDetailsQuery,
-} from 'features/admin/userApiSlice'
+import { useFetchOwnCompanyDetailsQuery } from 'features/admin/userApiSlice'
+import { COMPANY_ROLES } from 'types/Constants'
 
 export const Header = ({
   main,
@@ -81,7 +79,7 @@ export const Header = ({
   useEffect(() => {
     if (!(companyData && companyDetails)) return
     setSubmittedOverlayOpen(
-      !companyDetails?.companyRole.includes(CompanyRoleEnum.OPERATOR) &&
+      !companyDetails?.companyRole.includes(COMPANY_ROLES.OPERATOR) &&
         companyData?.applicationStatus === ApplicationStatus.SUBMITTED
     )
   }, [companyData, companyDetails])

--- a/src/features/admin/userApiSlice.ts
+++ b/src/features/admin/userApiSlice.ts
@@ -82,13 +82,6 @@ export type AdminData = {
   email: string
 }
 
-export enum CompanyRoleEnum {
-  APP_PROVIDER = 'APP_PROVIDER',
-  SERVICE_PROVIDER = 'SERVICE_PROVIDER',
-  ONBOARDING_SERVICE_PROVIDER = 'ONBOARDING_SERVICE_PROVIDER',
-  OPERATOR = 'OPERATOR',
-}
-
 export interface CompanyDetails {
   bpn: string
   city: string

--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -51,7 +51,14 @@ import Test from 'components/pages/Test'
 import UserManagement from 'components/pages/UserManagement'
 import UserDetails from 'components/pages/UserDetail'
 import { Route } from 'react-router-dom'
-import { ACTIONS, HINTS, OVERLAYS, PAGES, ROLES } from './Constants'
+import {
+  ACTIONS,
+  COMPANY_ROLES,
+  HINTS,
+  OVERLAYS,
+  PAGES,
+  ROLES,
+} from './Constants'
 import type { IAction, RestrictedItem, IPage } from './MainTypes'
 import AppUserManagement from 'components/pages/AppUserManagement'
 import IDPManagement from 'components/pages/IDPManagement'
@@ -87,6 +94,7 @@ import CompanySubscriptions from 'components/pages/CompanySubscriptions'
 import CompanySubscriptionDetail from 'components/pages/CompanySubscriptions/CompanySubscriptionDetail'
 import CompanyData from 'components/pages/CompanyData'
 import {
+  companyHasRole,
   userHasBpdmRole,
   userHasPortalRole,
   userHasRegistrationRole,
@@ -599,7 +607,9 @@ export const ALL_PAGES: IPage[] = [
   },
   {
     name: PAGES.ONBOARDING_SERVICE_PROVIDER_MANAGEMENT,
-    allowTo: () => userHasPortalRole(ROLES.CONFIGURE_PARTNER_REGISTRATION),
+    allowTo: () =>
+      userHasPortalRole(ROLES.CONFIGURE_PARTNER_REGISTRATION) &&
+      companyHasRole(COMPANY_ROLES.ONBOARDING_SERVICE_PROVIDER),
     element: <OnboardingServiceProvider />,
   },
 ]


### PR DESCRIPTION
## Description

remove customised logic to check company role info in osp page and header component. use company role check in config file to allow user to navigate to osp page.

### Chnagelog

```
**OSP**
 - removed customised logic to check company role info in osp page and header component. use company role check in config file to allow user to navigate to osp page.[#1390](https://github.com/eclipse-tractusx/portal-frontend/pull/1390)
```

## Why

remove custom check for company roles

## Issue

#1108 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally