### PR TITLE
fix: remove non portal roles from user list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugfixes
 
+- **User Management**
+  - added missing short name field osp consent form [#1391](https://github.com/eclipse-tractusx/portal-frontend/issues/1391)
 - **Onboarding Service Provider**
   - added missing short name field osp consent form [#1341](https://github.com/eclipse-tractusx/portal-frontend/pull/1341)
 - **App Marketplace**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Bugfixes
 
-- **User Management**
-  - filter out app permissions from user list [#1391](https://github.com/eclipse-tractusx/portal-frontend/issues/1391)
 - **Onboarding Service Provider**
   - added missing short name field osp consent form [#1341](https://github.com/eclipse-tractusx/portal-frontend/pull/1341)
 - **App Marketplace**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Bugfixes
 
 - **User Management**
-  - added missing short name field osp consent form [#1391](https://github.com/eclipse-tractusx/portal-frontend/issues/1391)
+  - filter out app permissions from user list [#1391](https://github.com/eclipse-tractusx/portal-frontend/issues/1391)
 - **Onboarding Service Provider**
   - added missing short name field osp consent form [#1341](https://github.com/eclipse-tractusx/portal-frontend/pull/1341)
 - **App Marketplace**

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -34,6 +34,7 @@ import './style.scss'
 import { setSearchInput } from 'features/appManagement/actions'
 import { appManagementSelector } from 'features/appManagement/slice'
 import { isSearchUserEmail } from 'types/Patterns'
+import { getClientId } from 'services/EnvironmentService'
 
 interface FetchHookArgsType {
   appId?: string
@@ -157,14 +158,20 @@ export const UserList = ({
                 }}
               >
                 {roles.length
-                  ? roles.map((role: RoleType | string) => (
-                      <StatusTag
-                        key={typeof role === 'string' ? role : role.roleId}
-                        color="label"
-                        label={typeof role === 'string' ? role : role.roleName}
-                        className="statusTag"
-                      />
-                    ))
+                  ? roles
+                      .filter(
+                        (role: RoleType | string) =>
+                          typeof role !== 'string' &&
+                          role.clientId === getClientId()
+                      )
+                      .map((role: RoleType) => (
+                        <StatusTag
+                          key={role.roleId}
+                          color="label"
+                          label={role.roleName}
+                          className="statusTag"
+                        />
+                      ))
                   : ''}
               </span>
             ),


### PR DESCRIPTION
## Description

- Added filter to role column renderCell on "User Management" screen user list to remove roles not associated with portal roles.

## Why

- The user list table on the "User Management" screen is showing roles for each user that are not related to portal access. For example, roles associated with app access. 

## Issue

#1391 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

