### PR TITLE
fix: masked confidentail technical user fields

### DIFF
--- a/src/components/overlays/UpdateIDP/UpdateIDPContent.tsx
+++ b/src/components/overlays/UpdateIDP/UpdateIDPContent.tsx
@@ -31,7 +31,6 @@ import type { IHashMap } from 'types/MainTypes'
 import { useTranslation } from 'react-i18next'
 import ReadOnlyValue from 'components/shared/basic/ReadOnlyValue'
 import ValidatingInput from 'components/shared/basic/Input/ValidatingInput'
-import { InputType } from 'components/shared/basic/Input/BasicInput'
 import {
   StaticTable,
   type TableType,
@@ -118,9 +117,7 @@ const UpdateIDPForm = ({
         <ValidatingInput
           name="secret"
           label={t('field.clientSecret.name')}
-          value={idp.oidc?.hasClientSecret ? '******' : ''}
           hint={t('field.clientSecret.hint')}
-          type={InputType.password}
           validate={isIDPClientSecret}
           onValid={onChange}
         />

--- a/src/components/pages/OnboardingServiceProvider/OnboardingServiceProvider.tsx
+++ b/src/components/pages/OnboardingServiceProvider/OnboardingServiceProvider.tsx
@@ -47,7 +47,6 @@ import {
 } from 'features/admin/idpApiSlice'
 import ValidatingInput from 'components/shared/basic/Input/ValidatingInput'
 import { isIDPClientID, isIDPClientSecret, isURL } from 'types/Patterns'
-import { InputType } from 'components/shared/basic/Input/BasicInput'
 import { type IHashMap } from 'types/MainTypes'
 import { success } from 'services/NotifyService'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
@@ -206,7 +205,6 @@ const OnboardingServiceProvider = () => {
                   hint={t(
                     'content.onboardingServiceProvider.clientSecret.hint'
                   )}
-                  type={InputType.password}
                   validate={isIDPClientSecret}
                   onValid={checkValidData}
                 />

--- a/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
+++ b/src/components/pages/TechnicalUserDetails/TechnicalUserDetailsContent.tsx
@@ -51,6 +51,15 @@ export const statusColorMap: Record<
   [ServiceAccountStatus.PENDING_DELETION]: 'pending',
 }
 
+export type DataValue = string | number | JSX.Element | string[]
+export interface ValueItem {
+  key?: DataValue
+  value: DataValue
+  copy?: boolean
+  showHideButton?: boolean
+  masked?: boolean
+}
+
 const getValueWithTooltip = (value: string, tooltipTitle: string) => {
   return (
     value || (
@@ -94,23 +103,12 @@ export default function TechnicalUserDetailsContent({
   const [mutationRequest] = useResetCredentialMutation()
   const [loading, setLoading] = useState<boolean>(false)
   const [newData, setNewData] = useState<ServiceAccountDetail>(data)
-
   const missingInformationHint = t(
     'content.usermanagement.technicalUser.detailsPage.missingInfoHint'
   )
-  const connectedData = [
-    {
-      key: t('content.usermanagement.technicalUser.detailsPage.connectorLink'),
-      value: newData?.connector?.name ?? 'N/A',
-    },
-    {
-      key: t('content.usermanagement.technicalUser.detailsPage.offerLink'),
-      value: newData?.offer?.name ?? 'N/A',
-      copy: !!newData.offer?.name,
-    },
-  ]
-
-  const displayData = [
+  const [technicalUserDetailList, setTechnicalUserDetailList] = useState<
+    Array<ValueItem>
+  >([
     {
       key: t('global.field.status'),
       value: (
@@ -159,6 +157,8 @@ export default function TechnicalUserDetailsContent({
       key: t('global.field.clientId'),
       value: newData.clientId,
       copy: true,
+      showHideButton: true,
+      masked: true,
     },
     {
       key: t(
@@ -170,6 +170,20 @@ export default function TechnicalUserDetailsContent({
       key: t('global.field.secret'),
       value: newData.secret,
       copy: true,
+      showHideButton: true,
+      masked: true,
+    },
+  ])
+
+  const connectedData = [
+    {
+      key: t('content.usermanagement.technicalUser.detailsPage.connectorLink'),
+      value: newData?.connector?.name ?? 'N/A',
+    },
+    {
+      key: t('content.usermanagement.technicalUser.detailsPage.offerLink'),
+      value: newData?.offer?.name ?? 'N/A',
+      copy: !!newData.offer?.name,
     },
   ]
 
@@ -286,7 +300,8 @@ export default function TechnicalUserDetailsContent({
             title={t(
               'content.usermanagement.technicalUser.detailsPage.userDetails'
             )}
-            items={displayData}
+            items={technicalUserDetailList}
+            setTechnicalUserDetailList={setTechnicalUserDetailList}
           />
         </Box>
         <Box

--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -36,7 +36,7 @@ import {
 interface KeyValueViewProps {
   cols: number
   title: string
-  items: Array<ValueItem>
+  items: ValueItem | Array<ValueItem>
   editLink?: string
   setTechnicalUserDetailList?: Dispatch<SetStateAction<ValueItem[]>>
 }
@@ -104,10 +104,12 @@ export const KeyValueView = ({
         {item.showHideButton && setTechnicalUserDetailList && (
           <Box
             onClick={() => {
-              const updatedItems = items.map((itm) =>
-                itm.key === item.key ? { ...itm, masked: !itm.masked } : itm
-              )
-              setTechnicalUserDetailList(updatedItems)
+              if (Array.isArray(items)) {
+                const updatedItems = items.map((itm) =>
+                  itm.key === item.key ? { ...itm, masked: !itm.masked } : itm
+                )
+                setTechnicalUserDetailList(updatedItems)
+              }
             }}
             sx={{
               color: item.masked ? '#eeeeee' : '#cccccc',

--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useState } from 'react'
+import { type Dispatch, type SetStateAction, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@mui/material'
@@ -26,24 +26,24 @@ import { Typography } from '@catena-x/portal-shared-components'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import { success } from 'services/NotifyService'
-
-type DataValue = string | number | JSX.Element | string[]
-
-interface ValueItem {
-  key?: DataValue
-  value: DataValue
-  copy?: boolean
-}
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+import {
+  type ValueItem,
+  type DataValue,
+} from 'components/pages/TechnicalUserDetails/TechnicalUserDetailsContent'
 
 interface KeyValueViewProps {
   cols: number
   title: string
-  items: ValueItem | Array<ValueItem>
+  items: Array<ValueItem>
   editLink?: string
+  setTechnicalUserDetailList?: Dispatch<SetStateAction<ValueItem[]>>
 }
 
-const renderValue = (value: DataValue) =>
-  typeof value === 'string' ? (
+const renderValue = (value: DataValue, masked: boolean = false) => {
+  const maskedText = masked ? '*****' : value
+  return (
     <Typography
       sx={{
         fontSize: '14px',
@@ -52,57 +52,80 @@ const renderValue = (value: DataValue) =>
         wordBreak: 'break-all',
       }}
     >
-      {value}
+      {maskedText}
     </Typography>
-  ) : (
-    <Box sx={{ margin: 'auto 0px' }}>{value}</Box>
   )
+}
 
 export const KeyValueView = ({
   cols,
   title,
   items,
   editLink,
+  setTechnicalUserDetailList,
 }: KeyValueViewProps) => {
   const [copied, setCopied] = useState<string>('')
   const { t } = useTranslation()
 
-  const renderValueItem = (item: ValueItem) =>
-    item.copy ? (
+  const renderValueItem = (item: ValueItem) => (
+    <Box>
       <Box
         sx={{
           cursor: 'pointer',
-          display: 'flex',
-          color: copied === item.value ? '#00cc00' : '#888888',
-          ':hover': {
-            color: copied === item.value ? '#00cc00' : '#0088CC',
-          },
-        }}
-        onClick={async () => {
-          const value = item.value ?? ''
-          await navigator.clipboard.writeText(value as string)
-          setCopied(value as string)
-          success(t('global.actions.copyInfoSuccessMessage'))
-          setTimeout(() => {
-            setCopied('')
-          }, 1000)
+          display: 'inline-flex',
         }}
       >
-        {renderValue(item.value ?? '')}
-        {item.value && (
-          <ContentCopyIcon
+        {renderValue(item.value ?? '', item?.masked)}
+        {item?.copy && (
+          <Box
             sx={{
-              marginLeft: '10px',
-              fontSize: '18px',
+              color: copied === item.value ? '#00cc00' : '#eeeeee',
+              ':hover': {
+                color: copied === item.value ? '#00cc00' : '#cccccc',
+              },
             }}
-          />
+            onClick={async () => {
+              const value = item.value ?? ''
+              await navigator.clipboard.writeText(value as string)
+              setCopied(value as string)
+              success(t('global.actions.copyInfoSuccessMessage'))
+              setTimeout(() => {
+                setCopied('')
+              }, 1000)
+            }}
+          >
+            <ContentCopyIcon
+              sx={{
+                marginLeft: '10px',
+              }}
+            />
+          </Box>
+        )}
+        {item.showHideButton && setTechnicalUserDetailList && (
+          <Box
+            onClick={() => {
+              const updatedItems = items.map((itm) =>
+                itm.key === item.key ? { ...itm, masked: !itm.masked } : itm
+              )
+              setTechnicalUserDetailList(updatedItems)
+            }}
+            sx={{
+              color: item.masked ? '#eeeeee' : '#cccccc',
+              ':hover': {
+                color: '#cccccc',
+              },
+            }}
+          >
+            {item.masked ? (
+              <VisibilityOffIcon style={{ marginLeft: '8px' }} />
+            ) : (
+              <VisibilityIcon style={{ marginLeft: '8px' }} />
+            )}
+          </Box>
         )}
       </Box>
-    ) : (
-      <Box sx={{ marginRight: '34px', textAlign: 'left' }}>
-        {renderValue(item.value)}
-      </Box>
-    )
+    </Box>
+  )
 
   return (
     <Box


### PR DESCRIPTION
## Description
Removed Password type fields from OSP callback config and IDP config screen because requirement is to make them text based Input while Adding/Updating the configuration of either of them and also made Technical User detail screen protected for the sensitive information with masking and toggleable them by introducing an eye icon.

```
- **Changelog entry**
  - Technical User | IDP config | OSP callback config
  - Introduced Masking for Sensitive information in Technical User Detail Section [#1399](https://github.com/eclipse-tractusx/portal-frontend/issues/1399)
```

## Why
Best Practice to hide the sensitive information by default and whenever Customer support team wants to prepare Demo video of Portal they says sensitive information should be hidden e.g., Passwords, secrets from Technical User Detail.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1399

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
