### PR TITLE
fix(app subscription): fix overlay close

### DIFF
--- a/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
@@ -45,7 +45,6 @@ import './style.scss'
 import type { store } from 'features/store'
 import { setSuccessType } from 'features/appSubscription/slice'
 import { Link } from 'react-router-dom'
-import { closeOverlay } from 'features/control/overlay'
 import { useFetchTechnicalUserProfilesQuery } from 'features/appManagement/apiSlice'
 
 const TentantHelpURL =
@@ -169,7 +168,9 @@ const ActivateSubscriptionOverlay = ({
                   color="success"
                 />
               }
-              onCloseWithIcon={() => dispatch(closeOverlay())}
+              onCloseWithIcon={() => {
+                handleOverlayClose()
+              }}
             />
             <DialogContent>
               {loading ? (


### PR DESCRIPTION
## Description

Fixed closing of overlay on click of close icon.

Changelog entry:

- **App Subscription**
  - fixed closing of overlay on click of close icon [#1413](https://github.com/eclipse-tractusx/portal-frontend/pull/1413)
 
## Why

Close icon was not closing the overlay

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1359

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally