### PR TITLE
fix(connector management): fix connector URL update

### DIFF
--- a/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
+++ b/src/components/pages/EdcConnector/ConnectorDetailsOverlay.tsx
@@ -50,12 +50,16 @@ interface DeleteConfirmationOverlayProps {
   openDialog?: boolean
   handleOverlayClose: React.MouseEventHandler
   overlayData?: ConnectorDetailsType
+  // Add an ESLint exception until there is a solution
+  // eslint-disable-next-line
+  updateTableConnectorURL: any
 }
 
 const ConnectorDetailsOverlay = ({
   openDialog = false,
   handleOverlayClose,
   overlayData,
+  updateTableConnectorURL,
 }: DeleteConfirmationOverlayProps) => {
   const { t } = useTranslation()
   const [fetchSDDocument] = useFetchSdDocumentMutation()
@@ -158,6 +162,7 @@ const ConnectorDetailsOverlay = ({
           success(t('content.edcconnector.details.urlUpdatedSuccessfully'))
           refetch()
           setEnableConnectorUrl(true)
+          updateTableConnectorURL(true)
         })
         .catch(() => {
           setEnableUrlApiErrorMsg(true)

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -360,6 +360,9 @@ const EdcConnector = () => {
           setOpenDetailsOverlay(false)
         }}
         overlayData={overlayData}
+        updateTableConnectorURL={(data: boolean) => {
+          data && setRefresh(Date.now())
+        }}
       />
       {deleteConnectorConfirmModalOpen && (
         <DeleteConfirmationOverlay


### PR DESCRIPTION
## Description

Fixed table connector URL update after updating and closing the overlay

Changelog entry:

- **Connector Management**
  - fixed table connector URL update after updating and closing the overlay [#1420](https://github.com/eclipse-tractusx/portal-frontend/pull/1420)

## Why

Connector URL should update in table after its value is updated in details overlay.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1418

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally