### PR TITLE
feat: mobile navigation bar enhancement

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2461,5 +2461,17 @@
   "hints": {
     "coming_soon": "Coming soon",
     "new": "New"
+  },
+  "menu": {
+    "heading": {
+      "dataSpaceParticipation": "Datenraum Teilnahme",
+      "marketplace": "Marktplatz",
+      "marketplaceManagement": "Marktplatz Management",
+      "technicalSetup": "Technisches Setup",
+      "cxOperator": "CX Operator",
+      "appManagement": "App Management",
+      "serviceManagement": "Service Management",
+      "onBoardingManagement": "OSP"
+    }
   }
 }

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -55,7 +55,7 @@
     "serviceManagement": "Service Management",
     "serviceOverview": "Service Overview",
     "serviceReleaseProcess": "Service Release Process",
-    "serviceAdminBoard": "Admin Board",
+    "serviceAdminBoard": "Service Board",
     "serviceSubscription": "Service Subscription Mgt",
     "serviceDetail": "Service Details",
     "companyRole": "Config - Company Role",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -55,7 +55,7 @@
     "serviceManagement": "Service Management",
     "serviceOverview": "Service Overview",
     "serviceReleaseProcess": "Service Release Process",
-    "serviceAdminBoard": "Admin Board",
+    "serviceAdminBoard": "Service Board",
     "serviceSubscription": "Service Subscription Mgt",
     "serviceDetail": "Service Details",
     "companyRole": "Config - Company Role",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2436,5 +2436,17 @@
   "hints": {
     "coming_soon": "Coming soon",
     "new": "New"
+  },
+  "menu": {
+    "heading": {
+      "dataSpaceParticipation": "Dataspace Participation",
+      "marketplace": "Marketplace",
+      "marketplaceManagement": "Marketplace Management",
+      "technicalSetup": "Technical Setup",
+      "cxOperator": "CX Operator",
+      "appManagement": "App Management",
+      "serviceManagement": "Service Management",
+      "onBoardingManagement": "OSP"
+    }
   }
 }

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -133,13 +133,20 @@ export default function Main() {
           <Header
             main={AccessService.mainMenuTree()}
             user={AccessService.userMenu()}
+            userMenuWithChildren={AccessService.userMenuWithChild()}
           />
           <MainSearchOverlay />
-          <Outlet />
+          <div className="initial-main-div">
+            <Outlet />
+          </div>
           <Footer pages={AccessService.footerMenu()} />
           <MainOverlay />
           <MainNotify />
-          <MenuInfo main={AccessService.mainMenuTree()} />
+          <MenuInfo
+            main={AccessService.mainMenuTree().concat(
+              AccessService.userMenuWithChild()
+            )}
+          />
         </>
       )}
     </>

--- a/src/components/pages/Home/components/MenuInfo/index.tsx
+++ b/src/components/pages/Home/components/MenuInfo/index.tsx
@@ -24,11 +24,16 @@ import { useSelector, useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
 import ClickAwayListener from '@mui/material/ClickAwayListener'
 import type { MenuItem, Tree } from 'types/MainTypes'
-import CloseIcon from '@mui/icons-material/Close'
 import { MobileMenu } from 'components/shared/MobileMenu'
 import { Drawer } from '@mui/material'
 
-export const MenuInfo = ({ main }: { main: Tree[] | undefined }) => {
+export const MenuInfo = ({
+  main,
+  shouldDisplayMenuItems,
+}: {
+  main: Tree[]
+  shouldDisplayMenuItems?: boolean
+}) => {
   const { t } = useTranslation()
   const visible = useSelector(appearMenuSelector)
   const dispatch = useDispatch()
@@ -37,7 +42,9 @@ export const MenuInfo = ({ main }: { main: Tree[] | undefined }) => {
       (item: Tree): MenuItem => ({
         ...item,
         to: `/${item.name}`,
-        title: t(`pages.${item.name}`),
+        title: item.children
+          ? t(`menu.heading.${item.name}`)
+          : t(`pages.${item.name}`),
         hint: item.hint ? t(`hints.${item.hint}`) : '',
         children: addTitle(item.children),
       })
@@ -71,18 +78,12 @@ export const MenuInfo = ({ main }: { main: Tree[] | undefined }) => {
         }}
       >
         <div className="MenuInfo">
-          <CloseIcon
-            onClick={() => dispatch(setAppear({ MENU: !visible }))}
-            sx={{
-              color: '#B6B6B6',
-            }}
-            className="closeIcon"
-          />
           <MobileMenu
             className="userMenuInfo"
             component={Link}
-            divider
+            divider={shouldDisplayMenuItems}
             items={menu}
+            shouldDisplayMenuItems={shouldDisplayMenuItems}
           />
         </div>
       </ClickAwayListener>

--- a/src/components/pages/Home/components/MenuInfo/menu-info.scss
+++ b/src/components/pages/Home/components/MenuInfo/menu-info.scss
@@ -24,20 +24,56 @@
   z-index: 999;
   background: #fff;
   right: 0px;
-  width: 280px;
+  width: 280px !important;
   padding: 10px 0px;
-  height: 99%;
+}
+.dep {
+  transition: all 3s ease-out;
 }
 
-.closeIcon {
-  position: absolute;
-  right: 10px;
+.topRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px;
 }
 
 .userMenuInfo {
-  margin-top: 20px;
-}
+  .MuiTypography-label2 {
+    font-size: 18px;
+  }
+  .MuiLink-root,
+  .MuiListItem-root {
+    font-weight: 500;
+    border-radius: 0;
+    color: #000000 !important;
+    width: 100%;
 
-.dep {
-  transition: all 3s ease-out;
+    &:hover {
+      border-radius: 8px;
+      background-color: #ededed;
+      color: #000000 !important;
+      cursor: pointer;
+
+      .MuiSvgIcon-root {
+        color: #000000 !important;
+        background-color: #ededed;
+      }
+      .MuiListItemAvatar-root {
+        .MuiSvgIcon-root {
+          color: white !important;
+          background-color: inherit;
+
+          path {
+            fill: white !important;
+          }
+        }
+      }
+
+      .badgeBox,
+      a {
+        color: #000000 !important;
+      }
+    }
+  }
 }

--- a/src/components/shared/MobileMenu/LogoutLink.tsx
+++ b/src/components/shared/MobileMenu/LogoutLink.tsx
@@ -16,31 +16,35 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-import PermIdentityIcon from '@mui/icons-material/PermIdentity'
+
+import LogoutIcon from '@mui/icons-material/Logout'
+import { t } from 'i18next'
 import { MenuItem, type MenuItemProps } from './MenuItem'
 import './MobileMenu.scss'
-import { t } from 'i18next'
+import { useNavigate } from 'react-router-dom'
 
-interface ProfileLinkProps {
+type LinkItem = Partial<Record<'href' | 'to', string>>
+
+interface LogoutLinkProps extends LinkItem {
   onSelect?: (title: string, children: MenuItemProps[]) => void
   onClick?: React.MouseEventHandler
-  userMenu: MenuItemProps[]
 }
 
-export const ProfileLink = ({
+export const LogoutLink = ({
   onSelect,
-  userMenu,
-}: ProfileLinkProps): JSX.Element => {
+  onClick,
+  ...props
+}: LogoutLinkProps): JSX.Element => {
+  const navigate = useNavigate()
   return (
     <MenuItem
-      title={t('pages.account')}
+      title={t('pages.logout')}
+      isSeparate={true}
       onClick={() => {
-        if (onSelect) onSelect(t('pages.account'), userMenu)
+        if (props.to) navigate(props.to)
       }}
-      children={userMenu}
-      onSelect={onSelect}
       icon={
-        <PermIdentityIcon
+        <LogoutIcon
           sx={{
             height: 18,
             width: 18,

--- a/src/components/shared/MobileMenu/MenuChildren.tsx
+++ b/src/components/shared/MobileMenu/MenuChildren.tsx
@@ -17,13 +17,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Box, Link, useTheme } from '@mui/material'
+import { Box, Divider, Link, useTheme } from '@mui/material'
 import { Typography } from '@catena-x/portal-shared-components'
-import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft'
-import type { MenuItemProps } from './MenuItem'
-
+import { MenuItem, type MenuItemProps } from './MenuItem'
 import './MobileMenu.scss'
-import { t } from 'i18next'
 
 type LinkItem = Partial<Record<'href' | 'to', string>>
 
@@ -33,87 +30,71 @@ export interface MenuSubItemsProps extends LinkItem {
   children: MenuItemProps[]
   component: React.ElementType
   title: string
+  headerRowComponent?: React.ReactNode
 }
 
 export const MenuSubItems = ({
   onClick,
-  onHide,
   children,
   component = Link,
-  title,
+  headerRowComponent,
 }: MenuSubItemsProps): JSX.Element => {
   const { spacing } = useTheme()
   return (
     <Box
       sx={{
-        marginBottom: '55px',
+        px: 1,
+        py: 0,
+        paddingTop: 1,
+        ':hover': {
+          borderRadius: spacing(1, 1),
+        },
       }}
     >
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'flex-start',
-          marginLeft: '20px',
-          cursor: 'pointer',
-          marginBottom: '20px',
-          alignItems: 'center',
-        }}
-        onClick={onHide}
-      >
-        <KeyboardArrowLeftIcon sx={{ color: 'icon.icon02' }} />
-        <Typography
-          className="font-libre"
-          sx={{
-            paddingLeft: '5px',
-            fontSize: '12px',
-            textTransform: 'lowercase',
-          }}
-          variant="body2"
-        >
-          {t('global.actions.back')}
-        </Typography>
-      </Box>
-      <Box
-        sx={{
-          paddingLeft: '25px',
-          paddingBottom: '10px',
-          paddingTop: '15px',
-        }}
-      >
-        <Typography
-          variant="label2"
-          sx={{
-            fontWeight: '600',
-            fontSize: '14px',
-          }}
-        >
-          {title}
-        </Typography>
-      </Box>
-      {children?.map((item) => (
-        <Link
-          component={component}
-          key={item.title}
-          className="titleBox"
-          sx={{
-            color: 'text.primary',
-            alignItems: 'center',
-            padding: spacing(1.5, 2),
-            marginLeft: '10px',
-            ':hover': {
-              backgroundColor: 'rgba(15, 113, 203, 0.05)',
-              color: 'primary.dark',
-              '.MuiSvgIcon-root': {
-                color: 'primary.dark',
-              },
-            },
-          }}
-          onClick={onClick}
-          {...item}
-        >
-          {item.title}
-        </Link>
-      ))}
+      {headerRowComponent ? <Box>{headerRowComponent}</Box> : null}
+      {children?.map((item, index) => {
+        if (item.children) {
+          return (
+            <>
+              <Box
+                sx={{
+                  paddingLeft: 1,
+                  paddingBottom: '10px',
+                  paddingTop: '15px',
+                }}
+              >
+                <Typography variant="h6" sx={{ textTransform: 'uppercase' }}>
+                  {item.title}
+                </Typography>
+              </Box>
+              {item.children.map((childItem) => {
+                return (
+                  <MenuItem
+                    key={childItem.title}
+                    component={component}
+                    onSelect={onClick}
+                    onClick={onClick}
+                    {...childItem}
+                  />
+                )
+              })}
+
+              {index + 1 !== children.length && (
+                <Divider sx={{ margin: spacing(1, 1) }} />
+              )}
+            </>
+          )
+        }
+        return (
+          <MenuItem
+            key={item.title}
+            component={component}
+            onSelect={onClick}
+            onClick={onClick}
+            {...item}
+          />
+        )
+      })}
     </Box>
   )
 }

--- a/src/components/shared/MobileMenu/MenuFooter.tsx
+++ b/src/components/shared/MobileMenu/MenuFooter.tsx
@@ -18,12 +18,11 @@
  ********************************************************************************/
 
 import { Box } from '@mui/material'
-import { Typography, LanguageSwitch } from '@catena-x/portal-shared-components'
+import { LanguageSwitch, Button } from '@catena-x/portal-shared-components'
 import { useDispatch } from 'react-redux'
 import i18next, { changeLanguage, t } from 'i18next'
 import I18nService from 'services/I18nService'
 import { setLanguage } from 'features/language/actions'
-import UserService from 'services/UserService'
 
 export const MenuFooter = (): JSX.Element => {
   const dispatch = useDispatch()
@@ -32,9 +31,9 @@ export const MenuFooter = (): JSX.Element => {
       sx={{
         display: 'flex',
         justifyContent: 'space-between',
-        alignContent: 'center',
         alignItems: 'center',
-        cursor: 'pointer',
+        py: 0.5,
+        px: 1,
       }}
     >
       <LanguageSwitch
@@ -45,46 +44,22 @@ export const MenuFooter = (): JSX.Element => {
           changeLanguage(key)
         }}
       />
-      <Box
-        onClick={() => {
-          window.open(
-            `${document.location.origin}/documentation/`,
-            'documentation',
-            'noreferrer'
-          )
-        }}
-      >
-        <Typography
-          sx={{
-            paddingLeft: '10px',
-            fontSize: '14px',
-            fontFamily:
-              '"LibreFranklin-Medium",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
+      <Box sx={{ pr: 1 }}>
+        <Button
+          size="small"
+          color="secondary"
+          variant="outlined"
+          onClick={() => {
+            window.open(
+              `${document.location.origin}/documentation/`,
+              'documentation',
+              'noreferrer'
+            )
           }}
-          variant="body2"
+          className="documentation"
         >
           {t('pages.help')}
-        </Typography>
-      </Box>
-      <Box
-        sx={{
-          marginRight: '20px',
-        }}
-        onClick={() => {
-          UserService.doLogout()
-        }}
-      >
-        <Typography
-          sx={{
-            paddingLeft: '10px',
-            fontSize: '14px',
-            fontFamily:
-              '"LibreFranklin-Medium",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
-          }}
-          variant="body2"
-        >
-          {t('pages.logout')}
-        </Typography>
+        </Button>
       </Box>
     </Box>
   )

--- a/src/components/shared/MobileMenu/MenuItem.tsx
+++ b/src/components/shared/MobileMenu/MenuItem.tsx
@@ -132,7 +132,6 @@ export const MenuItem = ({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-
           typography: 'body2',
           textDecoration: 'none',
           whiteSpace: 'nowrap',

--- a/src/components/shared/MobileMenu/MenuItem.tsx
+++ b/src/components/shared/MobileMenu/MenuItem.tsx
@@ -24,11 +24,17 @@ import {
   ListItem,
   useTheme,
   Box,
+  ListItemAvatar,
+  Avatar,
 } from '@mui/material'
 import { type MenuType } from '.'
-import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight'
+import {
+  Typography,
+  type NotificationBadgeType,
+} from '@catena-x/portal-shared-components'
 import { useDispatch, useSelector } from 'react-redux'
 import { appearMenuSelector, setAppear } from 'features/control/appear'
+import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 
 type LinkItem = Partial<Record<'href' | 'to', string>>
 
@@ -43,6 +49,12 @@ export interface MenuItemProps extends LinkItem {
   Menu?: MenuType
   disable?: boolean
   onSelect?: (title: string, children: MenuItemProps[]) => void
+  icon?: React.ReactNode
+  notificationInfo?: NotificationBadgeType
+  showNotificationCount?: boolean
+  isSeparate?: boolean
+  isHeader?: boolean
+  isActive?: boolean
 }
 
 export const MenuItem = ({
@@ -56,6 +68,9 @@ export const MenuItem = ({
   onClick,
   Menu,
   onSelect,
+  icon,
+  notificationInfo,
+  isSeparate = false,
   ...props
 }: MenuItemProps): JSX.Element => {
   const { spacing } = useTheme()
@@ -65,19 +80,50 @@ export const MenuItem = ({
   return (
     <ListItem
       sx={{
-        display: 'block',
+        display: 'flex',
         position: 'relative',
-        padding: spacing(0, 1),
+        padding: spacing(hint ? 1.3 : 1.5, 1),
+        ':hover': {
+          borderRadius: 10,
+          backgroundColor: 'selected.hover !important',
+          color: 'primary.main',
+          '.MuiSvgIcon-root': {
+            color: 'primary.dark',
+          },
+        },
+
         ...(onClick != null && { cursor: 'pointer' }),
       }}
-      onClick={() => {
-        if (children != null && onSelect != null) {
+      onClick={(e) => {
+        if (isSeparate && onClick !== undefined) {
+          onClick(e)
+          dispatch(setAppear({ MENU: !visible }))
+        } else if (children != null && onSelect != null) {
           onSelect(title, children)
         } else {
           dispatch(setAppear({ MENU: !visible }))
         }
       }}
     >
+      {icon ? (
+        <ListItemAvatar sx={{ height: 30, width: 30, minWidth: 30, mr: 1 }}>
+          <Avatar
+            sx={{
+              height: 30,
+              width: 30,
+              color: 'white',
+              backgroundColor: 'secondary.main',
+              ':hover': {
+                color: 'white !important',
+                backgroundColor: 'secondary.main !important',
+              },
+            }}
+          >
+            {icon}
+          </Avatar>
+        </ListItemAvatar>
+      ) : null}
+
       <Link
         component={children == null ? component : Box}
         sx={{
@@ -86,16 +132,13 @@ export const MenuItem = ({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          padding: spacing(hint ? 1.3 : 1.5, 2),
-          borderRadius: 3,
-          typography: 'label3',
+
+          typography: 'body2',
           textDecoration: 'none',
           whiteSpace: 'nowrap',
-          fontSize: '14px',
-          fontFamily:
-            '"LibreFranklin-Medium",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol"',
+          fontWeight: 500,
           ':hover': {
-            backgroundColor: 'rgba(15, 113, 203, 0.05)',
+            backgroundColor: 'selected.hover',
             color: 'primary.dark',
             '.MuiSvgIcon-root': {
               color: 'primary.dark',
@@ -105,8 +148,22 @@ export const MenuItem = ({
         {...props}
       >
         {title}
-        {children != null && (
-          <KeyboardArrowRightIcon sx={{ color: 'icon.icon02' }} />
+        {children != null && <NavigateNextIcon sx={{ color: 'icon.icon02' }} />}
+        {notificationInfo != null && notificationInfo.notificationCount > 0 && (
+          <Typography
+            sx={{
+              fontWeight: '500',
+              fontSize: '0.75rem',
+              minWidth: '20px',
+              padding: '2px 6px',
+              height: '20px',
+              borderRadius: '10px',
+              background: notificationInfo.notificationColor,
+              color: 'white',
+            }}
+          >
+            {notificationInfo?.notificationCount}
+          </Typography>
         )}
       </Link>
       {divider && <Divider />}

--- a/src/components/shared/MobileMenu/MobileMenu.scss
+++ b/src/components/shared/MobileMenu/MobileMenu.scss
@@ -49,10 +49,8 @@ a.link-router-text {
   display: flex !important;
   justify-content: space-between !important;
   align-items: center !important;
-  border-radius: 3px !important;
   text-decoration: none !important;
   white-space: nowrap !important;
-  font-size: 14px !important;
   font-family:
     'LibreFranklin-Medium',
     -apple-system,

--- a/src/components/shared/MobileMenu/NotificationLink.tsx
+++ b/src/components/shared/MobileMenu/NotificationLink.tsx
@@ -17,18 +17,15 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { Typography } from '@mui/material'
-import type { MenuItemProps } from './MenuItem'
+import { MenuItem, type MenuItemProps } from './MenuItem'
 import { useGetNotificationMetaQuery } from 'features/notification/apiSlice'
+import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone'
+import { theme } from '@catena-x/portal-shared-components'
 import { INTERVAL_CHECK_NOTIFICATIONS } from 'types/Constants'
 import { useEffect, useState } from 'react'
-import { theme } from '@catena-x/portal-shared-components'
-import { Link as LinkRouter } from 'react-router-dom'
 import './MobileMenu.scss'
-import { useDispatch, useSelector } from 'react-redux'
-import { appearMenuSelector, setAppear } from 'features/control/appear'
 import { t } from 'i18next'
-import { WraperLink } from './WraperLink'
+import { useNavigate } from 'react-router-dom'
 
 interface NotificationBadgeType {
   notificationCount: number
@@ -38,21 +35,25 @@ interface NotificationBadgeType {
 type LinkItem = Partial<Record<'href' | 'to', string>>
 
 interface NotificationLinkProps extends LinkItem {
-  onSelect?: (children: MenuItemProps) => void
+  onSelect?: (title: string, children: MenuItemProps[]) => void
+  onClick?: React.MouseEventHandler
 }
 
 export const NotificationLink = ({
   onSelect,
   ...props
 }: NotificationLinkProps): JSX.Element => {
-  const dispatch = useDispatch()
-  const visible = useSelector(appearMenuSelector)
+  const navigate = useNavigate()
+
   const { data } = useGetNotificationMetaQuery(null, {
     pollingInterval: INTERVAL_CHECK_NOTIFICATIONS,
   })
 
   const [notificationInfo, setNotificationInfo] =
-    useState<NotificationBadgeType>()
+    useState<NotificationBadgeType>({
+      isNotificationAlert: false,
+      notificationCount: 0,
+    })
 
   useEffect(() => {
     if (
@@ -76,37 +77,25 @@ export const NotificationLink = ({
     : theme.palette.brand.brand02
 
   return (
-    <WraperLink
-      onClick={() => {
-        dispatch(setAppear({ MENU: !visible }))
+    <MenuItem
+      {...props}
+      title={t('pages.mynotifications')}
+      notificationInfo={{
+        ...notificationInfo,
+        notificationColor,
       }}
-    >
-      <>
-        <div
-          className="badgeBox"
-          style={{
-            marginRight: '12px',
-            marginLeft: '3px',
-            backgroundColor: notificationColor,
+      isSeparate={true}
+      onClick={() => {
+        if (props.to) navigate(props.to)
+      }}
+      icon={
+        <NotificationsNoneIcon
+          sx={{
+            height: 18,
+            width: 18,
           }}
-        >
-          <Typography
-            sx={{
-              paddingRight: '12px',
-            }}
-            variant="body2"
-          >
-            {notificationInfo?.notificationCount}
-          </Typography>
-        </div>
-        <LinkRouter
-          className="link-router-text"
-          to={props.to ?? '/'}
-          {...props}
-        >
-          {t('pages.mynotifications')}
-        </LinkRouter>
-      </>
-    </WraperLink>
+        />
+      }
+    />
   )
 }

--- a/src/components/shared/frame/Header/Header.scss
+++ b/src/components/shared/frame/Header/Header.scss
@@ -50,7 +50,7 @@ header {
     padding-left: 5px;
   }
 }
-@media (min-width: 1499px) {
+@media (min-width: 1440px) {
   .mobileHeader,
   .mobileNav {
     display: none;
@@ -67,7 +67,7 @@ header {
 }
 
 //mobile layout
-@media (max-width: 1499px) {
+@media (max-width: 1440px) {
   header {
     display: none;
   }
@@ -108,5 +108,163 @@ header {
     color: #0f71cb;
     position: relative;
     z-index: -9;
+  }
+}
+
+header {
+  display: none;
+}
+
+.mobileHeader,
+.mobileNav {
+  display: block;
+}
+
+.mobile-search-icon {
+  display: block;
+}
+
+.mobileNav {
+  display: flex;
+  justify-content: space-between;
+  position: static;
+  z-index: 999;
+  width: 100%;
+  margin-top: 0;
+  align-items: center;
+  background: #fff;
+  padding: 10px 5px;
+  border-bottom: 2px solid #f6f6f6;
+
+  position: fixed;
+  top: 0;
+  left: auto;
+  right: auto;
+  max-width: 1800px;
+  height: 85px;
+
+  .MuiSvgIcon-root {
+    color: #4d4d4d;
+
+    path {
+      fill: #4d4d4d;
+    }
+  }
+}
+
+.logo {
+  display: flex;
+  height: 100%;
+  width: auto;
+  align-items: center;
+  justify-content: flex-start;
+  max-width: 140px;
+  margin-top: 4px;
+
+  img {
+    max-width: 100%;
+  }
+}
+
+.logo-mobile {
+  display: flex;
+  height: 100%;
+  width: auto;
+  align-items: center;
+  justify-content: flex-start;
+  margin-top: 0px;
+
+  img {
+    max-width: 100%;
+  }
+}
+
+.mobileHeaderRight {
+  display: flex;
+  align-items: center;
+  margin-right: 10px;
+  position: relative;
+  right: 0px;
+  z-index: -9;
+  top: 5px;
+}
+
+.mobileHeader {
+  display: flex;
+  z-index: 999;
+  width: auto;
+  height: auto;
+  margin-left: 15px;
+  margin-top: 10px;
+  margin-bottom: 5px;
+}
+
+.mobileHeader img {
+  width: auto;
+  height: 30px;
+}
+
+.mobile-search-icon {
+  margin-right: 10px;
+  color: #d31184;
+  position: relative;
+  z-index: -9;
+  cursor: pointer;
+}
+
+// desktop nav enabled start
+.user-is-admin {
+  @media (min-width: 1440px) {
+    header {
+      display: block;
+      background: #fff;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      left: auto;
+      right: auto;
+      max-width: 1800px;
+    }
+
+    main .customHeight {
+      top: 85px !important;
+    }
+
+    .mobileHeader,
+    .mobileNav {
+      display: none;
+    }
+
+    .mobile-search-icon {
+      display: none;
+    }
+  }
+}
+
+.user-is-not-admin {
+  @media (min-width: 1280px) {
+    header {
+      display: block;
+      background: #fff;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      left: auto;
+      right: auto;
+      max-width: 1800px;
+    }
+
+    main .customHeight {
+      top: 85px !important;
+    }
+
+    .mobileHeader,
+    .mobileNav {
+      display: none;
+    }
+
+    .mobile-search-icon {
+      display: none;
+    }
   }
 }

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -18,14 +18,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useEffect, useState } from 'react'
-import { NavLink } from 'react-router-dom'
+import { useMemo, useState } from 'react'
+import { Link, NavLink } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
 import MenuIcon from '@mui/icons-material/Menu'
 import { Box, useMediaQuery, useTheme } from '@mui/material'
 import SearchIcon from '@mui/icons-material/Search'
-import SortIcon from '@mui/icons-material/Sort'
 import {
   Button,
   CustomAccordion,
@@ -33,7 +32,6 @@ import {
   Typography,
 } from '@catena-x/portal-shared-components'
 import type { MenuItem, Tree } from 'types/MainTypes'
-import { getAssetBase } from 'services/EnvironmentService'
 import {
   ApplicationStatus,
   useFetchApplicationsQuery,
@@ -44,20 +42,24 @@ import {
   appearMenuSelector,
 } from 'features/control/appear'
 import { UserInfo } from '../UserInfo'
-import { Logo } from '../Logo'
 import RegistrationReviewOverlay from './RegistrationReviewOverlay'
 import './Header.scss'
 import RegistrationReviewContent from './RegistrationReviewOverlay/RegistrationReviewContent'
 import RegistrationDeclinedOverlay from './RegistrationDeclinedOverlay'
-import { useFetchOwnCompanyDetailsQuery } from 'features/admin/userApiSlice'
-import { COMPANY_ROLES } from 'types/Constants'
+import { HELP_LINK, ROLES } from 'types/Constants'
+import { getCompanyRoles } from 'services/CompanyService'
+import AccessService, { userHasPortalRole } from 'services/AccessService'
+import { ImageReferences } from 'types/ImageReferences'
+import { setIsHeaderNote } from 'features/home/slice'
 
 export const Header = ({
   main,
   user,
+  userMenuWithChildren,
 }: {
   main: Tree[] | undefined
   user: string[]
+  userMenuWithChildren?: Tree[]
 }) => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -71,37 +73,59 @@ export const Header = ({
 
   const { data } = useFetchApplicationsQuery()
   const companyData = data?.[0]
-  const { data: companyDetails } = useFetchOwnCompanyDetailsQuery('')
-  const [submittedOverlayOpen, setSubmittedOverlayOpen] =
-    useState<boolean>(false)
+
+  // const { data: companyDetails } = useFetchOwnCompanyDetailsQuery('')
+  const [submittedOverlayOpen, setSubmittedOverlayOpen] = useState(
+    companyData?.applicationStatus === ApplicationStatus.SUBMITTED
+  )
   const [headerNote, setHeaderNote] = useState(false)
 
-  useEffect(() => {
-    if (!(companyData && companyDetails)) return
-    setSubmittedOverlayOpen(
-      !companyDetails?.companyRole.includes(COMPANY_ROLES.OPERATOR) &&
-        companyData?.applicationStatus === ApplicationStatus.SUBMITTED
-    )
-  }, [companyData, companyDetails])
-
   const addTitle = (items: Tree[] | undefined) =>
-    items?.map(
-      (item: Tree): MenuItem => ({
-        ...item,
-        to: `/${item.name}`,
-        title: t(`pages.${item.name}`),
-        hint: item.hint ? t(`hints.${item.hint}`) : '',
-        children: addTitle(item.children),
-      })
-    )
+    items
+      ?.filter(
+        (item: Tree) =>
+          !item.companyRole ||
+          (getCompanyRoles().includes(item.companyRole) &&
+            userHasPortalRole(ROLES.CONFIGURE_PARTNER_REGISTRATION))
+      )
+      .map(
+        (item: Tree): MenuItem => ({
+          ...item,
+          to: `/${item.name}`,
+          title: item.children
+            ? t(`menu.heading.${item.name}`)
+            : t(`pages.${item.name}`),
+          hint: item.hint ? t(`hints.${item.hint}`) : '',
+          children: addTitle(item.children),
+        })
+      )
 
   const menu = addTitle(main) ?? []
+  console.log(main, getCompanyRoles())
+
+  const menuWithChild = addTitle(userMenuWithChildren) ?? []
+
+  const activeMenuBucket = useMemo(() => {
+    return menu.find((item) => {
+      if (item.children) {
+        return item.children.find((menuItem) => {
+          if (menuItem.children) {
+            return menuItem.children.find(
+              (subItem) => subItem.to === location.pathname
+            )
+          }
+          return menuItem.to === location.pathname
+        })
+      }
+      return false
+    })?.name
+  }, [menu])
 
   const renderFullText = () => {
     return (
       <div
         className="registration-review"
-        style={{ width: isMobile ? '100%' : '40%', margin: '0 auto' }}
+        style={{ width: isMobile ? '100%' : '40%' }}
       >
         <RegistrationReviewContent />
         <div className="helpMain">
@@ -135,11 +159,14 @@ export const Header = ({
               children: renderFullText(),
               expanded: false,
               icon: (
-                <Typography variant="label3" className="noteReviewText">
-                  <SortIcon className="subjectIcon" />
-                  {isMobile
-                    ? 'REGISTRATION IN REVIEW '
-                    : t('content.registrationInreview.note')}
+                <Typography variant="label1" className="noteReviewText">
+                  <img
+                    src="/note_stack.svg"
+                    alt="cx logo"
+                    style={{
+                      width: 24,
+                    }}
+                  />
                 </Typography>
               ),
               id: 'panel-1',
@@ -147,11 +174,17 @@ export const Header = ({
               titleElement: !isMobile ? (
                 <div>
                   <Trans>
-                    <Typography variant="label3">
-                      {t('content.registrationInreview.noteDetail')}
+                    <Typography
+                      variant="label1"
+                      className="noteReviewText"
+                      sx={{ fontWeight: 500 }}
+                    >
+                      {isMobile
+                        ? 'REGISTRATION IN REVIEW '
+                        : t('content.registrationInreview.note')}
                     </Typography>
-                    <Typography variant="label3" className="emailText">
-                      {t('content.registrationInreview.email')}
+                    <Typography variant="label1" sx={{ fontWeight: 500 }}>
+                      {t('content.registrationInreview.noteDetail')}
                     </Typography>
                   </Trans>
                 </div>
@@ -168,61 +201,76 @@ export const Header = ({
 
   return (
     <>
-      <header>
-        <MainNavigation items={menu} component={NavLink}>
-          <Logo />
-          <div className="d-flex">
+      <div
+        className={`${AccessService.isAdmin() ? 'user-is-admin' : 'user-is-not-admin'}`}
+      >
+        <header>
+          <MainNavigation
+            items={menu}
+            component={NavLink}
+            activePathname={activeMenuBucket}
+            navigationUnstyled={true}
+          >
+            <Link to={'/'} className="logo">
+              <img
+                src={ImageReferences.logo.url}
+                alt={ImageReferences.logo.alt}
+              />
+            </Link>
+            <div className="d-flex">
+              <div
+                onClick={() => dispatch(setAppear({ SEARCH: !visible }))}
+                className="search-icon"
+                onKeyUp={() => {
+                  // do nothing
+                }}
+              >
+                <SearchIcon className="searchIcon" />
+              </div>
+              <Button
+                size="small"
+                color="secondary"
+                variant="outlined"
+                onClick={() => {
+                  window.open(HELP_LINK(), 'documentation', 'noreferrer')
+                }}
+                className="documentation"
+              >
+                {t('pages.help')}
+              </Button>
+              <UserInfo pages={user} menuWithChild={menuWithChild} />
+            </div>
+          </MainNavigation>
+        </header>
+        <div className="mobileNav">
+          <div className="mobileHeader">
+            <Link to={'/'} className="logo-mobile">
+              <img
+                src={ImageReferences.logoMobile.url}
+                alt={ImageReferences.logoMobile.alt}
+              />
+            </Link>
+          </div>
+          <div className="mobileHeaderRight">
             <div
               onClick={() => dispatch(setAppear({ SEARCH: !visible }))}
-              className="search-icon"
-              onKeyUp={() => {
+              className="mobile-search-icon"
+              onKeyDown={() => {
                 // do nothing
               }}
             >
               <SearchIcon className="searchIcon" />
             </div>
-            <Button
-              size="small"
-              color="secondary"
-              variant="contained"
-              onClick={() => {
-                window.open(
-                  `${document.location.origin}/documentation/`,
-                  'documentation',
-                  'noreferrer'
-                )
+            <Box
+              onClick={() => dispatch(setAppear({ MENU: !appearShow }))}
+              className="mobile-search-icon"
+              onKeyDown={() => {
+                // do nothing
               }}
-              className="documentation"
             >
-              {t('pages.help')}
-            </Button>
-            <UserInfo pages={user} />
+              <MenuIcon className="searchIcon" />
+            </Box>
           </div>
-        </MainNavigation>
-      </header>
-      <div className="mobileNav">
-        <div className="mobileHeader">
-          <img src={`${getAssetBase()}/images/logos/cx-short.svg`} alt="logo" />
-        </div>
-        <div className="mobileHeaderRight">
-          <div
-            onClick={() => dispatch(setAppear({ SEARCH: !visible }))}
-            className="mobile-search-icon"
-            onKeyDown={() => {
-              // do nothing
-            }}
-          >
-            <SearchIcon className="searchIcon" />
-          </div>
-          <Box
-            onClick={() => dispatch(setAppear({ MENU: !appearShow }))}
-            className="mobile-search-icon"
-            onKeyDown={() => {
-              // do nothing
-            }}
-          >
-            <MenuIcon className="searchIcon" />
-          </Box>
         </div>
       </div>
       {headerNote && renderRegistrationNoteSection()}
@@ -231,6 +279,7 @@ export const Header = ({
         handleOverlayClose={() => {
           setSubmittedOverlayOpen(false)
           setHeaderNote(true)
+          dispatch(setIsHeaderNote({ headerNote: true }))
         }}
       />
       <RegistrationDeclinedOverlay

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -18,7 +18,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
@@ -46,7 +46,8 @@ import RegistrationReviewOverlay from './RegistrationReviewOverlay'
 import './Header.scss'
 import RegistrationReviewContent from './RegistrationReviewOverlay/RegistrationReviewContent'
 import RegistrationDeclinedOverlay from './RegistrationDeclinedOverlay'
-import { HELP_LINK, ROLES } from 'types/Constants'
+import { useFetchOwnCompanyDetailsQuery } from 'features/admin/userApiSlice'
+import { COMPANY_ROLES, HELP_LINK, ROLES } from 'types/Constants'
 import { getCompanyRoles } from 'services/CompanyService'
 import AccessService, { userHasPortalRole } from 'services/AccessService'
 import { ImageReferences } from 'types/ImageReferences'
@@ -74,11 +75,18 @@ export const Header = ({
   const { data } = useFetchApplicationsQuery()
   const companyData = data?.[0]
 
-  // const { data: companyDetails } = useFetchOwnCompanyDetailsQuery('')
-  const [submittedOverlayOpen, setSubmittedOverlayOpen] = useState(
-    companyData?.applicationStatus === ApplicationStatus.SUBMITTED
-  )
+  const { data: companyDetails } = useFetchOwnCompanyDetailsQuery('')
+  const [submittedOverlayOpen, setSubmittedOverlayOpen] =
+    useState<boolean>(false)
   const [headerNote, setHeaderNote] = useState(false)
+
+  useEffect(() => {
+    if (!(companyData && companyDetails)) return
+    setSubmittedOverlayOpen(
+      !companyDetails?.companyRole.includes(COMPANY_ROLES.OPERATOR) &&
+        companyData?.applicationStatus === ApplicationStatus.SUBMITTED
+    )
+  }, [companyData, companyDetails])
 
   const addTitle = (items: Tree[] | undefined) =>
     items
@@ -208,7 +216,7 @@ export const Header = ({
           <MainNavigation
             items={menu}
             component={NavLink}
-            activePathname={activeMenuBucket}
+            activeMenu={activeMenuBucket}
             navigationUnstyled={true}
           >
             <Link to={'/'} className="logo">

--- a/src/components/shared/frame/Header/index.tsx
+++ b/src/components/shared/frame/Header/index.tsx
@@ -216,7 +216,7 @@ export const Header = ({
           <MainNavigation
             items={menu}
             component={NavLink}
-            activeMenu={activeMenuBucket}
+            activePathname={activeMenuBucket}
             navigationUnstyled={true}
           >
             <Link to={'/'} className="logo">

--- a/src/components/shared/frame/UserInfo/index.tsx
+++ b/src/components/shared/frame/UserInfo/index.tsx
@@ -21,9 +21,9 @@
 import { useRef, useState, useEffect } from 'react'
 import {
   LanguageSwitch,
+  Menu,
   UserAvatar,
   UserMenu,
-  UserNav,
   type NotificationBadgeType,
 } from '@catena-x/portal-shared-components'
 import UserService from 'services/UserService'
@@ -36,9 +36,16 @@ import { INTERVAL_CHECK_NOTIFICATIONS } from 'types/Constants'
 import { useGetNotificationMetaQuery } from 'features/notification/apiSlice'
 import { setLanguage } from 'features/language/actions'
 import { useDispatch } from 'react-redux'
-import { Box } from '@mui/material'
+import { Box, Divider, styled } from '@mui/material'
+import type { MenuItemProps } from '@catena-x/portal-shared-components/dist/components/basic/Menu/MenuItem'
 
-export const UserInfo = ({ pages }: { pages: string[] }) => {
+export const UserInfo = ({
+  pages,
+  menuWithChild,
+}: {
+  pages: string[]
+  menuWithChild: MenuItemProps[]
+}) => {
   const { t } = useTranslation()
   const [menuOpen, setMenuOpen] = useState(false)
   const avatar = useRef<HTMLDivElement>(null)
@@ -49,7 +56,7 @@ export const UserInfo = ({ pages }: { pages: string[] }) => {
   const [notificationInfo, setNotificationInfo] =
     useState<NotificationBadgeType>()
   const menu = pages.map((link) => ({
-    to: link,
+    to: `/${link}`,
     title: t(`pages.${link}`),
   }))
 
@@ -89,18 +96,26 @@ export const UserInfo = ({ pages }: { pages: string[] }) => {
           isNotificationAlert={notificationInfo?.isNotificationAlert}
         />
       </div>
-      <UserMenu
+      <UserMenuStyled
         open={menuOpen}
         sx={{
           top: '60px',
-          width: '256px',
+          width: 300,
           position: 'absolute',
         }}
         userName={UserService.getName()}
         userRole={UserService.getCompany()}
         onClickAway={onClickAway}
       >
-        <UserNav
+        <Menu
+          items={menuWithChild}
+          component={Link}
+          subMenuDivider={true}
+          onClick={openCloseMenu}
+        />
+        <>{menuWithChild.length > 0 ? <Divider /> : null}</>
+
+        <Menu
           component={Link}
           onClick={openCloseMenu}
           divider
@@ -115,7 +130,27 @@ export const UserInfo = ({ pages }: { pages: string[] }) => {
             changeLanguage(key)
           }}
         />
-      </UserMenu>
+      </UserMenuStyled>
     </Box>
   )
 }
+
+const UserMenuStyled = styled(UserMenu)(
+  ({ theme }) => `
+  .MuiBox-root {
+    background-color: ${theme.palette.common.white};
+    .MuiTypography-label3{
+      font-size: 20px !important;
+      font-weight: 600;
+      padding-bottom: 8px;
+
+    }
+
+    .MuiTypography-label4 {
+      font-size: 16px !important;
+      font-weight: 500;
+      color: ${theme.palette.secondary.main}
+    }
+  }
+  `
+)

--- a/src/components/styles/_colors.scss
+++ b/src/components/styles/_colors.scss
@@ -36,7 +36,8 @@ $colors: (
   text-secondary: #252525,
   text-tertiary: #888888,
   text-quaternary: #a2a2a2,
-  text-quinary: #2962ba
+  text-quinary: #2962ba,
+  secondary-hover: #333333
 );
 
 @function color($key) {

--- a/src/components/styles/main.scss
+++ b/src/components/styles/main.scss
@@ -34,9 +34,14 @@ body {
 }
 
 #app {
+  position: relative;
+  padding-top: 85px !important;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  flex: 1;
+}
+.initial-main-div {
+  flex: 1;
 }
 
 main {
@@ -99,4 +104,59 @@ a {
 
 .app-back button {
   text-transform: capitalize;
+}
+
+.cx-main-navigation__wrapper {
+  .cx-list-item-header-item {
+    .MuiTypography-root:not(.notification-badge-text) {
+      font-size: 18px !important;
+      font-weight: 500 !important;
+      color: color(secondary-hover);
+    }
+
+    :not(.notification-badge-text):hover {
+      background-color: color(secondary-hover) !important;
+      border-radius: 8px;
+      color: color(secondary-hover) !important;
+    }
+
+    .active {
+      color: color(color-primary) !important;
+
+      :not(.notification-badge-text):hover {
+        color: color(color-primary) !important;
+      }
+    }
+
+    .MuiListItem-root a .active {
+      :hover {
+        color: color(color-primary) !important;
+      }
+    }
+  }
+
+  .cx-list-item-header {
+    .MuiTypography-root {
+      font-size: 16px !important;
+      font-weight: 600 !important;
+      color: color(black);
+    }
+  }
+
+  .UserInfo {
+    .MuiTypography-label3 {
+      font-weight: 600;
+      font-size: 20px;
+    }
+
+    .MuiTypography-label4 {
+      font-weight: 500;
+      font-size: 16px;
+      color: color(color-secondary);
+    }
+  }
+
+  .MuiAvatar-circular.MuiAvatar-colorDefault {
+    // background-color: $color-primary !important;
+  }
 }

--- a/src/features/home/slice.ts
+++ b/src/features/home/slice.ts
@@ -1,5 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,37 +17,24 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-import PermIdentityIcon from '@mui/icons-material/PermIdentity'
-import { MenuItem, type MenuItemProps } from './MenuItem'
-import './MobileMenu.scss'
-import { t } from 'i18next'
 
-interface ProfileLinkProps {
-  onSelect?: (title: string, children: MenuItemProps[]) => void
-  onClick?: React.MouseEventHandler
-  userMenu: MenuItemProps[]
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from 'features/store'
+import type { IHome } from './types'
+
+const initialState: IHome = {
+  headerNote: false,
 }
 
-export const ProfileLink = ({
-  onSelect,
-  userMenu,
-}: ProfileLinkProps): JSX.Element => {
-  return (
-    <MenuItem
-      title={t('pages.account')}
-      onClick={() => {
-        if (onSelect) onSelect(t('pages.account'), userMenu)
-      }}
-      children={userMenu}
-      onSelect={onSelect}
-      icon={
-        <PermIdentityIcon
-          sx={{
-            height: 18,
-            width: 18,
-          }}
-        />
-      }
-    />
-  )
-}
+export const homeSlice = createSlice({
+  name: 'home',
+  initialState,
+  reducers: {
+    setIsHeaderNote: (_state: IHome, action: PayloadAction<IHome>) => {
+      return action.payload
+    },
+  },
+})
+
+export const { setIsHeaderNote } = homeSlice.actions
+export const homeSelector = (state: RootState): IHome => state.home

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -1,5 +1,6 @@
 /********************************************************************************
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -16,37 +17,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-import PermIdentityIcon from '@mui/icons-material/PermIdentity'
-import { MenuItem, type MenuItemProps } from './MenuItem'
-import './MobileMenu.scss'
-import { t } from 'i18next'
 
-interface ProfileLinkProps {
-  onSelect?: (title: string, children: MenuItemProps[]) => void
-  onClick?: React.MouseEventHandler
-  userMenu: MenuItemProps[]
-}
-
-export const ProfileLink = ({
-  onSelect,
-  userMenu,
-}: ProfileLinkProps): JSX.Element => {
-  return (
-    <MenuItem
-      title={t('pages.account')}
-      onClick={() => {
-        if (onSelect) onSelect(t('pages.account'), userMenu)
-      }}
-      children={userMenu}
-      onSelect={onSelect}
-      icon={
-        <PermIdentityIcon
-          sx={{
-            height: 18,
-            width: 18,
-          }}
-        />
-      }
-    />
-  )
+export interface IHome {
+  headerNote: boolean
 }

--- a/src/features/store.ts
+++ b/src/features/store.ts
@@ -75,6 +75,7 @@ import companyDataSlice from './companyData/slice'
 
 import languageSlice from './language/slice'
 import { apiSlice as usecaseApiSlice } from './usecase/usecaseApiSlice'
+import { homeSlice } from './home/slice'
 
 export const reducers = {
   admin,
@@ -134,6 +135,7 @@ export const reducers = {
   [companyCertificateApiSlice.reducerPath]: companyCertificateApiSlice.reducer,
   [staticContentApiSlice.reducerPath]: staticContentApiSlice.reducer,
   [companyDataApiSlice.reducerPath]: companyDataApiSlice.reducer,
+  [homeSlice.reducerPath]: homeSlice.reducer,
 }
 
 export const store = configureStore({

--- a/src/services/AccessService.tsx
+++ b/src/services/AccessService.tsx
@@ -35,8 +35,9 @@ import {
   userMenuFull,
   userMenuRegistration,
   userMenuCompany,
+  userMenuWithChildren,
 } from 'types/Config'
-import { OVERLAYS } from 'types/Constants'
+import { OVERLAYS, ROLES } from 'types/Constants'
 import { AddTechnicalUser } from 'components/overlays/AddTechnicalUser'
 import AddAppUserRoles from 'components/overlays/AddAppUserRoles'
 import EditAppUserRoles from 'components/overlays/EditAppUserRoles'
@@ -137,23 +138,32 @@ export const hasAccessOverlay = (overlay: string) =>
 const accessToMenu = (menu: string[]) =>
   menu.filter((page: string) => hasAccess(page))
 
-const accessToMenuTree = (menu: Tree[] | undefined): Tree[] | undefined =>
+const accessToMenuTree = (menu: Tree[]): Tree[] =>
   menu
-    ?.filter((item: Tree) => hasAccess(item.name))
+    ?.filter((item: Tree) => {
+      return item.children ?? hasAccess(item.name)
+    })
     .map((item: Tree) => ({
       ...item,
-      children: accessToMenuTree(item.children),
+      children: item.children ? accessToMenuTree(item.children) : undefined,
     }))
+    .filter((item) => {
+      return !item.children || (item.children && item.children.length > 0)
+    })
 
 const mainMenuTree = () => accessToMenuTree(mainMenuFullTree)
 
 const userMenu = () => accessToMenu(userMenuFull)
+
+const userMenuWithChild = () => accessToMenuTree(userMenuWithChildren)
 
 const userMenuReg = () => accessToMenu(userMenuRegistration)
 
 const userMenuComp = () => accessToMenu(userMenuCompany)
 
 const footerMenu = () => accessToMenu(footerMenuFull)
+
+const isAdmin = () => userHasPortalRole(ROLES.CX_ADMIN)
 
 const permittedRoutes = () =>
   ALL_PAGES.filter((page: IPage) => hasAccess(page.name)).map((p) => p.element)
@@ -299,6 +309,8 @@ const AccessService = {
   footerMenu,
   userMenuComp,
   companyHasRole,
+  userMenuWithChild,
+  isAdmin,
 }
 
 export default AccessService

--- a/src/types/Config.tsx
+++ b/src/types/Config.tsx
@@ -53,8 +53,9 @@ import UserDetails from 'components/pages/UserDetail'
 import { Route } from 'react-router-dom'
 import {
   ACTIONS,
+  COMPANY_ROLE,
   COMPANY_ROLES,
-  HINTS,
+  MENUS,
   OVERLAYS,
   PAGES,
   ROLES,
@@ -772,55 +773,57 @@ export const ALL_ACTIONS: IAction[] = [
  * it will be restricted by personal user permissions
  */
 export const mainMenuFullTree = [
-  { name: PAGES.HOME },
   {
-    name: PAGES.INTRODUCTION,
+    name: MENUS.DATASPACE_PARTICIPATION,
     children: [
-      { name: PAGES.INTRODUCTION_PARTICIPANT, hint: HINTS.NEW },
-      { name: PAGES.INTRODUCTION_APP_PROVIDER, hint: HINTS.NEW },
-      { name: PAGES.INTRODUCTION_SERVICE_PROVIDER, hint: HINTS.NEW },
-      { name: PAGES.INTRODUCTION_CONFORMITY_BODY, hint: HINTS.NEW },
-      { name: PAGES.INTRODUCTION_OSP_BODY, hint: HINTS.NEW },
+      { name: PAGES.PARTNER_NETWORK },
+      { name: PAGES.USECASE_PARTICIPATION },
     ],
   },
   {
-    name: PAGES.USE_CASE,
-    children: [{ name: PAGES.USE_CASE_TRACABILITY, hint: HINTS.NEW }],
-  },
-  {
-    name: PAGES.DATA_SPACE,
-  },
-  {
-    name: PAGES.MARKETPLACE,
+    name: MENUS.MARKETPLACE,
     children: [
       { name: PAGES.APP_MARKETPLACE },
-      { name: PAGES.SERVICE_MARKETPLACE, hint: HINTS.NEW },
+      { name: PAGES.SERVICE_MARKETPLACE },
+      { name: PAGES.COMPANY_SUBSCRIPTIONS },
     ],
   },
   {
-    name: PAGES.DATA_MANAGEMENT,
-    children: [{ name: PAGES.SEMANTICHUB }],
-  },
-  { name: PAGES.PARTNER_NETWORK },
-  {
-    name: PAGES.APP_MANAGEMENT,
+    name: MENUS.MARKETPLACE_MANAGEMENT,
     children: [
-      { name: PAGES.APP_OVERVIEW, hint: HINTS.NEW },
-      { name: PAGES.APP_RELEASE_PROCESS },
-      { name: PAGES.APP_SUBSCRIPTION, hint: HINTS.NEW },
-      { name: PAGES.APP_ADMIN_BOARD, hint: HINTS.NEW },
-    ],
-  },
-  {
-    name: PAGES.SERVICE_MANAGEMENT,
-    children: [
-      { name: PAGES.SERVICE_OVERVIEW, hint: HINTS.NEW },
-      { name: PAGES.SERVICE_RELEASE_PROCESS, hint: HINTS.NEW },
       {
-        name: PAGES.SERVICE_SUBSCRIPTION,
-        hint: HINTS.NEW,
+        name: MENUS.APP_MANAGEMENT,
+        children: [
+          { name: PAGES.APP_OVERVIEW },
+          { name: PAGES.APP_RELEASE_PROCESS },
+          { name: PAGES.APP_SUBSCRIPTION },
+        ],
       },
-      { name: PAGES.SERVICE_ADMIN_BOARD, hint: HINTS.NEW },
+      {
+        name: MENUS.SERVICE_MANAGEMENT,
+        children: [
+          { name: PAGES.SERVICE_OVERVIEW },
+          { name: PAGES.SERVICE_RELEASE_PROCESS },
+          { name: PAGES.SERVICE_SUBSCRIPTION },
+        ],
+      },
+    ],
+  },
+  {
+    name: MENUS.TECHNICAL_SETUP,
+    children: [
+      { name: PAGES.TECH_USER_MANAGEMENT },
+      { name: PAGES.IDP_MANAGEMENT },
+      { name: PAGES.CONNECTOR_MANAGEMENT },
+      { name: PAGES.SEMANTICHUB },
+    ],
+  },
+  {
+    name: MENUS.ON_BOARDING_MANAGEMENT,
+    companyRole: COMPANY_ROLE.ONBOARDING_SERVICE_PROVIDER,
+    children: [
+      { name: PAGES.ONBOARDING_SERVICE_PROVIDER_MANAGEMENT },
+      { name: PAGES.OSP_TECHNICAL_USER_MANAGEMENT },
     ],
   },
 ]
@@ -833,24 +836,25 @@ export const mainMenuFullTree = [
  */
 export const userMenuFull = [
   PAGES.ACCOUNT,
-  PAGES.ORGANIZATION,
-  PAGES.COMPANY_SUBSCRIPTIONS,
-  PAGES.NOTIFICATIONS,
   PAGES.USER_MANAGEMENT,
-  PAGES.IDP_MANAGEMENT,
-  PAGES.CONNECTOR_MANAGEMENT,
-  PAGES.APPLICATION_REQUESTS,
-  PAGES.CLEARINGHOUSE_SELF_DESCRIPTION,
-  PAGES.INVITE,
-  PAGES.COMPANY_ROLE,
-  PAGES.USECASE_PARTICIPATION,
-  PAGES.CERTIFICATE_CREDENTIAL,
-  PAGES.ADMIN_CREDENTIAL,
-  PAGES.COMPANY_CERTIFICATE,
+  PAGES.ORGANIZATION,
   PAGES.COMPANY_WALLET,
   PAGES.COMPANY_DATA,
-  PAGES.ONBOARDING_SERVICE_PROVIDER_MANAGEMENT,
+  PAGES.NOTIFICATIONS,
   PAGES.LOGOUT,
+]
+
+export const userMenuWithChildren = [
+  {
+    name: MENUS.CX_OPERATOR,
+    children: [
+      { name: PAGES.INVITE },
+      { name: PAGES.APPLICATION_REQUESTS },
+      { name: PAGES.ADMIN_CREDENTIAL },
+      { name: PAGES.APP_ADMIN_BOARD },
+      { name: PAGES.SERVICE_ADMIN_BOARD },
+    ],
+  },
 ]
 
 export const userMenuRegistration = [PAGES.LOGOUT]

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -19,6 +19,7 @@
  ********************************************************************************/
 
 import { ServiceTypeIdsEnum } from 'features/serviceManagement/apiSlice'
+import i18next from 'i18next'
 
 export const PAGE_SIZE = 10
 
@@ -110,6 +111,7 @@ export enum PAGES {
   COMPANY_SUBSCRIPTIONS_DETAIL = 'companySubscriptionsDetail',
   COMPANY_DATA = 'companyData',
   ONBOARDING_SERVICE_PROVIDER_MANAGEMENT = 'onboardingServiceProviderManagement',
+  OSP_TECHNICAL_USER_MANAGEMENT = 'ospTechnicalUserManagement',
 }
 
 export enum OVERLAYS {
@@ -263,3 +265,29 @@ export enum COMPANY_ROLES {
   OPERATOR = 'OPERATOR',
   ONBOARDING_SERVICE_PROVIDER = 'ONBOARDING_SERVICE_PROVIDER',
 }
+
+export const MENUS = {
+  DATASPACE_PARTICIPATION: 'dataSpaceParticipation',
+  MARKETPLACE: 'marketplace',
+  MARKETPLACE_MANAGEMENT: 'marketplaceManagement',
+  APP_MANAGEMENT: 'appManagement',
+  SERVICE_MANAGEMENT: 'serviceManagement',
+  TECHNICAL_SETUP: 'technicalSetup',
+  CX_OPERATOR: 'cxOperator',
+  ON_BOARDING_MANAGEMENT: 'onBoardingManagement',
+}
+
+export const COMPANY_ROLE = {
+  ACTIVE_PARTICIPANT: 'ACTIVE_PARTICIPANT',
+  APP_PROVIDER: 'APP_PROVIDER',
+  SERVICE_PROVIDER: 'SERVICE_PROVIDER',
+  ONBOARDING_SERVICE_PROVIDER: 'ONBOARDING_SERVICE_PROVIDER',
+}
+
+export const HELP_LINK = () => {
+  // TODO: in future we need to replace 323675-portal-marketplace with specific section of this page
+  return `https://intercom-help.eu/catena-x/${i18next.language}/collections/323675-portal-marketplace`
+}
+
+export const DOCUMENTATION_HELP_LINK = (path: string) =>
+  `https://intercom-help.eu/catena-x/?path=${path}`

--- a/src/types/ImageReferences.ts
+++ b/src/types/ImageReferences.ts
@@ -1,0 +1,12 @@
+import { getAssetBase } from 'services/EnvironmentService'
+
+export const ImageReferences = {
+  logo: {
+    url: `${getAssetBase()}/images-cfx/logos/CofinityX-logo-gray-colored-Cfx.svg`,
+    alt: 'Cofinity-X Logo',
+  },
+  logoMobile: {
+    url: `${getAssetBase()}/images-cfx/logos/CofinityX-favicon-gradient-Cfx.svg`,
+    alt: 'Cofinity-X Logo',
+  },
+}

--- a/src/types/MainTypes.ts
+++ b/src/types/MainTypes.ts
@@ -113,6 +113,7 @@ export interface Tree {
   name: string
   hint?: string
   children?: Tree[]
+  companyRole?: string
 }
 
 export interface MenuItem extends LinkItem, Tree {


### PR DESCRIPTION
As part of the discussion with the Catena-X portal team, it was discussed and agreed upon that Cofinity-X would contribute the Cofinity-X navigation bar and mobile menu.

This feature is spit into two parts. A contribution to the portal repo which contains code that upgrades the mobile navigation and a contribution to the shared components, which upgrades components used in the main navigation and user menu. 

Shared components PR: https://github.com/eclipse-tractusx/portal-shared-components/pull/407

## Description

- Updated MenuInfo component
- Updated MenuItem component
- Update logo component
- New LogoutLink component
- Updated mobile menu MenuChildren component
- Updated mobile menu MenuFooter component
- Updated mobile menu ProfileLink component
- Updated Header component
- Updated AccessService 
- Added new redux store & slice to store header note state
- Added new menu constants
- Added company role constants

## Why

Cofinity-X uses a more concise and neat structure which handles a large amount of navigation items well. The idea of using this navigation structure was offered by Cofinity-X team and accepted by the open source community.

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

