### PR TITLE
fix(copywriting): improve partner network page copywriting

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -792,7 +792,7 @@
         "uniqueid": "Eindeutige ID",
         "zipcode": "PLZ",
         "city": "PLZ/Stadt",
-        "cxparticipant": "CX Member",
+        "cxparticipant": "Aktiver Teilnehmer",
         "address": "Anschrift",
         "identifiers": "Identifiers"
       },

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -798,7 +798,7 @@
         "uniqueid": "Unique ID",
         "zipcode": "Zip Code",
         "city": "PLZ/City",
-        "cxparticipant": "CX Member",
+        "cxparticipant": "Active Participant",
         "address": "Address",
         "identifiers": "Identifiers"
       },


### PR DESCRIPTION
## Description

Improve partner network page copywriting

## Why

Avoid confusion linked to phrase "CX Member", which can also refers to Association members.

Use "Active Participant" instead.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1429

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
