### PR TITLE
fix(react): fix dom nesting

### DIFF
--- a/src/components/shared/basic/KeyValueView/index.tsx
+++ b/src/components/shared/basic/KeyValueView/index.tsx
@@ -43,7 +43,7 @@ interface KeyValueViewProps {
 
 const renderValue = (value: DataValue, masked: boolean = false) => {
   const maskedText = masked ? '*****' : value
-  return (
+  return typeof maskedText === 'string' ? (
     <Typography
       sx={{
         fontSize: '14px',
@@ -54,6 +54,8 @@ const renderValue = (value: DataValue, masked: boolean = false) => {
     >
       {maskedText}
     </Typography>
+  ) : (
+    <>{maskedText}</>
   )
 }
 


### PR DESCRIPTION
## Description

Fix dom where div appears as a child of p

## Why

According to the HTML specification the p element must only contain "Phrasing Content" while div is not permitted: https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
(Typography is rendered to p and StatusTag rendered to a div)

## Issue

#1269 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally