### PR TITLE
fix: disable document download button for unavailable documents

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2028,6 +2028,7 @@
     "adminCertificate": {
       "headline": "Credential Request Overview",
       "search": "Suchen via Name der Firma",
+      "noDocumentAvailable": "Kein Dokument verfügbar",
       "tabs": {
         "all": "Alle",
         "pending": "Ausstehend",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2028,6 +2028,7 @@
     "adminCertificate": {
       "headline": "Credential Request Overview",
       "search": "...search for Company Name",
+      "noDocumentAvailable": "No Document available",
       "tabs": {
         "all": "All",
         "pending": "Pending",

--- a/src/components/pages/AdminCredential/AdminCredentialElements.tsx
+++ b/src/components/pages/AdminCredential/AdminCredentialElements.tsx
@@ -280,13 +280,13 @@ export default function AdminCredentialElements() {
           {row.documents?.map((document) => (
             <div
               className={
-                !document.documentId ? 'document-disabled' : 'documenticon-main'
+                document.documentId ? 'documenticon-main' : 'document-disabled'
               }
               key={document.documentId || document.documentName}
               title={
-                !document.documentId
-                  ? t('content.adminCertificate.noDocumentAvailable')
-                  : ''
+                document.documentId
+                  ? ''
+                  : t('content.adminCertificate.noDocumentAvailable')
               }
             >
               <ArticleOutlinedIcon

--- a/src/components/pages/AdminCredential/AdminCredentialElements.tsx
+++ b/src/components/pages/AdminCredential/AdminCredentialElements.tsx
@@ -275,10 +275,20 @@ export default function AdminCredentialElements() {
       field: 'document',
       headerName: t('content.adminCertificate.table.document'),
       flex: 2,
-      renderCell: ({ row }: { row: CredentialData }) =>
-        row.documents?.map((document) => {
-          return (
-            <div className="documenticon-main" key={document.documentId}>
+      renderCell: ({ row }: { row: CredentialData }) => {
+        ;<>
+          {row.documents?.map((document) => (
+            <div
+              className={
+                !document.documentId ? 'document-disabled' : 'documenticon-main'
+              }
+              key={document.documentId || document.documentName}
+              title={
+                !document.documentId
+                  ? t('content.adminCertificate.noDocumentAvailable')
+                  : ''
+              }
+            >
               <ArticleOutlinedIcon
                 className={`${
                   document.documentId ? 'document-icon' : 'document-disabled'
@@ -292,8 +302,9 @@ export default function AdminCredentialElements() {
                 }
               />
             </div>
-          )
-        }),
+          ))}
+        </>
+      },
     },
     {
       field: 'credentialDetailId',

--- a/src/components/pages/AdminCredential/AdminCredentialElements.tsx
+++ b/src/components/pages/AdminCredential/AdminCredentialElements.tsx
@@ -275,8 +275,8 @@ export default function AdminCredentialElements() {
       field: 'document',
       headerName: t('content.adminCertificate.table.document'),
       flex: 2,
-      renderCell: ({ row }: { row: CredentialData }) => {
-        ;<>
+      renderCell: ({ row }: { row: CredentialData }) => (
+        <>
           {row.documents?.map((document) => (
             <div
               className={
@@ -304,7 +304,7 @@ export default function AdminCredentialElements() {
             </div>
           ))}
         </>
-      },
+      ),
     },
     {
       field: 'credentialDetailId',

--- a/src/components/pages/AdminCredential/style.scss
+++ b/src/components/pages/AdminCredential/style.scss
@@ -86,6 +86,7 @@
   .document-disabled {
     color: #999999;
     font-size: 20px;
+    cursor: pointer;
   }
 
   .document-button-link {


### PR DESCRIPTION
## Description

disabled the document download icon for credential request's that doesn't have document attached.

## Why

we have had the check there to disable the download functionality and disabled the button but It needed to be fixed.
Now the button should be displayed as disabled and won't work. more over tool tip has been added for disabled icons.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1447

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
