### PR TITLE
fix(technical integration): enable multiple technical user creation 

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1329,7 +1329,7 @@
         "roleUpdateError": "Error while updating roles",
         "encoding": "Encoding(select supported encoding)",
         "encodingPlaceholder": "Select supported encoding",
-        "noneOption": "Nicht notwendig (für die Integration ist kein technisches benutzerprofile notwendig)",
+        "noneOption": "Nicht notwendig (für die Integration ist kein technisches benutzerprofil notwendig)",
         "table": {
           "addtechUserButton": "Technisches Benutzerprofil hinzufügen",
           "title": "Technisches Benutzerprofil",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1329,22 +1329,22 @@
         "roleUpdateError": "Error while updating roles",
         "encoding": "Encoding(select supported encoding)",
         "encodingPlaceholder": "Select supported encoding",
-        "noneOption": "Nicht notwendig (für die Integration ist kein technischer User notwendig)",
+        "noneOption": "Nicht notwendig (für die Integration ist kein technisches benutzerprofile notwendig)",
         "table": {
           "addtechUserButton": "Technisches Benutzerprofil hinzufügen",
           "title": "Technisches Benutzerprofil",
           "name": "Technisches Benutzerprofil",
           "type": "Type",
           "role": "Role",
-          "noRoles": "Keine technischen Benutzer hinzugefügt"
+          "noRoles": "Keine technischen Benutzerprofile hinzugefügt"
         },
         "form": {
-          "title": "Technischen Benutzer konfigurieren",
-          "intro": "Wählen Sie interne oder externe Rollen aus und fahren Sie mit der Konfiguration des technischen Benutzers fort",
-          "internalUserRoles": "Interner technischer Benutzer",
-          "internalUserRolesDescription": "Interne technische Benutzer werden in der direkten Umgebung des Portals erstellt und können daher mehrere Rollen haben",
-          "externalUserRoles": "Externer technischer Benutzer",
-          "externalUserRolesDescription": "Externe technische Benutzer werden in einer externen Umgebung erstellt und können daher nur eine Rolle haben"
+          "title": "Technisches Benutzerprofil konfigurieren",
+          "intro": "Wählen Sie interne oder externe Rollen aus und fahren Sie mit der Konfiguration des technischen Benutzerprofils fort",
+          "internalUserRoles": "Internes technischer Benutzerprofil",
+          "internalUserRolesDescription": "Interne technische Benutzerprofile werden in der direkten Umgebung des Portals erstellt und können daher mehrere Rollen haben",
+          "externalUserRoles": "Externers technischer Benutzer",
+          "externalUserRolesDescription": "Externe technische Benutzerprofile werden in einer externen Umgebung erstellt und können daher nur eine Rolle haben"
         }
       },
       "betaTest": {

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1335,7 +1335,7 @@
           "title": "Technisches Benutzerprofil",
           "name": "Technisches Benutzerprofil",
           "type": "Type",
-          "role": "Role",
+          "role": "Roles",
           "noRoles": "Keine technischen Benutzerprofile hinzugefügt",
           "action": "Action"
         },

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1329,7 +1329,7 @@
         "roleUpdateError": "Error while updating roles",
         "encoding": "Encoding(select supported encoding)",
         "encodingPlaceholder": "Select supported encoding",
-        "noneOption": "Nicht notwendig (für die Integration ist kein technisches benutzerprofil notwendig)",
+        "noneOption": "Nicht notwendig (für die Integration ist kein technisches Benutzerprofil notwendig)",
         "table": {
           "addtechUserButton": "Technisches Benutzerprofil hinzufügen",
           "title": "Technisches Benutzerprofil",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1331,8 +1331,9 @@
         "encodingPlaceholder": "Select supported encoding",
         "noneOption": "Nicht notwendig (für die Integration ist kein technischer User notwendig)",
         "table": {
-          "addtechUserButton": "Neuen technischen Benutzer hinzufügen",
-          "title": "Technical Users",
+          "addtechUserButton": "Technisches Benutzerprofil hinzufügen",
+          "title": "Technisches Benutzerprofil",
+          "name": "Technisches Benutzerprofil",
           "type": "Type",
           "role": "Role",
           "noRoles": "Keine technischen Benutzer hinzugefügt"

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1336,7 +1336,8 @@
           "name": "Technisches Benutzerprofil",
           "type": "Type",
           "role": "Role",
-          "noRoles": "Keine technischen Benutzerprofile hinzugefügt"
+          "noRoles": "Keine technischen Benutzerprofile hinzugefügt",
+          "action": "Action"
         },
         "form": {
           "title": "Technisches Benutzerprofil konfigurieren",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1342,9 +1342,9 @@
         "form": {
           "title": "Technisches Benutzerprofil konfigurieren",
           "intro": "Wählen Sie interne oder externe Rollen aus und fahren Sie mit der Konfiguration des technischen Benutzerprofils fort",
-          "internalUserRoles": "Internes technischer Benutzerprofil",
+          "internalUserRoles": "Internes technisches Benutzerprofil",
           "internalUserRolesDescription": "Interne technische Benutzerprofile werden in der direkten Umgebung des Portals erstellt und können daher mehrere Rollen haben",
-          "externalUserRoles": "Externers technischer Benutzer",
+          "externalUserRoles": "Externer technischer Benutzer",
           "externalUserRolesDescription": "Externe technische Benutzerprofile werden in einer externen Umgebung erstellt und können daher nur eine Rolle haben"
         }
       },

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1331,8 +1331,9 @@
         "encodingPlaceholder": "Select supported encoding",
         "noneOption": "none (no technical user needed to run the app/service)",
         "table": {
-          "addtechUserButton": "Configure Technical User",
-          "title": "Technical Users",
+          "addtechUserButton": "Add Technical Userprofile",
+          "title": "Technical Userprofile",
+          "name": "Technical user profile",
           "type": "Type",
           "role": "Role",
           "noRoles": "No technical users added"

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1323,28 +1323,28 @@
         "getHelp": "Get Help",
         "deleteOverlayContent": "Deletion will not be reversable, do you still want to delete?",
         "roleUploadIsMandatory": "Role upload is mandatory",
-        "technicalUserSetupMandatory": "Please select at least one technical user setup",
+        "technicalUserSetupMandatory": "Please select at least one technical userprofile setup",
         "roleDeleteSuccessMessage": "Role deleted successfully",
         "technicalUserProfileError": "Error while updating technical user profiles",
         "roleUpdateError": "Error while updating roles",
         "encoding": "Encoding(select supported encoding)",
         "encodingPlaceholder": "Select supported encoding",
-        "noneOption": "none (no technical user needed to run the app/service)",
+        "noneOption": "none (no technical userprofile needed to run the app/service)",
         "table": {
           "addtechUserButton": "Add Technical Userprofile",
           "title": "Technical Userprofile",
           "name": "Technical user profile",
           "type": "Type",
           "role": "Role",
-          "noRoles": "No technical users added"
+          "noRoles": "No technical userprofiles added"
         },
         "form": {
-          "title": "Configure Technical User",
-          "intro": "Select internal or external roles and continue to configure technical user",
-          "internalUserRoles": "Internal technical user",
-          "internalUserRolesDescription": "Internal technical user are created in the direct environment of the portal therefore can have multiple roles",
-          "externalUserRoles": "External technical user",
-          "externalUserRolesDescription": "External technical user are created in external environment therefore can only have one role"
+          "title": "Configure Technical Userprofile",
+          "intro": "Select internal or external roles and continue to configure technical userprofile",
+          "internalUserRoles": "Internal technical userprofile",
+          "internalUserRolesDescription": "Internal technical userprofile are created in the direct environment of the portal therefore can have multiple roles",
+          "externalUserRoles": "External technical userprofile",
+          "externalUserRolesDescription": "External technical userprofile are created in external environment therefore can only have one role"
         }
       },
       "betaTest": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1335,7 +1335,7 @@
           "title": "Technical Userprofile",
           "name": "Technical user profile",
           "type": "Type",
-          "role": "Role",
+          "role": "Roles",
           "noRoles": "No technical userprofiles added",
           "action": "Action"
         },

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1336,7 +1336,8 @@
           "name": "Technical user profile",
           "type": "Type",
           "role": "Role",
-          "noRoles": "No technical userprofiles added"
+          "noRoles": "No technical userprofiles added",
+          "action": "Action"
         },
         "form": {
           "title": "Configure Technical Userprofile",

--- a/src/components/pages/AppOverview/AppOverViewDetails.tsx
+++ b/src/components/pages/AppOverview/AppOverViewDetails.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from 'react-i18next'
 import {
   ConsentStatusEnum,
   useFetchAppRolesDataQuery,
+  useFetchTechnicalUserProfilesQuery,
   useSubmitappMutation,
 } from 'features/appManagement/apiSlice'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -52,6 +53,9 @@ export default function AppOverViewDetails({
   const [cardLanguage, setCardLanguage] = useState<string>('en')
   const { data } = useFetchAppRolesDataQuery(id ?? '')
   const [submitapp] = useSubmitappMutation()
+  const { data: technicalUserProfiles } = useFetchTechnicalUserProfilesQuery(
+    id ?? ''
+  )
 
   const defaultValues = useMemo(() => {
     return {
@@ -209,6 +213,7 @@ export default function AppOverViewDetails({
           stepperDescription={''}
           statusData={item}
           id={id}
+          techUserProfiles={technicalUserProfiles ?? []}
           fetchDocumentById={fetchDocumentById}
           submitData={submitapp}
           validateAndPublishItemText="content.apprelease.validateAndPublish"

--- a/src/components/shared/basic/ReleaseProcess/OfferTechnicalIntegration/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferTechnicalIntegration/index.tsx
@@ -129,9 +129,7 @@ export default function OfferTechnicalIntegration() {
     const body: TechnicalUserProfileBody[] = []
     if (data) {
       data.forEach((techUserInfo) => {
-        const ids: string[] = []
         techUserInfo.userRoles.forEach((roleObj) => {
-          ids.push(roleObj.roleId)
           if (
             selectedTechUser?.technicalUserProfileId ===
             techUserInfo.technicalUserProfileId
@@ -141,6 +139,8 @@ export default function OfferTechnicalIntegration() {
               userRoleIds: roles,
             })
           } else {
+            const ids: string[] = []
+            ids.push(roleObj.roleId)
             body.push({
               technicalUserProfileId: techUserInfo.technicalUserProfileId,
               userRoleIds: ids,
@@ -167,13 +167,12 @@ export default function OfferTechnicalIntegration() {
           techUserInfo.technicalUserProfileId !== row.technicalUserProfileId
       )
       finalyArray.forEach((techUserInfo) => {
-        const userRoleIds: string[] = []
-        techUserInfo.userRoles.forEach((roleObj) => {
-          userRoleIds.push(roleObj.roleId)
-          body.push({
-            technicalUserProfileId: techUserInfo.technicalUserProfileId,
-            userRoleIds,
-          })
+        const userRoleIds: string[] = techUserInfo.userRoles.map(
+          (roleObj) => roleObj.roleId
+        )
+        body.push({
+          technicalUserProfileId: techUserInfo.technicalUserProfileId,
+          userRoleIds,
         })
       })
     }

--- a/src/components/shared/basic/ReleaseProcess/OfferTechnicalIntegration/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferTechnicalIntegration/index.tsx
@@ -120,36 +120,36 @@ export default function OfferTechnicalIntegration() {
   }
 
   const [showAddTechUser, setShowAddTechUser] = useState<boolean>(false)
-  const [createNewTechUserProfile, setCreateNewTechUserProfile] =
+  const [addNewTechUserProfile, setAddNewTechUserProfile] =
     useState<boolean>(false)
   const [selectedTechUser, setSelectedTechUser] =
     useState<TechnicalUserProfiles | null>(null)
 
-  const getBody = (roles: string[]) => {
+  const getBodyParams = (roles: string[]) => {
     const body: TechnicalUserProfileBody[] = []
     if (data) {
-      data.forEach((x) => {
-        const userRoleIds: string[] = []
-        x.userRoles.forEach((y) => {
-          userRoleIds.push(y.roleId)
+      data.forEach((techUserInfo) => {
+        const ids: string[] = []
+        techUserInfo.userRoles.forEach((roleObj) => {
+          ids.push(roleObj.roleId)
           if (
             selectedTechUser?.technicalUserProfileId ===
-            x.technicalUserProfileId
+            techUserInfo.technicalUserProfileId
           ) {
             body.push({
-              technicalUserProfileId: x.technicalUserProfileId,
+              technicalUserProfileId: techUserInfo.technicalUserProfileId,
               userRoleIds: roles,
             })
           } else {
             body.push({
-              technicalUserProfileId: x.technicalUserProfileId,
-              userRoleIds,
+              technicalUserProfileId: techUserInfo.technicalUserProfileId,
+              userRoleIds: ids,
             })
           }
         })
       })
     }
-    if (createNewTechUserProfile) {
+    if (addNewTechUserProfile) {
       body.push({
         technicalUserProfileId: null,
         userRoleIds: roles,
@@ -162,15 +162,16 @@ export default function OfferTechnicalIntegration() {
     const body: TechnicalUserProfileBody[] = []
     setLoading(true)
     if (data) {
-      const trimmedArray = data.filter(
-        (x) => x.technicalUserProfileId !== row.technicalUserProfileId
+      const finalyArray = data.filter(
+        (techUserInfo) =>
+          techUserInfo.technicalUserProfileId !== row.technicalUserProfileId
       )
-      trimmedArray.forEach((x) => {
+      finalyArray.forEach((techUserInfo) => {
         const userRoleIds: string[] = []
-        x.userRoles.forEach((y) => {
-          userRoleIds.push(y.roleId)
+        techUserInfo.userRoles.forEach((roleObj) => {
+          userRoleIds.push(roleObj.roleId)
           body.push({
-            technicalUserProfileId: x.technicalUserProfileId,
+            technicalUserProfileId: techUserInfo.technicalUserProfileId,
             userRoleIds,
           })
         })
@@ -189,7 +190,9 @@ export default function OfferTechnicalIntegration() {
     const updateData = {
       serviceId,
       body:
-        roles && roles[0] === serviceTechnicalUserNone ? [] : getBody(roles),
+        roles && roles[0] === serviceTechnicalUserNone
+          ? []
+          : getBodyParams(roles),
     }
     handleApiCall(updateData)
   }
@@ -206,7 +209,7 @@ export default function OfferTechnicalIntegration() {
         error(t('technicalIntegration.technicalUserProfileError'), '', err)
       })
     setLoading(false)
-    setCreateNewTechUserProfile(false)
+    setAddNewTechUserProfile(false)
     setSelectedTechUser(null)
   }
 
@@ -228,11 +231,11 @@ export default function OfferTechnicalIntegration() {
           <TechUserTable
             userProfiles={data}
             handleAddTechUser={() => {
-              setCreateNewTechUserProfile(true)
+              setAddNewTechUserProfile(true)
               setShowAddTechUser(true)
             }}
             handleEdit={(row: TechnicalUserProfiles) => {
-              setCreateNewTechUserProfile(false)
+              setAddNewTechUserProfile(false)
               setSelectedTechUser(row)
               setShowAddTechUser(true)
             }}
@@ -252,7 +255,7 @@ export default function OfferTechnicalIntegration() {
               setShowAddTechUser(false)
             }}
             handleConfirm={handletechUserProfiles}
-            createNewTechUserProfile={createNewTechUserProfile}
+            createNewTechUserProfile={addNewTechUserProfile}
           />
         )}
 

--- a/src/components/shared/basic/ReleaseProcess/OfferValidateAndPublish/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/OfferValidateAndPublish/index.tsx
@@ -29,6 +29,7 @@ import {
   ServiceTypeIdsEnum,
   useFetchDocumentMutation,
   useFetchServiceStatusQuery,
+  useFetchServiceTechnicalUserProfilesQuery,
   useSubmitServiceMutation,
 } from 'features/serviceManagement/apiSlice'
 
@@ -44,6 +45,9 @@ export default function OfferValidateAndPublish({
   const fetchServiceStatus = useFetchServiceStatusQuery(serviceId, {
     refetchOnMountOrArgChange: true,
   }).data
+
+  const { data: technicalUserProfiles } =
+    useFetchServiceTechnicalUserProfilesQuery(serviceId ?? '')
 
   const defaultValues = useMemo(() => {
     return {
@@ -80,6 +84,7 @@ export default function OfferValidateAndPublish({
           stepperDescription={t('step4.headerDescription')}
           statusData={fetchServiceStatus}
           id={serviceId}
+          techUserProfiles={technicalUserProfiles ?? []}
           fetchDocumentById={fetchDocumentById}
           showSubmitPage={showSubmitPage}
           submitData={submitService}

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -42,6 +42,7 @@ interface AddTechUserFormProps {
   userProfiles: {
     roleId: string
     roleName: string
+    type: string
   }[]
   createNewTechUserProfile: boolean
 }

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -43,6 +43,7 @@ interface AddTechUserFormProps {
     roleId: string
     roleName: string
   }[]
+  createNewTechUserProfile: boolean
 }
 
 enum RoleType {
@@ -55,6 +56,7 @@ export const AddTechUserForm = ({
   handleClose,
   handleConfirm,
   userProfiles,
+  createNewTechUserProfile,
 }: AddTechUserFormProps) => {
   const { t } = useTranslation()
   const roles = useFetchServiceAccountRolesQuery().data
@@ -68,7 +70,7 @@ export const AddTechUserForm = ({
   const [selectedRoleType, setSelectedRoleType] = useState<string>('')
 
   useEffect(() => {
-    if (userProfiles.length > 0) {
+    if (userProfiles.length > 0 && !createNewTechUserProfile) {
       setSelectedUserRoles(() => {
         const roles = []
         for (const obj of userProfiles) {

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -71,7 +71,9 @@ export const AddTechUserForm = ({
   const [selectedRoleType, setSelectedRoleType] = useState<string>('')
 
   useEffect(() => {
-    if (userProfiles.length > 0 && !createNewTechUserProfile) {
+    if (createNewTechUserProfile) {
+      setSelectedUserRoles([])
+    } else if (userProfiles.length > 0) {
       setSelectedUserRoles(() => {
         const roles = []
         for (const obj of userProfiles) {

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -71,9 +71,7 @@ export const AddTechUserForm = ({
   const [selectedRoleType, setSelectedRoleType] = useState<string>('')
 
   useEffect(() => {
-    if (createNewTechUserProfile) {
-      setSelectedUserRoles([])
-    } else if (userProfiles.length > 0) {
+    if (userProfiles.length > 0 && !createNewTechUserProfile) {
       setSelectedUserRoles(() => {
         const roles = []
         for (const obj of userProfiles) {

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
@@ -86,8 +86,8 @@ export const TechUserTable = ({
         },
         {
           field: 'roleName',
-          headerAlign: 'left',
-          align: 'left',
+          headerAlign: 'center',
+          align: 'center',
           headerName: t('content.apprelease.technicalIntegration.table.role'),
           flex: 2,
           valueGetter: ({ row }: { row: TechnicalUserProfiles }) =>
@@ -96,8 +96,8 @@ export const TechUserTable = ({
         {
           field: 'edit',
           headerAlign: 'left',
-          align: 'center',
-          headerName: '',
+          align: 'left',
+          headerName: t('content.apprelease.technicalIntegration.table.action'),
           flex: 1,
           renderCell: ({ row }: { row: TechnicalUserProfiles }) => (
             <Box

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
@@ -27,9 +27,10 @@ import { findIndex } from 'lodash'
 
 interface TechUserTableProps {
   userProfiles: TechnicalUserProfiles[]
-  handleAddTechUser: () => void
-  handleDelete: (row: TechnicalUserProfiles) => void
-  handleEdit: (row: TechnicalUserProfiles) => void
+  handleAddTechUser?: () => void
+  handleDelete?: (row: TechnicalUserProfiles) => void
+  handleEdit?: (row: TechnicalUserProfiles) => void
+  disableActions?: boolean
 }
 
 export const TechUserTable = ({
@@ -37,6 +38,7 @@ export const TechUserTable = ({
   handleAddTechUser,
   handleDelete,
   handleEdit,
+  disableActions = false,
 }: TechUserTableProps) => {
   return (
     <Table
@@ -89,7 +91,7 @@ export const TechUserTable = ({
           headerAlign: 'center',
           align: 'center',
           headerName: t('content.apprelease.technicalIntegration.table.role'),
-          flex: 2,
+          flex: disableActions ? 2.5 : 2,
           valueGetter: ({ row }: { row: TechnicalUserProfiles }) =>
             row.userRoles.map((x) => x.roleName.split('"')).toString(),
         },
@@ -97,45 +99,51 @@ export const TechUserTable = ({
           field: 'edit',
           headerAlign: 'left',
           align: 'left',
-          headerName: t('content.apprelease.technicalIntegration.table.action'),
-          flex: 1,
+          headerName: disableActions
+            ? ''
+            : t('content.apprelease.technicalIntegration.table.action'),
+          flex: disableActions ? 0 : 1,
           renderCell: ({ row }: { row: TechnicalUserProfiles }) => (
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-                justifyContent: 'flex-start',
-                alignItems: 'center',
-                placeItems: 'center',
-              }}
-            >
-              <EditOutlinedIcon
-                sx={{
-                  color: '#adadad',
-                  ':hover': {
-                    color: 'blue',
-                    cursor: 'pointer',
-                  },
-                }}
-                onClick={() => {
-                  handleEdit(row)
-                }}
-              />
+            <>
+              {!disableActions && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'flex-start',
+                    alignItems: 'center',
+                    placeItems: 'center',
+                  }}
+                >
+                  <EditOutlinedIcon
+                    sx={{
+                      color: '#adadad',
+                      ':hover': {
+                        color: 'blue',
+                        cursor: 'pointer',
+                      },
+                    }}
+                    onClick={() => {
+                      handleEdit && handleEdit(row)
+                    }}
+                  />
 
-              <DeleteOutlineIcon
-                sx={{
-                  color: '#adadad',
-                  marginLeft: '10px',
-                  ':hover': {
-                    color: 'blue',
-                    cursor: 'pointer',
-                  },
-                }}
-                onClick={() => {
-                  handleDelete(row)
-                }}
-              />
-            </Box>
+                  <DeleteOutlineIcon
+                    sx={{
+                      color: '#adadad',
+                      marginLeft: '10px',
+                      ':hover': {
+                        color: 'blue',
+                        cursor: 'pointer',
+                      },
+                    }}
+                    onClick={() => {
+                      handleDelete && handleDelete(row)
+                    }}
+                  />
+                </Box>
+              )}
+            </>
           ),
         },
       ]}

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
@@ -19,24 +19,25 @@
 
 import { t } from 'i18next'
 import { Table } from '@catena-x/portal-shared-components'
-import { type technicalUserProfiles } from 'features/appManagement/apiSlice'
+import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import { Box } from '@mui/material'
+import { type TechnicalUserProfiles } from 'features/appManagement/types'
+import { findIndex } from 'lodash'
 
 interface TechUserTableProps {
-  userProfiles: technicalUserProfiles[]
+  userProfiles: TechnicalUserProfiles[]
   handleAddTechUser: () => void
-}
-
-interface UserRoleType {
-  roleId: string
-  roleName: string
-  type: string
+  handleDelete: (row: TechnicalUserProfiles) => void
+  handleEdit: (row: TechnicalUserProfiles) => void
 }
 
 export const TechUserTable = ({
   userProfiles,
   handleAddTechUser,
+  handleDelete,
+  handleEdit,
 }: TechUserTableProps) => {
-  const profiles = userProfiles?.[0]?.userRoles
   return (
     <Table
       hideFooterPagination={true}
@@ -51,18 +52,37 @@ export const TechUserTable = ({
       searchDebounce={1000}
       noRowsMsg={t('content.apprelease.technicalIntegration.table.noRoles')}
       title={t('content.apprelease.technicalIntegration.table.title')}
-      getRowId={(row: { [key: string]: string }) => row.roleId}
-      rows={profiles ?? []}
-      rowsCount={profiles?.length ?? 0}
+      getRowId={(row: { [key: string]: string }) => row.technicalUserProfileId}
+      rows={userProfiles ?? []}
+      rowsCount={userProfiles?.length ?? 0}
       onCellClick={() => {}}
       columns={[
+        {
+          field: 'name',
+          headerAlign: 'left',
+          align: 'left',
+          headerName: t('content.apprelease.technicalIntegration.table.name'),
+          flex: 2,
+          valueGetter: ({ row }: { row: TechnicalUserProfiles }) =>
+            t('content.apprelease.technicalIntegration.table.name') +
+            ' ' +
+            (findIndex(
+              userProfiles,
+              (e) => {
+                return e.technicalUserProfileId == row.technicalUserProfileId
+              },
+              0
+            ) +
+              1),
+        },
         {
           field: 'type',
           headerAlign: 'left',
           align: 'left',
           headerName: t('content.apprelease.technicalIntegration.table.type'),
-          flex: 1.5,
-          valueGetter: ({ row }: { row: UserRoleType }) => row.type,
+          flex: 1,
+          valueGetter: ({ row }: { row: TechnicalUserProfiles }) =>
+            row.userRoles[0]?.type,
         },
         {
           field: 'roleName',
@@ -70,7 +90,53 @@ export const TechUserTable = ({
           align: 'left',
           headerName: t('content.apprelease.technicalIntegration.table.role'),
           flex: 2,
-          valueGetter: ({ row }: { row: UserRoleType }) => row.roleName,
+          valueGetter: ({ row }: { row: TechnicalUserProfiles }) =>
+            row.userRoles.map((x) => x.roleName.split('"')).toString(),
+        },
+        {
+          field: 'edit',
+          headerAlign: 'left',
+          align: 'center',
+          headerName: '',
+          flex: 1,
+          renderCell: ({ row }: { row: TechnicalUserProfiles }) => (
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'flex-start',
+                alignItems: 'center',
+                placeItems: 'center',
+              }}
+            >
+              <EditOutlinedIcon
+                sx={{
+                  color: '#adadad',
+                  ':hover': {
+                    color: 'blue',
+                    cursor: 'pointer',
+                  },
+                }}
+                onClick={() => {
+                  handleEdit(row)
+                }}
+              />
+
+              <DeleteOutlineIcon
+                sx={{
+                  color: '#adadad',
+                  marginLeft: '10px',
+                  ':hover': {
+                    color: 'blue',
+                    cursor: 'pointer',
+                  },
+                }}
+                onClick={() => {
+                  handleDelete(row)
+                }}
+              />
+            </Box>
+          ),
         },
       ]}
       disableColumnMenu

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/index.tsx
@@ -344,24 +344,20 @@ export default function TechnicalIntegration() {
     const body: UpdateTechnicalUserProfileBody[] = []
     if (fetchTechnicalUserProfiles) {
       fetchTechnicalUserProfiles.forEach((x) => {
-        const userRoleIds: string[] = []
-        x.userRoles.forEach((y) => {
-          userRoleIds.push(y.roleId)
-          if (
-            selectedTechUser?.technicalUserProfileId ===
-            x.technicalUserProfileId
-          ) {
-            body.push({
-              technicalUserProfileId: x.technicalUserProfileId,
-              userRoleIds: roles,
-            })
-          } else {
-            body.push({
-              technicalUserProfileId: x.technicalUserProfileId,
-              userRoleIds,
-            })
-          }
-        })
+        if (
+          selectedTechUser?.technicalUserProfileId === x.technicalUserProfileId
+        ) {
+          body.push({
+            technicalUserProfileId: x.technicalUserProfileId,
+            userRoleIds: roles,
+          })
+        } else {
+          const userRoleIds: string[] = x.userRoles.map((y) => y.roleId)
+          body.push({
+            technicalUserProfileId: x.technicalUserProfileId,
+            userRoleIds,
+          })
+        }
       })
     }
     if (createNewTechUserProfile) {
@@ -381,13 +377,10 @@ export default function TechnicalIntegration() {
         (x) => x.technicalUserProfileId !== row.technicalUserProfileId
       )
       trimmedArray.forEach((x) => {
-        const userRoleIds: string[] = []
-        x.userRoles.forEach((y) => {
-          userRoleIds.push(y.roleId)
-          body.push({
-            technicalUserProfileId: x.technicalUserProfileId,
-            userRoleIds,
-          })
+        const userRoleIds: string[] = x.userRoles.map((y) => y.roleId)
+        body.push({
+          technicalUserProfileId: x.technicalUserProfileId,
+          userRoleIds,
         })
       })
     }

--- a/src/components/shared/basic/ReleaseProcess/ValidateAndPublish/index.tsx
+++ b/src/components/shared/basic/ReleaseProcess/ValidateAndPublish/index.tsx
@@ -28,6 +28,7 @@ import {
   useFetchAppStatusQuery,
   useFetchAppRolesDataQuery,
   useSubmitappMutation,
+  useFetchTechnicalUserProfilesQuery,
 } from 'features/appManagement/apiSlice'
 import { setAppStatus } from 'features/appManagement/actions'
 import CommonValidateAndPublish from '../components/CommonValidateAndPublish'
@@ -44,6 +45,9 @@ export default function ValidateAndPublish({
   const [submitapp] = useSubmitappMutation()
   const appId = useSelector(appIdSelector)
   const [fetchDocumentById] = useFetchDocumentByIdMutation()
+  const { data: technicalUserProfiles } = useFetchTechnicalUserProfilesQuery(
+    appId ?? ''
+  )
 
   const fetchAppStatus = useFetchAppStatusQuery(appId ?? '', {
     refetchOnMountOrArgChange: true,
@@ -100,6 +104,7 @@ export default function ValidateAndPublish({
         fetchDocumentById={fetchDocumentById}
         showSubmitPage={showSubmitPage}
         submitData={submitapp}
+        techUserProfiles={technicalUserProfiles ?? []}
         validateAndPublishItemText="content.apprelease.validateAndPublish"
         detailsText={t('content.apprelease.validateAndPublish.appDetails')}
         longDescriptionTitleEN={t(

--- a/src/components/shared/basic/ReleaseProcess/components/CommonValidateAndPublish.tsx
+++ b/src/components/shared/basic/ReleaseProcess/components/CommonValidateAndPublish.tsx
@@ -54,6 +54,7 @@ import { DocumentTypeText } from 'features/apps/types'
 import { download } from 'utils/downloadUtils'
 import {
   AppOverviewTypes,
+  type TechnicalUserProfiles,
   type AppStatusDataState,
   type UseCaseType,
 } from 'features/appManagement/types'
@@ -69,6 +70,7 @@ import { PrivacyPolicyType } from 'features/adminBoard/adminBoardApiSlice'
 import { Apartment, Person, LocationOn, Web, Info } from '@mui/icons-material'
 import '../../../../pages/AppDetail/AppDetailPrivacy/style.scss'
 import 'components/styles/document.scss'
+import { TechUserTable } from '../TechnicalIntegration/TechUserTable'
 
 export interface DefaultValueType {
   images: Array<string>
@@ -111,6 +113,7 @@ interface CommonValidateAndPublishType {
     | AppOverviewTypes.APP_OVERVIEW_DETAILS
   serviceTypes?: string
   rolesData?: updateRolePayload[]
+  techUserProfiles: TechnicalUserProfiles[]
 }
 
 export default function CommonValidateAndPublish({
@@ -138,6 +141,7 @@ export default function CommonValidateAndPublish({
   serviceTypes,
   rolesData,
   helpUrl,
+  techUserProfiles,
 }: CommonValidateAndPublishType) {
   const dispatch = useDispatch()
   const { t } = useTranslation()
@@ -250,28 +254,6 @@ export default function CommonValidateAndPublish({
       default:
         return <Apartment className="policy-icon" />
     }
-  }
-
-  const getTechUserData = (data: string[] | null) => {
-    return data && data?.length > 0 ? (
-      data?.map((role: string) => (
-        <Grid spacing={2} container sx={{ margin: '0px' }} key={role}>
-          <Grid xs={12} className="tech-user-data" item>
-            <Typography variant="body2">* {role}</Typography>
-          </Grid>
-        </Grid>
-      ))
-    ) : (
-      <Grid container spacing={2} margin={'0px'}>
-        <Typography
-          variant="label3"
-          className="not-available"
-          style={{ width: '100%' }}
-        >
-          {t('global.errors.noTechnicalUserProfilesAvailable')}
-        </Typography>
-      </Grid>
-    )
   }
 
   const renderConformityDocuments = () => {
@@ -552,21 +534,21 @@ export default function CommonValidateAndPublish({
           </>
         )}
 
-        {statusData?.technicalUserProfile &&
-          Object.values(statusData?.technicalUserProfile) && (
-            <>
-              <Divider className="verify-validate-form-divider" />
-              <Typography variant="h4">
-                {t('content.adminboardDetail.technicalUserSetup.heading')}
-              </Typography>
-              <Typography variant="body2" className="form-field">
-                {t('content.adminboardDetail.technicalUserSetup.message')}
-              </Typography>
-              {getTechUserData(
-                Object.values(statusData?.technicalUserProfile)[0]
-              )}
-            </>
-          )}
+        {statusData?.technicalUserProfile && techUserProfiles && (
+          <>
+            <Divider className="verify-validate-form-divider" />
+            <Typography variant="h4">
+              {t('content.adminboardDetail.technicalUserSetup.heading')}
+            </Typography>
+            <Typography variant="body2" className="form-field">
+              {t('content.adminboardDetail.technicalUserSetup.message')}
+            </Typography>
+            <TechUserTable
+              userProfiles={techUserProfiles}
+              disableActions={true}
+            />
+          </>
+        )}
 
         <Divider className="verify-validate-form-divider" />
         <Typography variant="h4" sx={{ mb: 4 }}>

--- a/src/features/appManagement/apiSlice.ts
+++ b/src/features/appManagement/apiSlice.ts
@@ -20,7 +20,7 @@
 
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import { apiBaseQuery } from 'utils/rtkUtil'
-import type { AppStatusDataState } from './types'
+import type { AppStatusDataState, TechnicalUserProfiles } from './types'
 import i18next from 'i18next'
 
 export type useCasesItem = {
@@ -167,12 +167,14 @@ export type userRolesType = {
   roleDescription: string | null
 }
 
+export interface UpdateTechnicalUserProfileBody {
+  technicalUserProfileId: string | null
+  userRoleIds: string[]
+}
+
 export type updateTechnicalUserProfiles = {
   appId: string
-  body: {
-    technicalUserProfileId: string | null
-    userRoleIds: string[]
-  }[]
+  body: UpdateTechnicalUserProfileBody[]
 }
 
 export type technicalUserProfiles = {
@@ -346,7 +348,7 @@ export const apiSlice = createApi({
     fetchUserRoles: builder.query<userRolesType[], void>({
       query: () => 'api/administration/serviceaccount/user/roles',
     }),
-    fetchTechnicalUserProfiles: builder.query<technicalUserProfiles[], string>({
+    fetchTechnicalUserProfiles: builder.query<TechnicalUserProfiles[], string>({
       query: (appId) =>
         `/api/apps/appreleaseprocess/${appId}/technical-user-profiles`,
     }),

--- a/src/features/appManagement/types.ts
+++ b/src/features/appManagement/types.ts
@@ -96,6 +96,17 @@ export interface AppManagementState {
   appStatusData: AppStatusDataState
 }
 
+export interface UserRoleType {
+  roleId: string
+  roleName: string
+  type: string
+}
+
+export interface TechnicalUserProfiles {
+  technicalUserProfileId: string
+  userRoles: UserRoleType[]
+}
+
 export const initialState: AppManagementState = {
   searchInput: {
     open: false,

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -157,6 +157,7 @@ export type technicalUserProfile = {
   userRoles: {
     roleId: string
     roleName: string
+    type: string
   }[]
 }
 

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -144,12 +144,14 @@ export type serviceUserRolesType = {
   roleDescription: string | null
 }
 
+export interface TechnicalUserProfileBody {
+  technicalUserProfileId: string | null
+  userRoleIds: string[]
+}
+
 export type updateTechnicalUserProfile = {
   serviceId: string
-  body: {
-    technicalUserProfileId: string | null
-    userRoleIds: string[]
-  }[]
+  body: TechnicalUserProfileBody[]
 }
 
 export type technicalUserProfile = {


### PR DESCRIPTION
## Description

use existing new user interface for creating multiple technical users in technical integration page.
Include edit/update feature.
Also support delete functionality.

### Changelog Entry

```
**Technical Integration**
- enabled multiple tech user creation feature in technical integration step in app and service release process [#1441](https://github.com/eclipse-tractusx/portal-frontend/pull/1441)
```

## Why

NA

## Issue

#1305 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
