### PR TITLE
feat(auto-setup): add fields for auth in auto setup

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1542,7 +1542,7 @@
           "error": "Geben Sie das gültige URL-Format ein"
         },
         "authUrl": {
-          "name": "Autorisierungs-URL",
+          "name": "Auth-URL",
           "hint": "Geben Sie die von Ihrem IdP bereitgestellte URL für das Authentifizierungstoken ein.",
           "error": "Geben Sie das gültige URL-Format ein"
         },

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1524,13 +1524,38 @@
         "message": "The terms of use, as well as the data models and further information can be viewed by clicking on the documents shared below."
       },
       "register": {
-        "heading": "Configuration Autosetup URL",
-        "message": "The company autosetup URL configuration feature allows operators to set up a custom URL that will be used to automatically submit subscription requests to the service provider when app subscriptions are triggered on the marketplace. This feature also enables operators to retrieve technical configuration elements and activate the subscription.",
-        "endpointConfigured": "Configured Provider Endpoint",
-        "autosetupURL": "Set a new endpoint URL",
-        "inputPlaceholder": "...enter your setup url",
-        "providerErrorMessage": "Something went wrong!",
-        "providerSuccessMessage": "Details updated successfully."
+        "heading": "Konfiguration Autosetup URL",
+        "message": "Die Funktion zur Konfiguration der URL für die automatische Einrichtung des Unternehmens ermöglicht es den Betreibern, eine benutzerdefinierte URL einzurichten, die verwendet wird, um automatisch Abonnementanfragen an den Dienstanbieter zu übermitteln, wenn App-Abonnements auf dem Marketplace ausgelöst werden. \n\n Diese URL-Konfigurationsfunktion für die automatische Einrichtung ermöglicht es Betreibern auch, technische Konfigurationselemente abzurufen und das Abonnement zu aktivieren.",
+        "endpointConfigured": "Konfigurierter Anbieter-Endpunkt",
+        "inputPlaceholder": "...Geben Sie Ihre Einrichtungsurl ein",
+        "deleteAutoSetup": "Löschen Sie die bestehende Konfiguration von Auto-Setup",
+        "providerErrorMessage": "Es ist ein Fehler aufgetreten! Bitte versuchen Sie es später noch einmal.",
+        "providerSuccessMessage": "Details erfolgreich aktualisiert.",
+        "autoSetupURL": {
+          "name": "URL automatisch einrichten",
+          "hint": "Geben Sie die für die automatische Einrichtung gültige URL ein, um die Abonnementdetails des Benutzers zu erhalten.",
+          "error": "Geben Sie das gültige URL-Format ein"
+        },
+        "callbackUrl": {
+          "name": "Rückruf-URL für die automatische Einrichtung",
+          "hint": "Geben Sie die gültige Rückruf-URL ein, um die technischen Benutzerdaten zu erhalten.",
+          "error": "Geben Sie das gültige URL-Format ein"
+        },
+        "authUrl": {
+          "name": "Autorisierungs-URL",
+          "hint": "Geben Sie die von Ihrem IdP bereitgestellte URL für das Authentifizierungstoken ein.",
+          "error": "Geben Sie das gültige URL-Format ein"
+        },
+        "clientId": {
+          "name": "Client ID",
+          "hint": "Geben Sie die von Ihrem IdP bereitgestellte Client-ID ein.",
+          "error": "Geben Sie die gültige Client-ID ein"
+        },
+        "clientSecret": {
+          "name": "Client Secret",
+          "hint": "Geben Sie das von Ihrem IdP bereitgestellte Client-Geheimnis ein.",
+          "error": "Geben Sie das gültige Client-Geheimnis ein"
+        }
       },
       "activation": {
         "heading": "Activate App Subscription",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1524,21 +1524,21 @@
         "message": "The terms of use, as well as the data models and further information can be viewed by clicking on the documents shared below."
       },
       "register": {
-        "heading": "Konfiguration Autosetup URL",
-        "message": "Die Funktion zur Konfiguration der URL für die automatische Einrichtung des Unternehmens ermöglicht es den Betreibern, eine benutzerdefinierte URL einzurichten, die verwendet wird, um automatisch Abonnementanfragen an den Dienstanbieter zu übermitteln, wenn App-Abonnements auf dem Marketplace ausgelöst werden. \n\n Diese URL-Konfigurationsfunktion für die automatische Einrichtung ermöglicht es Betreibern auch, technische Konfigurationselemente abzurufen und das Abonnement zu aktivieren.",
+        "heading": "Konfiguration Auto-Setup URL",
+        "message": "Die Auto-Setup URL Konfiguration des Unternehmens ermöglicht es eine benutzerdefinierte URL einzurichten, die verwendet wird, um automatisch Abonnementanfragen an den Dienstanbieter zu übermitteln, wenn App-Abonnements auf dem Marketplace ausgelöst werden. \n\n Diese Auto-Setup URL Konfiguration ermöglicht auch dem Betreiber technische Konfigurationselemente abzurufen und das Abonnement zu aktivieren.",
         "endpointConfigured": "Konfigurierter Anbieter-Endpunkt",
-        "inputPlaceholder": "...Geben Sie Ihre Einrichtungsurl ein",
-        "deleteAutoSetup": "Löschen Sie die bestehende Konfiguration von Auto-Setup",
+        "inputPlaceholder": "...Geben Sie Ihre Auto-Setup URL ein",
+        "deleteAutoSetup": "Löschen Sie die bestehende Auto-Setup Konfiguration",
         "providerErrorMessage": "Es ist ein Fehler aufgetreten! Bitte versuchen Sie es später noch einmal.",
         "providerSuccessMessage": "Details erfolgreich aktualisiert.",
         "autoSetupURL": {
-          "name": "URL automatisch einrichten",
-          "hint": "Geben Sie die für die automatische Einrichtung gültige URL ein, um die Abonnementdetails des Benutzers zu erhalten.",
+          "name": "Auto-Setup URL einrichten",
+          "hint": "Geben Sie gültige Auto-Setup URL ein, um die Abonnementdetails des Benutzers zu erhalten.",
           "error": "Geben Sie das gültige URL-Format ein"
         },
         "callbackUrl": {
-          "name": "Rückruf-URL für die automatische Einrichtung",
-          "hint": "Geben Sie die gültige Rückruf-URL ein, um die technischen Benutzerdaten zu erhalten.",
+          "name": "Callback-URL für das Auto-Setup",
+          "hint": "Geben Sie die gültige Callback-URL ein, um die technischen Benutzerdaten zu erhalten.",
           "error": "Geben Sie das gültige URL-Format ein"
         },
         "authUrl": {
@@ -1553,8 +1553,8 @@
         },
         "clientSecret": {
           "name": "Client Secret",
-          "hint": "Geben Sie das von Ihrem IdP bereitgestellte Client-Geheimnis ein.",
-          "error": "Geben Sie das gültige Client-Geheimnis ein"
+          "hint": "Geben Sie das von Ihrem IdP bereitgestellte Client-Secret ein.",
+          "error": "Geben Sie das gültige Client-Secret ein"
         }
       },
       "activation": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1525,12 +1525,31 @@
       },
       "register": {
         "heading": "Configuration Autosetup URL",
-        "message": "The company autosetup URL configuration feature allows operators to set up a custom URL that will be used to automatically submit subscription requests to the service provider when app subscriptions are triggered on the marketplace. This feature also enables operators to retrieve technical configuration elements and activate the subscription.",
+        "message": "The company autosetup URL configuration feature allows operators to set up a custom URL that will be used to automatically submit subscription requests to the service provider when app subscriptions are triggered on the marketplace. \n\n This auto setup callback URL configuration feature also enables operators to retrieve technical configuration elements and activate the subscription.",
         "endpointConfigured": "Configured Provider Endpoint",
-        "autosetupURL": "Set a new endpoint URL",
         "inputPlaceholder": "...enter your setup url",
         "providerErrorMessage": "Something went wrong! Please try it later again.",
-        "providerSuccessMessage": "Details updated successfully."
+        "providerSuccessMessage": "Details updated successfully.",
+        "autoSetupURL": {
+          "name": "Auto setup URL",
+          "hint": "Enter the Auto setup URL to recieve the subscription details of user"
+        },
+        "callbackUrl": {
+          "name": "Auto setup callback URL",
+          "hint": "Enter the callback URL to recieve technical user details"
+        },
+        "authUrl": {
+          "name": "Auth URL",
+          "hint": "Enter the auth token url provided by your IdP"
+        },
+        "clientId": {
+          "name": "Client ID",
+          "hint": "Enter the client ID provided by your IdP"
+        },
+        "clientSecret": {
+          "name": "Client Secret",
+          "hint": "Enter the client secret provided by your IdP"
+        }
       },
       "activation": {
         "heading": "Activate App Subscription",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1528,27 +1528,33 @@
         "message": "The company autosetup URL configuration feature allows operators to set up a custom URL that will be used to automatically submit subscription requests to the service provider when app subscriptions are triggered on the marketplace. \n\n This auto setup callback URL configuration feature also enables operators to retrieve technical configuration elements and activate the subscription.",
         "endpointConfigured": "Configured Provider Endpoint",
         "inputPlaceholder": "...enter your setup url",
+        "deleteAutoSetup": "Delete the existing configuration of Auto setup",
         "providerErrorMessage": "Something went wrong! Please try it later again.",
         "providerSuccessMessage": "Details updated successfully.",
         "autoSetupURL": {
           "name": "Auto setup URL",
-          "hint": "Enter the Auto setup URL to recieve the subscription details of user"
+          "hint": "Enter the Auto setup valid URL to recieve the subscription details of user",
+          "error": "Enter the valid URL format"
         },
         "callbackUrl": {
           "name": "Auto setup callback URL",
-          "hint": "Enter the callback URL to recieve technical user details"
+          "hint": "Enter the callback valid URL to recieve technical user details",
+          "error": "Enter the valid URL format"
         },
         "authUrl": {
           "name": "Auth URL",
-          "hint": "Enter the auth token url provided by your IdP"
+          "hint": "Enter the auth token valid URL provided by your IdP",
+          "error": "Enter the valid URL format"
         },
         "clientId": {
           "name": "Client ID",
-          "hint": "Enter the client ID provided by your IdP"
+          "hint": "Enter the client ID provided by your IdP",
+          "error": "Enter the valid client ID"
         },
         "clientSecret": {
           "name": "Client Secret",
-          "hint": "Enter the client secret provided by your IdP"
+          "hint": "Enter the client secret provided by your IdP",
+          "error": "Enter the valid client secret"
         }
       },
       "activation": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1524,21 +1524,21 @@
         "message": "The terms of use, as well as the data models and further information can be viewed by clicking on the documents shared below."
       },
       "register": {
-        "heading": "Configuration Autosetup URL",
-        "message": "The company autosetup URL configuration feature allows operators to set up a custom URL that will be used to automatically submit subscription requests to the service provider when app subscriptions are triggered on the marketplace. \n\n This auto setup callback URL configuration feature also enables operators to retrieve technical configuration elements and activate the subscription.",
+        "heading": "Configuration Auto Setup URL",
+        "message": "The company's auto setup URL configuration to set up a custom URL that will be used to automatically submit subscription requests to the service provider when app subscriptions are triggered on the marketplace. \n\n This auto setup callback URL configuration also enables the operator to retrieve technical configuration elements and activate the subscription.",
         "endpointConfigured": "Configured Provider Endpoint",
         "inputPlaceholder": "...enter your setup url",
-        "deleteAutoSetup": "Delete the existing configuration of Auto setup",
+        "deleteAutoSetup": "Delete the existing configuration of auto setup",
         "providerErrorMessage": "Something went wrong! Please try it later again.",
         "providerSuccessMessage": "Details updated successfully.",
         "autoSetupURL": {
           "name": "Auto setup URL",
-          "hint": "Enter the Auto setup valid URL to recieve the subscription details of user",
+          "hint": "Enter the auto setup valid URL to receive the subscription details of user",
           "error": "Enter the valid URL format"
         },
         "callbackUrl": {
           "name": "Auto setup callback URL",
-          "hint": "Enter the callback valid URL to recieve technical user details",
+          "hint": "Enter the auto setup callback valid URL to receive technical user details",
           "error": "Enter the valid URL format"
         },
         "authUrl": {

--- a/src/components/overlays/AddServiceProvider/index.tsx
+++ b/src/components/overlays/AddServiceProvider/index.tsx
@@ -92,6 +92,7 @@ export default function AddServiceProvider() {
       dispatch(setSuccessType(true))
       dispatch(closeOverlay())
     } catch (error) {
+      console.error(error)
       setSaveErrorMessage(true)
     }
   }
@@ -102,6 +103,7 @@ export default function AddServiceProvider() {
       dispatch(setSuccessType(true))
       dispatch(closeOverlay())
     } catch (error) {
+      console.error(error)
       setSaveErrorMessage(true)
     }
   }

--- a/src/components/overlays/AddServiceProvider/index.tsx
+++ b/src/components/overlays/AddServiceProvider/index.tsx
@@ -147,7 +147,7 @@ export default function AddServiceProvider() {
               <ValidatingInput
                 name={'callbackUrl' as keyof ServiceRequest}
                 label={t('content.appSubscription.register.callbackUrl.name')}
-                value={data?.autoSetupCallbackUrl}
+                value={data?.callbackUrl}
                 hint={t('content.appSubscription.register.callbackUrl.hint')}
                 errorMessage={t(
                   'content.appSubscription.register.callbackUrl.error'

--- a/src/components/overlays/AddServiceProvider/index.tsx
+++ b/src/components/overlays/AddServiceProvider/index.tsx
@@ -24,10 +24,8 @@ import {
   DialogActions,
   DialogContent,
   DialogHeader,
-  Input,
   LoadingButton,
   PageSnackbar,
-  Typography,
 } from '@catena-x/portal-shared-components'
 import { closeOverlay } from 'features/control/overlay'
 import { useEffect, useState } from 'react'
@@ -38,17 +36,17 @@ import {
   useAddServiceProviderMutation,
   useFetchServiceProviderQuery,
 } from 'features/serviceProvider/serviceProviderApiSlice'
-import Patterns from 'types/Patterns'
+import { isIDPClientID, isIDPClientSecret, isURL } from 'types/Patterns'
 import { setSuccessType } from 'features/serviceProvider/slice'
-import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined'
+import ValidatingInput from 'components/shared/basic/Input/ValidatingInput'
 
 export default function AddServiceProvider() {
   const { t } = useTranslation()
   const dispatch = useDispatch()
-  const [inputURL, setInputURL] = useState<string | null>(null)
+  const [inputURL] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
-  const [deleteLoading, setDeleteLoading] = useState(false)
-  const [UrlErrorMsg, setUrlErrorMessage] = useState('')
+  //const [deleteLoading, setDeleteLoading] = useState(false)
+  const [UrlErrorMsg] = useState('')
   const [saveErrorMsg, setSaveErrorMessage] = useState(false)
 
   const { data, refetch } = useFetchServiceProviderQuery()
@@ -58,19 +56,19 @@ export default function AddServiceProvider() {
     dispatch(setSuccessType(false))
   }, [refetch, dispatch])
 
-  const addInputURL = (value: string) => {
-    setInputURL(value ?? null)
-    if (!value) return
-    if (!Patterns.URL.test(value.trim())) {
-      setUrlErrorMessage(t('content.appSubscription.pleaseEnterValidURL'))
-    } else {
-      setUrlErrorMessage('')
-    }
-  }
+  // const addInputURL = (value: string) => {
+  //   setInputURL(value ?? null)
+  //   if (!value) return
+  //   if (!Patterns.URL.test(value.trim())) {
+  //     setUrlErrorMessage(t('content.appSubscription.pleaseEnterValidURL'))
+  //   } else {
+  //     setUrlErrorMessage('')
+  //   }
+  // }
 
   const addURL = async () => {
     if (inputURL) setLoading(true)
-    else setDeleteLoading(true)
+    // else setDeleteLoading(true)
     try {
       await addServiceProvider({ url: inputURL }).unwrap()
       dispatch(setSuccessType(true))
@@ -96,55 +94,47 @@ export default function AddServiceProvider() {
         <div className="manageInputURL">
           {data ? (
             <>
-              <div className="urlListMain">
-                <Typography variant="body2">
-                  {t('content.appSubscription.register.endpointConfigured')}
-                </Typography>
-                <div className="urlList">
-                  {data?.url ? (
-                    <>
-                      {deleteLoading ? (
-                        <CircleProgress
-                          colorVariant="primary"
-                          interval={800}
-                          iteration
-                          size={20}
-                          step={100}
-                          thickness={1}
-                          variant="indeterminate"
-                        />
-                      ) : (
-                        <DeleteIcon
-                          onClick={() => {
-                            addURL()
-                          }}
-                          className="deleteIcon"
-                        />
-                      )}
-                      <Typography variant="label2" className="urlDetail">
-                        {data.url}
-                      </Typography>
-                    </>
-                  ) : (
-                    '-'
-                  )}
-                </div>
-              </div>
-              <Input
-                label={
-                  <Typography variant="body2">
-                    {t('content.appSubscription.register.autosetupURL')}
-                  </Typography>
-                }
-                placeholder={t(
-                  'content.appSubscription.register.inputPlaceholder'
-                )}
-                onChange={(e) => {
-                  addInputURL(e.target.value)
-                }}
-                value={inputURL}
+              <ValidatingInput
+                name="autoSetupURL"
+                label={t('content.appSubscription.register.autoSetupURL.name')}
+                value={data?.url}
+                hint={t('content.appSubscription.register.autoSetupURL.hint')}
+                onValid={() => {}}
+                validate={(expr) => isURL(expr)}
               />
-              <p className="error">{UrlErrorMsg}</p>
+              <ValidatingInput
+                name="callbackUrl"
+                label={t('content.appSubscription.register.callbackUrl.name')}
+                value={data?.autoSetupCallbackUrl}
+                hint={t('content.appSubscription.register.callbackUrl.hint')}
+                errorMessage="invalid"
+                validate={(expr) => isURL(expr)}
+                onValid={() => {}}
+              />
+              <ValidatingInput
+                name="authUrl"
+                label={t('content.appSubscription.register.authUrl.name')}
+                value={data?.authUrl}
+                hint={t('content.appSubscription.register.authUrl.hint')}
+                validate={(expr) => isURL(expr)}
+                onValid={() => {}}
+              />
+              <ValidatingInput
+                name="clientId"
+                label={t('content.appSubscription.register.clientId.name')}
+                value={data?.clientId}
+                hint={t('content.appSubscription.register.clientId.hint')}
+                validate={isIDPClientID}
+                onValid={() => {}}
+              />
+              <ValidatingInput
+                name="clientSecret"
+                label={t('content.appSubscription.register.clientSecret.name')}
+                value={data?.clientSecret}
+                hint={t('content.appSubscription.register.clientSecret.hint')}
+                validate={isIDPClientSecret}
+                onValid={() => {}}
+              />
             </>
           ) : (
             <div className="progress">

--- a/src/components/overlays/AddServiceProvider/index.tsx
+++ b/src/components/overlays/AddServiceProvider/index.tsx
@@ -24,7 +24,6 @@ import {
   DialogActions,
   DialogContent,
   DialogHeader,
-  LoadingButton,
   PageSnackbar,
 } from '@catena-x/portal-shared-components'
 import { closeOverlay } from 'features/control/overlay'
@@ -34,49 +33,85 @@ import { useTranslation } from 'react-i18next'
 import './style.scss'
 import {
   useAddServiceProviderMutation,
+  useDeleteServiceProviderMutation,
   useFetchServiceProviderQuery,
 } from 'features/serviceProvider/serviceProviderApiSlice'
+import type { ServiceRequest } from 'features/serviceProvider/serviceProviderApiSlice'
 import { isIDPClientID, isIDPClientSecret, isURL } from 'types/Patterns'
 import { setSuccessType } from 'features/serviceProvider/slice'
 import ValidatingInput from 'components/shared/basic/Input/ValidatingInput'
+import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined'
+import { InputType } from 'components/shared/basic/Input/BasicInput'
 
 export default function AddServiceProvider() {
   const { t } = useTranslation()
   const dispatch = useDispatch()
-  const [inputURL] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
-  //const [deleteLoading, setDeleteLoading] = useState(false)
-  const [UrlErrorMsg] = useState('')
   const [saveErrorMsg, setSaveErrorMessage] = useState(false)
+  const [invalidFields, setInvalidFields] = useState<Set<string>>(new Set())
+  const [callbackData, setCallbackData] = useState<ServiceRequest>({
+    url: '',
+    callbackUrl: undefined,
+    clientId: '',
+    clientSecret: '',
+    authUrl: '',
+  })
 
   const { data, refetch } = useFetchServiceProviderQuery()
   const [addServiceProvider] = useAddServiceProviderMutation()
+  const [deleteServiceProvider] = useDeleteServiceProviderMutation()
   useEffect(() => {
     refetch()
     dispatch(setSuccessType(false))
   }, [refetch, dispatch])
+  useEffect(() => {
+    const newInvalidFields = new Set<string>()
+    const requiredFields: (keyof ServiceRequest)[] = [
+      'authUrl',
+      'url',
+      'clientId',
+      'clientSecret',
+    ]
+    requiredFields.forEach((field) => {
+      if (!(data as Partial<ServiceRequest>)?.[field]) {
+        newInvalidFields.add(field)
+      }
+    })
+    setInvalidFields(newInvalidFields)
+  }, [data])
 
-  // const addInputURL = (value: string) => {
-  //   setInputURL(value ?? null)
-  //   if (!value) return
-  //   if (!Patterns.URL.test(value.trim())) {
-  //     setUrlErrorMessage(t('content.appSubscription.pleaseEnterValidURL'))
-  //   } else {
-  //     setUrlErrorMessage('')
-  //   }
-  // }
-
-  const addURL = async () => {
-    if (inputURL) setLoading(true)
-    // else setDeleteLoading(true)
+  const submitAutoSetup = async () => {
+    if (!callbackData || !invalidFields) return
     try {
-      await addServiceProvider({ url: inputURL }).unwrap()
+      const requestData: ServiceRequest = {
+        ...callbackData,
+        callbackUrl: callbackData.callbackUrl?.trim()
+          ? callbackData.callbackUrl
+          : undefined,
+      }
+      await addServiceProvider(requestData).unwrap()
       dispatch(setSuccessType(true))
       dispatch(closeOverlay())
     } catch (error) {
-      setLoading(false)
       setSaveErrorMessage(true)
     }
+  }
+
+  const deleteAutoSetup = async () => {
+    try {
+      await deleteServiceProvider().unwrap()
+      dispatch(setSuccessType(true))
+      dispatch(closeOverlay())
+    } catch (error) {
+      setSaveErrorMessage(true)
+    }
+  }
+
+  const handleInputChange = (field: string, value: string) => {
+    if (invalidFields?.has(field)) invalidFields.delete(field)
+    setCallbackData((prev) => ({
+      ...prev,
+      [field]: value,
+    }))
   }
 
   return (
@@ -95,45 +130,76 @@ export default function AddServiceProvider() {
           {data ? (
             <>
               <ValidatingInput
-                name="autoSetupURL"
+                name={'url' as keyof ServiceRequest}
                 label={t('content.appSubscription.register.autoSetupURL.name')}
                 value={data?.url}
                 hint={t('content.appSubscription.register.autoSetupURL.hint')}
-                onValid={() => {}}
+                errorMessage={t(
+                  'content.appSubscription.register.autoSetupURL.error'
+                )}
+                onValid={handleInputChange}
+                onInvalid={(name, _) => {
+                  setInvalidFields((prev) => new Set(prev).add(name))
+                }}
                 validate={(expr) => isURL(expr)}
               />
+
               <ValidatingInput
-                name="callbackUrl"
+                name={'callbackUrl' as keyof ServiceRequest}
                 label={t('content.appSubscription.register.callbackUrl.name')}
                 value={data?.autoSetupCallbackUrl}
                 hint={t('content.appSubscription.register.callbackUrl.hint')}
-                errorMessage="invalid"
-                validate={(expr) => isURL(expr)}
-                onValid={() => {}}
+                errorMessage={t(
+                  'content.appSubscription.register.callbackUrl.error'
+                )}
+                validate={(expr) => !expr || isURL(expr)}
+                onValid={handleInputChange}
+                onInvalid={(name, _) => {
+                  setInvalidFields((prev) => new Set(prev).add(name))
+                }}
               />
               <ValidatingInput
-                name="authUrl"
+                name={'authUrl' as keyof ServiceRequest}
                 label={t('content.appSubscription.register.authUrl.name')}
                 value={data?.authUrl}
                 hint={t('content.appSubscription.register.authUrl.hint')}
+                errorMessage={t(
+                  'content.appSubscription.register.authUrl.error'
+                )}
                 validate={(expr) => isURL(expr)}
-                onValid={() => {}}
+                onValid={handleInputChange}
+                onInvalid={(name, _) => {
+                  setInvalidFields((prev) => new Set(prev).add(name))
+                }}
               />
               <ValidatingInput
-                name="clientId"
+                name={'clientId' as keyof ServiceRequest}
                 label={t('content.appSubscription.register.clientId.name')}
                 value={data?.clientId}
                 hint={t('content.appSubscription.register.clientId.hint')}
+                errorMessage={t(
+                  'content.appSubscription.register.clientId.error'
+                )}
                 validate={isIDPClientID}
-                onValid={() => {}}
+                onValid={handleInputChange}
+                onInvalid={(name, _) => {
+                  setInvalidFields((prev) => new Set(prev).add(name))
+                }}
               />
               <ValidatingInput
-                name="clientSecret"
+                name={'clientSecret' as keyof ServiceRequest}
+                type={InputType.password}
                 label={t('content.appSubscription.register.clientSecret.name')}
                 value={data?.clientSecret}
                 hint={t('content.appSubscription.register.clientSecret.hint')}
+                errorMessage={t(
+                  'content.appSubscription.register.clientSecret.error'
+                )}
                 validate={isIDPClientSecret}
-                onValid={() => {}}
+                onValid={handleInputChange}
+                onInvalid={(name, _) => {
+                  setInvalidFields((prev) => new Set(prev).add(name))
+                }}
               />
             </>
           ) : (
@@ -153,34 +219,30 @@ export default function AddServiceProvider() {
       </DialogContent>
 
       <DialogActions>
+        {data?.url && (
+          <Button
+            variant="outlined"
+            title={t('content.appSubscription.register.deleteAutoSetup')}
+            onClick={() => {
+              deleteAutoSetup()
+            }}
+          >
+            <DeleteIcon className="deleteIcon" /> {t('global.actions.delete')}
+          </Button>
+        )}
+
         <Button variant="outlined" onClick={() => dispatch(closeOverlay())}>
           {t('global.actions.cancel')}
         </Button>
-        {loading ? (
-          <LoadingButton
-            color="primary"
-            helperText=""
-            helperTextColor="success"
-            label=""
-            loadIndicator="Loading ..."
-            loading
-            size="medium"
-            onButtonClick={() => {
-              // do nothing
-            }}
-            sx={{ marginLeft: '10px' }}
-          />
-        ) : (
-          <Button
-            variant="contained"
-            onClick={() => {
-              void addURL()
-            }}
-            disabled={UrlErrorMsg !== '' || !inputURL}
-          >
-            {t('global.actions.confirm')}
-          </Button>
-        )}
+        <Button
+          variant="contained"
+          onClick={() => {
+            void submitAutoSetup()
+          }}
+          disabled={invalidFields?.size > 0}
+        >
+          {t('global.actions.confirm')}
+        </Button>
       </DialogActions>
       <PageSnackbar
         open={saveErrorMsg}

--- a/src/components/overlays/AddServiceProvider/style.scss
+++ b/src/components/overlays/AddServiceProvider/style.scss
@@ -27,19 +27,6 @@
   .urlListMain {
     background-color: #dedede;
     padding: 20px;
-    .urlList {
-      display: flex;
-      margin-top: 10px;
-      .deleteIcon {
-        cursor: pointer;
-      }
-      .deleteIcon:hover {
-        color: #0f71cb;
-      }
-      .urlDetail {
-        margin-left: 10px;
-      }
-    }
   }
   .progress {
     display: flex;
@@ -50,6 +37,12 @@
     padding: 0 80px;
     .error {
       color: #e93333;
+    }
+    .deleteIcon {
+      cursor: pointer;
+    }
+    .deleteIcon:hover {
+      color: #0f71cb;
     }
   }
 }

--- a/src/components/shared/basic/Input/ValidatingInput.tsx
+++ b/src/components/shared/basic/Input/ValidatingInput.tsx
@@ -100,7 +100,9 @@ const ValidatingInput = ({
         toggleHide,
         errorMessage,
       }}
-      {...(color === Colors.error ? { errorMessage: hint } : {})}
+      {...(color === Colors.error
+        ? { errorMessage: errorMessage ?? hint }
+        : {})}
       style={{
         ...style,
         borderBottom: `2px solid ${color}`,

--- a/src/features/serviceProvider/serviceProviderApiSlice.ts
+++ b/src/features/serviceProvider/serviceProviderApiSlice.ts
@@ -31,7 +31,7 @@ export type ServiceProviderAPIResponse = {
   id: string
   companyId: string
   url: string
-  autoSetupCallbackUrl: string
+  callbackUrl: string
   authUrl: string
   clientId: string
   clientSecret: string

--- a/src/features/serviceProvider/serviceProviderApiSlice.ts
+++ b/src/features/serviceProvider/serviceProviderApiSlice.ts
@@ -53,7 +53,11 @@ export type SubscriptionServiceRequest = {
 }
 
 export type ServiceRequest = {
-  url: string | null
+  url: string
+  callbackUrl: string | null | undefined
+  authUrl: string
+  clientId: string
+  clientSecret: string
 }
 
 export const apiSlice = createApi({
@@ -70,8 +74,17 @@ export const apiSlice = createApi({
         body: data,
       }),
     }),
+    deleteServiceProvider: builder.mutation<void, void>({
+      query: () => ({
+        url: '/api/administration/subscriptionconfiguration/owncompany',
+        method: 'DELETE',
+      }),
+    }),
   }),
 })
 
-export const { useFetchServiceProviderQuery, useAddServiceProviderMutation } =
-  apiSlice
+export const {
+  useFetchServiceProviderQuery,
+  useAddServiceProviderMutation,
+  useDeleteServiceProviderMutation,
+} = apiSlice

--- a/src/features/serviceProvider/serviceProviderApiSlice.ts
+++ b/src/features/serviceProvider/serviceProviderApiSlice.ts
@@ -31,6 +31,10 @@ export type ServiceProviderAPIResponse = {
   id: string
   companyId: string
   url: string
+  autoSetupCallbackUrl: string
+  authUrl: string
+  clientId: string
+  clientSecret: string
 }
 
 export type AgreementRequest = {


### PR DESCRIPTION
## Description

Added auth fields in Auto setup 

Changelog entry:

```
- **app subscription management**:
  - Added fields for auth in auto setup. [#1457](https://github.com/eclipse-tractusx/portal-frontend/pull/1457)
```

## Why

All customer have to share same authentication details for auto setup from central idp.
Now Company can save their own authentication details for auto setup url

## Issue

[#1151](https://github.com/eclipse-tractusx/portal-backend/issues/1151)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

NOTE: Please only merge it after this PR is merged [PR-1232](https://github.com/eclipse-tractusx/portal-backend/pull/1232)
