### PR TITLE
fix(connector management): fix url alignment

### DIFF
--- a/src/components/pages/EdcConnector/EdcConnectorTableColumns.tsx
+++ b/src/components/pages/EdcConnector/EdcConnectorTableColumns.tsx
@@ -112,7 +112,7 @@ export const ConnectorTableColumns = (
       flex: 1,
       sortable: false,
       disableColumnMenu: true,
-      align: 'center',
+      align: 'left',
       headerAlign: 'center',
     },
     {


### PR DESCRIPTION
## Description

Fixed connector URL alignment in connector management page.

## Changelog Entry

**Connector Management**
- Fixed connector URL alignment in connector management page. [#1461](https://github.com/eclipse-tractusx/portal-frontend/pull/1461)

## Why

Connector URL not aligned properly in connector management page.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1460

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
