### PR TITLE
fix: enhance user visibility experience

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1337,14 +1337,15 @@
           "type": "Type",
           "role": "Roles",
           "noRoles": "Keine technischen Benutzerprofile hinzugefügt",
-          "action": "Action",
-          "visibility": "Visibility for endcustomer"
+          "action": "Action"
         },
         "form": {
           "title": "Technisches Benutzerprofil konfigurieren",
           "intro": "Wählen Sie interne oder externe Rollen aus und fahren Sie mit der Konfiguration des technischen Benutzerprofils fort",
           "internalUserRoles": "Internes technisches Benutzerprofil",
-          "internalUserRolesDescription": "Interne technische Benutzerprofile werden in der direkten Umgebung des Portals erstellt und können daher mehrere Rollen haben",
+          "internalUserRolesDescription": "Diese Auswahl umfasst alle Rollen, die zu einem technischen Benutzerprofil hinzugefügt werden können. Die technischen Benutzer, die aus diesem Profil erstellt werden, sind sowohl für den Kunden als auch für den Anbieter sichtbar!",
+          "internalUserRolesOnlyVisible": "Internes technisches Benutzerprofil(Nur für Anbieter sichtbar)",
+          "internalUserRolesDescriptionOnlyVisible": "Diese Auswahl umfasst alle Rollen, die zu einem technischen Benutzerprofil hinzugefügt werden können. Diese Benutzerrollen haben eine eingeschränkte Sichtbarkeit. Die technischen Benutzer, die aus diesem Profil erstellt werden, sind nur für den Anbieter sichtbar!",
           "externalUserRoles": "Externer technischer Benutzer",
           "externalUserRolesDescription": "Externe technische Benutzerprofile werden in einer externen Umgebung erstellt und können daher nur eine Rolle haben",
           "userDetailsNotVisible": "Technische Benutzerdaten sind für die abonnierenden Kunden nicht sichtbar."

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1337,7 +1337,8 @@
           "type": "Type",
           "role": "Roles",
           "noRoles": "Keine technischen Benutzerprofile hinzugefügt",
-          "action": "Action"
+          "action": "Action",
+          "visibility": "Visibility for endcustomer"
         },
         "form": {
           "title": "Technisches Benutzerprofil konfigurieren",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1337,7 +1337,8 @@
           "type": "Type",
           "role": "Roles",
           "noRoles": "No technical userprofiles added",
-          "action": "Action"
+          "action": "Action",
+          "visibility": "Visibility for endcustomer"
         },
         "form": {
           "title": "Configure Technical Userprofile",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1337,14 +1337,15 @@
           "type": "Type",
           "role": "Roles",
           "noRoles": "No technical userprofiles added",
-          "action": "Action",
-          "visibility": "Visibility for endcustomer"
+          "action": "Action"
         },
         "form": {
           "title": "Configure Technical Userprofile",
           "intro": "Select internal or external roles and continue to configure technical userprofile",
           "internalUserRoles": "Internal technical userprofile",
-          "internalUserRolesDescription": "Internal technical userprofile are created in the direct environment of the portal therefore can have multiple roles",
+          "internalUserRolesDescription": "This selection includes all roles that can be added to a technical user profile.The technical users created from this profile will  be visible to the customer and provider!",
+          "internalUserRolesOnlyVisible": "Internal Technical User Profile (Visible Only to Providers)",
+          "internalUserRolesDescriptionOnlyVisible": "Internal technical userprofile are created in the direct environment of the portal therefore can have multiple roles",
           "externalUserRoles": "External technical userprofile",
           "externalUserRolesDescription": "External technical userprofile are created in external environment therefore can only have one role",
           "userDetailsNotVisible": "Technical user details won't be visible to the subscribing customers"

--- a/src/components/shared/basic/ReleaseProcess/ReleaseProcessSteps.scss
+++ b/src/components/shared/basic/ReleaseProcess/ReleaseProcessSteps.scss
@@ -29,7 +29,7 @@
   }
 
   .header-description {
-    max-width: 733px;
+    max-width: 833px;
     margin: 0 auto 70px !important;
   }
 

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -37,6 +37,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import './style.scss'
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+import { groupBy } from 'lodash'
 
 interface AddTechUserFormProps {
   handleClose: () => void
@@ -51,6 +52,7 @@ interface AddTechUserFormProps {
 
 enum RoleType {
   Internal = 'Internal',
+  InternalOnlyVisible = 'InternalOnlyVisible',
   External = 'External',
   NONE = 'NONE',
 }
@@ -66,6 +68,9 @@ export const AddTechUserForm = ({
   const internalUserRoles = roles?.filter(
     (role) => role.roleType === RoleType.Internal
   )
+  const grouped = groupBy(internalUserRoles, 'onlyAccessibleByProvider')
+  const internalUserRolesVisible = grouped.true
+  const internalUserRolesNotVisible = grouped.false
   const externalUserRoles = roles?.filter(
     (role) => role.roleType === RoleType.External
   )
@@ -207,7 +212,10 @@ export const AddTechUserForm = ({
                         name="radio-buttons"
                         value={selectedUserRoles}
                         size="small"
-                        disabled={selectedRoleType === RoleType.Internal}
+                        disabled={
+                          selectedRoleType === RoleType.Internal ||
+                          selectedRoleType === RoleType.InternalOnlyVisible
+                        }
                       />
                       {role.onlyAccessibleByProvider &&
                         renderAccessibleByProvider()}
@@ -217,7 +225,8 @@ export const AddTechUserForm = ({
                       sx={{
                         marginLeft: '30px',
                         color:
-                          selectedRoleType === RoleType.External
+                          selectedRoleType === RoleType.Internal ||
+                          selectedRoleType === RoleType.InternalOnlyVisible
                             ? 'rgba(0, 0, 0, 0.38)'
                             : 'initial',
                       }}
@@ -257,7 +266,81 @@ export const AddTechUserForm = ({
                   marginLeft: '30px',
                 }}
               >
-                {internalUserRoles?.map((role: ServiceAccountRole) => (
+                {internalUserRolesNotVisible?.map(
+                  (role: ServiceAccountRole) => (
+                    <Box key={role.roleId}>
+                      <Box className="roles" sx={boxStyle}>
+                        <Checkbox
+                          key={role.roleId}
+                          label={role.roleName}
+                          checked={
+                            selectedUserRoles.indexOf(role.roleId) !== -1
+                          }
+                          onChange={(e) => {
+                            selectRoles(
+                              role.roleId,
+                              e.target.checked,
+                              'checkbox'
+                            )
+                          }}
+                          size="medium"
+                          value={selectedUserRoles}
+                          disabled={
+                            selectedRoleType === RoleType.External ||
+                            selectedRoleType === RoleType.InternalOnlyVisible
+                          }
+                        />
+                        {role.onlyAccessibleByProvider &&
+                          renderAccessibleByProvider()}
+                      </Box>
+                      <Typography
+                        variant="body3"
+                        sx={{
+                          marginLeft: '30px',
+                          color:
+                            selectedRoleType === RoleType.External ||
+                            selectedRoleType === RoleType.InternalOnlyVisible
+                              ? 'rgba(0, 0, 0, 0.38)'
+                              : 'initial',
+                        }}
+                      >
+                        {role.roleDescription}
+                      </Typography>
+                    </Box>
+                  )
+                )}
+              </Box>
+            )}
+            <Radio
+              label={t(
+                'content.apprelease.technicalIntegration.form.internalUserRolesOnlyVisible'
+              )}
+              checked={selectedRoleType === RoleType.InternalOnlyVisible}
+              onChange={() => {
+                setSelectedRoleType(RoleType.InternalOnlyVisible)
+              }}
+              name="radio-button"
+              value={selectedRoleType}
+              size="medium"
+            />
+            <Typography
+              variant="body3"
+              sx={{
+                marginLeft: '30px',
+                marginBottom: '10px',
+              }}
+            >
+              {t(
+                'content.apprelease.technicalIntegration.form.internalUserRolesDescriptionOnlyVisible'
+              )}
+            </Typography>
+            {selectedRoleType && selectedRoleType !== RoleType.NONE && (
+              <Box
+                sx={{
+                  marginLeft: '30px',
+                }}
+              >
+                {internalUserRolesVisible?.map((role: ServiceAccountRole) => (
                   <Box key={role.roleId}>
                     <Box className="roles" sx={boxStyle}>
                       <Checkbox
@@ -269,17 +352,19 @@ export const AddTechUserForm = ({
                         }}
                         size="medium"
                         value={selectedUserRoles}
-                        disabled={selectedRoleType === RoleType.External}
+                        disabled={
+                          selectedRoleType === RoleType.External ||
+                          selectedRoleType === RoleType.Internal
+                        }
                       />
-                      {role.onlyAccessibleByProvider &&
-                        renderAccessibleByProvider()}
                     </Box>
                     <Typography
                       variant="body3"
                       sx={{
                         marginLeft: '30px',
                         color:
-                          selectedRoleType === RoleType.External
+                          selectedRoleType === RoleType.External ||
+                          selectedRoleType === RoleType.Internal
                             ? 'rgba(0, 0, 0, 0.38)'
                             : 'initial',
                       }}

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
@@ -24,7 +24,7 @@ import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { Box } from '@mui/material'
 import { type TechnicalUserProfiles } from 'features/appManagement/types'
 import { findIndex } from 'lodash'
-import InfoIcon from '@mui/icons-material/Info'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 interface TechUserTableProps {
   userProfiles: TechnicalUserProfiles[]
   handleAddTechUser?: () => void
@@ -103,70 +103,80 @@ export const TechUserTable = ({
             ? ''
             : t('content.apprelease.technicalIntegration.table.action'),
           flex: disableActions ? 0 : 1,
-          renderCell: ({ row }: { row: TechnicalUserProfiles }) => (
-            <>
-              {!disableActions && (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'row',
-                    justifyContent: 'flex-start',
-                    alignItems: 'center',
-                    placeItems: 'center',
-                  }}
-                >
-                  <Tooltips
-                    additionalStyles={{
-                      cursor: 'pointer',
-                      height: '24px',
-                    }}
-                    tooltipPlacement="top-start"
-                    tooltipText={'maja maado ranga'}
-                    children={
-                      <div>
-                        <InfoIcon
-                          sx={{
-                            color: '#adadad',
-                            ':hover': {
-                              color: 'blue',
-                              cursor: 'pointer',
-                            },
-                          }}
-                        />
-                      </div>
-                    }
-                  />
-                  <EditOutlinedIcon
+          renderCell: ({ row }: { row: TechnicalUserProfiles }) => {
+            const flag = row.userRoles.find(
+              (val) => val.accessiblyByProviderOnly
+            )
+            return (
+              <>
+                {!disableActions && (
+                  <Box
                     sx={{
-                      marginLeft: '10px',
-                      color: '#adadad',
-                      ':hover': {
-                        color: 'blue',
-                        cursor: 'pointer',
-                      },
+                      display: 'flex',
+                      flexDirection: 'row',
+                      justifyContent: 'flex-start',
+                      alignItems: 'center',
+                      placeItems: 'center',
                     }}
-                    onClick={() => {
-                      handleEdit && handleEdit(row)
-                    }}
-                  />
+                  >
+                    <EditOutlinedIcon
+                      sx={{
+                        color: '#adadad',
+                        ':hover': {
+                          color: 'blue',
+                          cursor: 'pointer',
+                        },
+                      }}
+                      onClick={() => {
+                        handleEdit && handleEdit(row)
+                      }}
+                    />
 
-                  <DeleteOutlineIcon
-                    sx={{
-                      color: '#adadad',
-                      marginLeft: '10px',
-                      ':hover': {
-                        color: 'blue',
-                        cursor: 'pointer',
-                      },
-                    }}
-                    onClick={() => {
-                      handleDelete && handleDelete(row)
-                    }}
-                  />
-                </Box>
-              )}
-            </>
-          ),
+                    <DeleteOutlineIcon
+                      sx={{
+                        color: '#adadad',
+                        marginLeft: '10px',
+                        ':hover': {
+                          color: 'blue',
+                          cursor: 'pointer',
+                        },
+                      }}
+                      onClick={() => {
+                        handleDelete && handleDelete(row)
+                      }}
+                    />
+
+                    {flag && (
+                      <Tooltips
+                        additionalStyles={{
+                          cursor: 'pointer',
+                        }}
+                        tooltipPlacement="top-start"
+                        tooltipText={t(
+                          'content.apprelease.technicalIntegration.form.userDetailsNotVisible'
+                        )}
+                        children={
+                          <div>
+                            <VisibilityOffIcon
+                              sx={{
+                                marginTop: '5px',
+                                marginLeft: '10px',
+                                color: '#adadad',
+                                ':hover': {
+                                  color: 'blue',
+                                  cursor: 'pointer',
+                                },
+                              }}
+                            />
+                          </div>
+                        }
+                      />
+                    )}
+                  </Box>
+                )}
+              </>
+            )
+          },
         },
       ]}
       disableColumnMenu

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
@@ -18,13 +18,13 @@
  ********************************************************************************/
 
 import { t } from 'i18next'
-import { Table } from '@catena-x/portal-shared-components'
+import { Table, Tooltips } from '@catena-x/portal-shared-components'
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { Box } from '@mui/material'
 import { type TechnicalUserProfiles } from 'features/appManagement/types'
 import { findIndex } from 'lodash'
-
+import InfoIcon from '@mui/icons-material/Info'
 interface TechUserTableProps {
   userProfiles: TechnicalUserProfiles[]
   handleAddTechUser?: () => void
@@ -115,8 +115,30 @@ export const TechUserTable = ({
                     placeItems: 'center',
                   }}
                 >
+                  <Tooltips
+                    additionalStyles={{
+                      cursor: 'pointer',
+                      height: '24px',
+                    }}
+                    tooltipPlacement="top-start"
+                    tooltipText={'maja maado ranga'}
+                    children={
+                      <div>
+                        <InfoIcon
+                          sx={{
+                            color: '#adadad',
+                            ':hover': {
+                              color: 'blue',
+                              cursor: 'pointer',
+                            },
+                          }}
+                        />
+                      </div>
+                    }
+                  />
                   <EditOutlinedIcon
                     sx={{
+                      marginLeft: '10px',
                       color: '#adadad',
                       ':hover': {
                         color: 'blue',

--- a/src/features/appManagement/types.ts
+++ b/src/features/appManagement/types.ts
@@ -101,7 +101,7 @@ export interface UserRoleType {
   roleId: string
   roleName: string
   type: string
-  onlyAccessibleByProvider: boolean
+  accessiblyByProviderOnly: boolean
 }
 
 export interface TechnicalUserProfiles {

--- a/src/features/appManagement/types.ts
+++ b/src/features/appManagement/types.ts
@@ -101,6 +101,7 @@ export interface UserRoleType {
   roleId: string
   roleName: string
   type: string
+  onlyAccessibleByProvider: boolean
 }
 
 export interface TechnicalUserProfiles {

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -160,7 +160,7 @@ export type technicalUserProfile = {
     roleId: string
     roleName: string
     type: string
-    onlyAccessibleByProvider: boolean
+    accessiblyByProviderOnly: boolean
   }[]
 }
 

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -160,6 +160,7 @@ export type technicalUserProfile = {
     roleId: string
     roleName: string
     type: string
+    onlyAccessibleByProvider: boolean
   }[]
 }
 


### PR DESCRIPTION
## Description

enhance tech user table in technical integration page with an eye icon which displays visibility info for the current row.
update add new technical form with grouping logic on internal tech user section.

## Why

add visibility icon to the technical user profile selection

## Issue

[Link to Github issue.](https://github.com/eclipse-tractusx/portal-frontend/issues/1445)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
