### PR TITLE
fix: add visibility icon to internal/external section 

### DIFF
--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -160,9 +160,12 @@ export const AddTechUserForm = ({
           <VisibilityOffIcon
             sx={{
               marginLeft: '-5px !important',
-              fontSize: '16px',
+              fontSize: '22px',
               cursor: 'pointer',
               color: '#adadad',
+              ':hover': {
+                color: '#000',
+              },
             }}
           />
         }
@@ -245,8 +248,6 @@ export const AddTechUserForm = ({
                           selectedRoleType === RoleType.InternalOnlyVisible
                         }
                       />
-                      {role.onlyAccessibleByProvider &&
-                        renderAccessibleByProvider()}
                     </Box>
                     <Typography
                       variant="body3"
@@ -319,8 +320,6 @@ export const AddTechUserForm = ({
                             selectedRoleType === RoleType.InternalOnlyVisible
                           }
                         />
-                        {role.onlyAccessibleByProvider &&
-                          renderAccessibleByProvider()}
                       </Box>
                       <Typography
                         variant="body3"
@@ -340,18 +339,26 @@ export const AddTechUserForm = ({
                 )}
               </Box>
             )}
-            <Radio
-              label={t(
-                'content.apprelease.technicalIntegration.form.internalUserRolesOnlyVisible'
-              )}
-              checked={selectedRoleType === RoleType.InternalOnlyVisible}
-              onChange={() => {
-                setSelectedRoleType(RoleType.InternalOnlyVisible)
+            <Box
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-start',
               }}
-              name="radio-button"
-              value={selectedRoleType}
-              size="medium"
-            />
+            >
+              <Radio
+                label={t(
+                  'content.apprelease.technicalIntegration.form.internalUserRolesOnlyVisible'
+                )}
+                checked={selectedRoleType === RoleType.InternalOnlyVisible}
+                onChange={() => {
+                  setSelectedRoleType(RoleType.InternalOnlyVisible)
+                }}
+                name="radio-button"
+                value={selectedRoleType}
+                size="medium"
+              />
+              {renderAccessibleByProvider()}
+            </Box>
             <Typography
               variant="body3"
               sx={{


### PR DESCRIPTION
## Description

add visibility icon to add tech user profile form in the radio button title.

## Why

new request

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
