### PR TITLE
fix: use prop value if params appId is not defined

### DIFF
--- a/src/components/pages/AppDetail/AppDetailHeader/index.tsx
+++ b/src/components/pages/AppDetail/AppDetailHeader/index.tsx
@@ -163,7 +163,7 @@ export default function AppDetailHeader({
           return (
             subscribeStatus === SubscriptionStatus.INACTIVE &&
             userHasPortalRole(ROLES.SUBSCRIBE_APP_MARKETPLACE) &&
-            dispatch(show(OVERLAYS.APPMARKETPLACE_REQUEST, appId))
+            dispatch(show(OVERLAYS.APPMARKETPLACE_REQUEST, appId ?? item.id))
           )
         }}
       />

--- a/src/components/pages/ServiceMarketplaceDetail/MarketplaceHeader/index.tsx
+++ b/src/components/pages/ServiceMarketplaceDetail/MarketplaceHeader/index.tsx
@@ -66,7 +66,9 @@ export default function MarketplaceHeader({
       color="primary"
       className="subscribe-btn"
       disabled={!userHasPortalRole(ROLES.SUBSCRIBE_SERVICE_MARKETPLACE)}
-      onClick={() => dispatch(show(OVERLAYS.SERVICE_REQUEST, serviceId))}
+      onClick={() =>
+        dispatch(show(OVERLAYS.SERVICE_REQUEST, serviceId ?? item.id))
+      }
     >
       {t('content.appdetail.subscribe')}
     </Button>


### PR DESCRIPTION
## Description

fix unnecessary 400 issue in the app overlay

### Changelog
App Details Overlay
- App agreement data api being called with empty id. If the prop value which is passed to the component is empty, user app info to get the id value.

## Why

400 error is showing up on clicking subscribe button

## Issue

#1483 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally