### PR TITLE
fix: company service error handling

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,21 +31,41 @@ import {
   SharedCssBaseline,
 } from '@catena-x/portal-shared-components'
 import CompanyService from 'services/CompanyService'
+import ErrorBoundary from 'components/pages/ErrorBoundary'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 
 I18nService.init()
 AccessService.init()
 
 UserService.init(() => {
-  CompanyService.init(() => {
-    createRoot(document.getElementById('app')!).render(
-      <StrictMode>
-        <SharedCssBaseline />
-        <Provider store={store}>
-          <SharedThemeProvider>
-            <AuthorizingRouter />
-          </SharedThemeProvider>
-        </Provider>
-      </StrictMode>
-    )
-  })
+  CompanyService.init(
+    () => {
+      createRoot(document.getElementById('app')!).render(
+        <StrictMode>
+          <SharedCssBaseline />
+          <Provider store={store}>
+            <SharedThemeProvider>
+              <AuthorizingRouter />
+            </SharedThemeProvider>
+          </Provider>
+        </StrictMode>
+      )
+    },
+    () => {
+      createRoot(document.getElementById('app')!).render(
+        <StrictMode>
+          <SharedCssBaseline />
+          <Provider store={store}>
+            <SharedThemeProvider>
+              <BrowserRouter>
+                <Routes>
+                  <Route path="*" element={<ErrorBoundary />} />
+                </Routes>
+              </BrowserRouter>
+            </SharedThemeProvider>
+          </Provider>
+        </StrictMode>
+      )
+    }
+  )
 })

--- a/src/services/CompanyService.ts
+++ b/src/services/CompanyService.ts
@@ -38,7 +38,10 @@ let CI: CompanyDetails = {
   companyRole: [],
 }
 
-const init = (onCompanyDetailsCallback: () => void) => {
+const init = (
+  onCompanyDetailsCallback: () => void,
+  onCompanyErrorCallback: () => void
+) => {
   fetch(`${getApiBase()}/api/administration/companydata/ownCompanyDetails`, {
     method: 'GET',
     headers: {
@@ -52,6 +55,7 @@ const init = (onCompanyDetailsCallback: () => void) => {
     })
     .catch((error) => {
       console.log(error)
+      onCompanyErrorCallback()
     })
 }
 


### PR DESCRIPTION
## Description

company service init function to handle error callback 

### Changelog

Registration process
- handle error case in company service init method to avoid blank screen display. display error boundary component instead

## Why

When I try to login to the portal with as a user of a not yet onboarded company (still in registration phase), I'm greeted with a blank page due to not (yet) being allowed to view ownComanyDetails provided via backend api.

## Issue

#1487 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
