### PR TITLE
fix: use newly created tech user table in app/service detail page

### DIFF
--- a/src/components/pages/AppDetail/AppDetailTechUserSetup/index.tsx
+++ b/src/components/pages/AppDetail/AppDetailTechUserSetup/index.tsx
@@ -21,34 +21,17 @@
 import { useTranslation } from 'react-i18next'
 import { Typography } from '@catena-x/portal-shared-components'
 import type { AppDetails } from 'features/apps/types'
-import { Grid } from '@mui/material'
 import '../style.scss'
+import { useFetchTechnicalUserProfilesQuery } from 'features/appManagement/apiSlice'
+import { TechUserTable } from 'components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable'
 
 export default function AppDetailTechUserSetup({
   item,
 }: Readonly<{ item: AppDetails }>) {
   const { t } = useTranslation('')
-
-  const getAppDetailTechUserData = (data: string[] | null) => {
-    return data && data?.length > 0 ? (
-      data?.map((role: string) => (
-        <Grid spacing={2} sx={{ margin: '0px' }} key={role} container>
-          <Grid item sx={{ p: '10px 22px !important' }} xs={12}>
-            <Typography variant="label3">* {role}</Typography>
-          </Grid>
-        </Grid>
-      ))
-    ) : (
-      <Grid margin={'0px'} container spacing={2}>
-        <Typography
-          sx={{ textAlign: 'center', width: '100%' }}
-          variant="label3"
-        >
-          {t('global.errors.noTechnicalUserProfilesAvailable')}
-        </Typography>
-      </Grid>
-    )
-  }
+  const { data: technicalUserProfiles } = useFetchTechnicalUserProfilesQuery(
+    item.id ?? ''
+  )
 
   return (
     <div id="technical-user-setup">
@@ -59,8 +42,11 @@ export default function AppDetailTechUserSetup({
       <Typography variant="body2" sx={{ mb: 3 }}>
         {t('content.appdetail.technicalUserSetup.message')}
       </Typography>
-      {item.technicalUserProfile &&
-        getAppDetailTechUserData(Object.values(item?.technicalUserProfile)[0])}
+
+      <TechUserTable
+        userProfiles={technicalUserProfiles ?? []}
+        disableActions={true}
+      />
     </div>
   )
 }

--- a/src/components/pages/ServiceMarketplaceDetail/MarketplaceTechnicalUserSetup/index.tsx
+++ b/src/components/pages/ServiceMarketplaceDetail/MarketplaceTechnicalUserSetup/index.tsx
@@ -20,8 +20,9 @@
 
 import { useTranslation } from 'react-i18next'
 import { Typography } from '@catena-x/portal-shared-components'
-import { Grid } from '@mui/material'
 import type { ServiceRequest } from 'features/serviceMarketplace/serviceApiSlice'
+import { useFetchServiceTechnicalUserProfilesQuery } from 'features/serviceManagement/apiSlice'
+import { TechUserTable } from 'components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable'
 
 export default function MarketplaceTechnicalUserSetup({
   item,
@@ -29,28 +30,8 @@ export default function MarketplaceTechnicalUserSetup({
   item: ServiceRequest
 }>) {
   const { t } = useTranslation('')
-
-  const getTechUserInfo = (data: string[] | null) => {
-    return data && data?.length > 0 ? (
-      data?.map((item: string) => (
-        <Grid container spacing={2} sx={{ margin: '0px' }} key={item}>
-          <Grid item sx={{ p: '10px 22px !important' }} xs={12}>
-            <Typography variant="label3">* {item}</Typography>
-          </Grid>
-        </Grid>
-      ))
-    ) : (
-      <Grid spacing={2} margin={'0px'} container>
-        <Typography
-          sx={{ textAlign: 'center', width: '100%' }}
-          variant="label3"
-        >
-          {t('global.errors.noTechnicalUserProfilesAvailable')}
-        </Typography>
-      </Grid>
-    )
-  }
-
+  const { data: technicalUserProfiles } =
+    useFetchServiceTechnicalUserProfilesQuery(item.id ?? '')
   return (
     <>
       <Typography variant="h3">
@@ -59,8 +40,10 @@ export default function MarketplaceTechnicalUserSetup({
       <Typography variant="body2" sx={{ mb: 3 }}>
         {t('content.appdetail.technicalUserSetup.message')}
       </Typography>
-      {item.technicalUserProfile &&
-        getTechUserInfo(Object.values(item?.technicalUserProfile)[0])}
+      <TechUserTable
+        userProfiles={technicalUserProfiles ?? []}
+        disableActions={true}
+      />
     </>
   )
 }

--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable.tsx
@@ -89,7 +89,7 @@ export const TechUserTable = ({
         {
           field: 'roleName',
           headerAlign: 'center',
-          align: 'left',
+          align: disableActions ? 'center' : 'left',
           headerName: t('content.apprelease.technicalIntegration.table.role'),
           flex: disableActions ? 2.5 : 2,
           renderCell: ({ row }: { row: TechnicalUserProfiles }) => {


### PR DESCRIPTION
## Description

update tech user info component in app/service details page which is available from market place section

## Why

app/service using old component

## Issue

NA

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
