### PR TITLE
feat: update unsubscribe overlay

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -407,19 +407,18 @@
     },
     "organization": {
       "unsubscribe": {
-        "title": "Geschäftsanwendung/Dienst abbestellen",
-        "descriptionNote": "Bitte beachten Sie: Die Abmeldung ist nicht rückgängig zu machen",
-        "description": "Alle möglicherweise verbundenen Objekte (in der folgenden Tabelle aufgeführt) werden ebenfalls deaktiviert",
+        "title": "App/Service Abonnement beenden",
         "table": {
-          "listOfConnectedObjects": "Liste der verbundenen Objekte:",
-          "app": "Bewerbungs-/Diensttitel:",
+          "listOfConnectedObjects": "App/Service Details:",
+          "app": "App/Service Titel:",
           "status": "Aktueller Status:",
-          "connector": "Verbinder:",
-          "techUser": "Technischer Benutzer:"
+          "connector": "Connector:",
+          "techUser": "Technischer User:"
         },
         "subscribed": "Gezeichnet",
-        "checkBoxLabel": "Ja, ich bin damit einverstanden, mich von dieser Anwendung/diesem Dienst abzumelden.",
-        "checkBoxLabelDescription": "Ich verstehe die Auswirkungen einer Abmeldung und würde den Vorgang dennoch gerne fortsetzen. Ich bin mir meiner zugrunde liegenden vertraglichen Vereinbarungen mit dem Drittanbieter dieser Anwendung/dieses Dienstes bewusst, insbesondere was die Kündigungsfristen betrifft. Durch die Abmeldung werden diese Vereinbarungen nicht außer Kraft gesetzt.",
+        "checkBoxLabel": "Ich bestätige, dass ich den Hinweis gelesen habe und das App/Service Abonnement beenden möchte.",
+        "checkBoxDescriptionAlert": "Hinweis:",
+        "checkBoxLabelDescription": "Dieser Schritt kann nicht rückgängig gemacht werden. Wenn Sie das Abo beenden, gelten weiterhin Ihre Vereinbarungen mit den Drittanbietern, einschließlich Kündigungsfristen.",
         "buttonText": "Abbestellen",
         "unsubscribeSuccess": "Das Abmelden des Abonnements ist erfolgreich",
         "unsubscribeError": "Die Abmeldung konnte nicht durchgeführt werden. Bitte versuchen Sie es erneut oder kommen Sie später noch einmal vorbei.",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -419,7 +419,7 @@
         },
         "subscribed": "Gezeichnet",
         "checkBoxLabel": "Ja, ich bin damit einverstanden, mich von dieser Anwendung/diesem Dienst abzumelden.",
-        "checkBoxLabelDescription": "Ich verstehe die Auswirkungen einer Abmeldung und würde den Vorgang dennoch gerne fortsetzen.",
+        "checkBoxLabelDescription": "Ich verstehe die Auswirkungen einer Abmeldung und würde den Vorgang dennoch gerne fortsetzen. Ich bin mir meiner zugrunde liegenden vertraglichen Vereinbarungen mit dem Drittanbieter dieser Anwendung/dieses Dienstes bewusst, insbesondere was die Kündigungsfristen betrifft. Durch die Abmeldung werden diese Vereinbarungen nicht außer Kraft gesetzt.",
         "buttonText": "Abbestellen",
         "unsubscribeSuccess": "Das Abmelden des Abonnements ist erfolgreich",
         "unsubscribeError": "Die Abmeldung konnte nicht durchgeführt werden. Bitte versuchen Sie es erneut oder kommen Sie später noch einmal vorbei.",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -419,7 +419,7 @@
         },
         "subscribed": "Subscribed",
         "checkBoxLabel": "Yes, I agree to unsubscribe from this application / service.",
-        "checkBoxLabelDescription": "I understand the implications of unsubscribing and would still like to continue the process.",
+        "checkBoxLabelDescription": "I understand the implications of unsubscribing and would still like to continue the process. I am aware of my underlying contractual agreements with the third-party provider of this application / service, such as notice periods in particular. Unsubscribing does not override these agreements.",
         "buttonText": "Unsubscribe",
         "unsubscribeSuccess": "Unsubscribe subscription is successful",
         "unsubscribeError": "Unsubscription could not be executed. Please try again or come back later.",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -408,18 +408,17 @@
     "organization": {
       "unsubscribe": {
         "title": "Unsubscribe Business Application / Service",
-        "descriptionNote": "Please note: the unsubscription is not revertible",
-        "description": "all possibly connected objects (mentioned in below table) will get deactivated as well",
         "table": {
-          "listOfConnectedObjects": "List of connected objects:",
-          "app": "Application / Service title:",
+          "listOfConnectedObjects": "Application / Service Details:",
+          "app": "Application / Service Title:",
           "status": "Current Status:",
           "connector": "Connector:",
           "techUser": "Technical User:"
         },
         "subscribed": "Subscribed",
-        "checkBoxLabel": "Yes, I agree to unsubscribe from this application / service.",
-        "checkBoxLabelDescription": "I understand the implications of unsubscribing and would still like to continue the process. I am aware of my underlying contractual agreements with the third-party provider of this application / service, such as notice periods in particular. Unsubscribing does not override these agreements.",
+        "checkBoxLabel": "I confirm that I have read the notice and still wish to unsubscribe from this application / service.",
+        "checkBoxDescriptionAlert": "Please note:",
+        "checkBoxLabelDescription": "Unsubscribing cannot be undone. When you unsubscribe, your agreements with third-party providers, including notice periods, still apply.",
         "buttonText": "Unsubscribe",
         "unsubscribeSuccess": "Unsubscribe subscription is successful",
         "unsubscribeError": "Unsubscription could not be executed. Please try again or come back later.",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -407,16 +407,16 @@
     },
     "organization": {
       "unsubscribe": {
-        "title": "Unsubscribe Business Application / Service",
+        "title": "Unsubscribe Business Application/Service",
         "table": {
-          "listOfConnectedObjects": "Application / Service Details:",
-          "app": "Application / Service Title:",
+          "listOfConnectedObjects": "Application/Service Details:",
+          "app": "Application/Service Title:",
           "status": "Current Status:",
           "connector": "Connector:",
           "techUser": "Technical User:"
         },
         "subscribed": "Subscribed",
-        "checkBoxLabel": "I confirm that I have read the notice and still wish to unsubscribe from this application / service.",
+        "checkBoxLabel": "I confirm I have read the notice and still wish to unsubscribe from this application/service.",
         "checkBoxDescriptionAlert": "Please note:",
         "checkBoxLabelDescription": "Unsubscribing cannot be undone. When you unsubscribe, your agreements with third-party providers, including notice periods, still apply.",
         "buttonText": "Unsubscribe",

--- a/src/components/pages/Organization/UnSubscribeOverlay.tsx
+++ b/src/components/pages/Organization/UnSubscribeOverlay.tsx
@@ -100,21 +100,17 @@ const UnSubscribeOverlay = ({
         }}
       >
         <div className="unsubscribeOverlay">
-          <DialogHeader
-            title={t('content.organization.unsubscribe.title')}
-            intro={error ? '' : `For ${data?.name}`}
-          />
+          <DialogHeader title={t('content.organization.unsubscribe.title')} />
           <DialogContent>
             <div
               style={{
                 textAlign: 'center',
+                marginTop: '20px',
+                marginBottom: '30px',
               }}
             >
               <Typography variant="body3">
-                {t('content.organization.unsubscribe.descriptionNote')}
-              </Typography>
-              <Typography variant="body3">
-                {t('content.organization.unsubscribe.description')}
+                {error ? '' : `${data?.name}`}
               </Typography>
             </div>
             <Box sx={{ mt: '20px' }}>
@@ -185,6 +181,17 @@ const UnSubscribeOverlay = ({
                           padding: '44px 0 12px 0',
                         }}
                       >
+                        <Typography variant="body2" sx={{ mb: 2 }}>
+                          <span style={{ fontWeight: 'bold' }}>
+                            {t(
+                              'content.organization.unsubscribe.checkBoxDescriptionAlert'
+                            )}
+                          </span>{' '}
+                          {t(
+                            'content.organization.unsubscribe.checkBoxLabelDescription'
+                          )}
+                        </Typography>
+
                         <Checkbox
                           label={t(
                             'content.organization.unsubscribe.checkBoxLabel'
@@ -194,11 +201,6 @@ const UnSubscribeOverlay = ({
                             setCheckBoxSelected(!checkBoxSelected)
                           }}
                         />
-                        <Typography variant="body2" sx={{ ml: 4 }}>
-                          {t(
-                            'content.organization.unsubscribe.checkBoxLabelDescription'
-                          )}
-                        </Typography>
                       </Box>
                     </>
                   )}


### PR DESCRIPTION
## Description

Added legal disclaimer that clicking on unsubscribe does not override T&Cs.
As well as updated copywriting and design as per UX requirements.

Changelog entry:

```
* **Unsubscribe overlay**
  * updated legal disclaimer text as well as copywriting and design as per UX requirements [#1498](https://github.com/eclipse-tractusx/portal-frontend/pull/1498)
```

## Why

Users of portal should be aware of the implications of their unsubscribe action in portal. In particular that an unsubscribe in portal does not override their contractually agreed T&Cs.

## Issue

none

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
