### PR TITLE
fix(idp): fix display name issue

### DIFF
--- a/src/components/overlays/AddIDP/index.tsx
+++ b/src/components/overlays/AddIDP/index.tsx
@@ -277,8 +277,8 @@ export const AddIdp = () => {
           name="displayName"
           pattern={Patterns.idp.displayName}
           trigger={() => dispatch(setName(getValues().displayName))}
-          maxLength={40}
-          minLength={3}
+          maxLength={30}
+          minLength={2}
           label={
             <>
               {t('field.display.name')}
@@ -287,11 +287,11 @@ export const AddIdp = () => {
           }
           rules={{
             required: `${t('field.display.mandatoryMessage')}`,
-            minLength: `${t('field.display.minimum')} 3 ${t(
+            minLength: `${t('field.display.minimum')} 2 ${t(
               'field.display.charactersRequired'
             )}`,
             pattern: `${t('field.display.validCharactersIncludes')}`,
-            maxLength: `${t('field.display.maximum')} 40 ${t(
+            maxLength: `${t('field.display.maximum')} 30 ${t(
               'field.display.charactersRequired'
             )}`,
           }}

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -381,6 +381,19 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
     },
   }
 
+  const getDisplayName = (row: IdentityProvider) => {
+    if (row.displayName) return row.displayName
+    else
+      return (
+        <>
+          <ReportProblemIcon color="error" fontSize="small" />
+          <Typography variant="body2" sx={{ marginLeft: '5px' }}>
+            {ti('field.error')}
+          </Typography>
+        </>
+      )
+  }
+
   return (
     <Table
       rowsCount={isManagementOSP ? idpsManagedData?.length : idpsData?.length}
@@ -403,15 +416,7 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
           field: 'displayName',
           headerName: t('global.field.name'),
           flex: 3,
-          valueGetter: ({ row }) =>
-            row.displayName ?? (
-              <>
-                <ReportProblemIcon color="error" fontSize="small" />
-                <Typography variant="body2" sx={{ marginLeft: '5px' }}>
-                  {ti('field.error')}
-                </Typography>
-              </>
-            ),
+          valueGetter: ({ row }) => getDisplayName(row),
         },
         {
           field: 'alias',

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -403,7 +403,7 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
           field: 'displayName',
           headerName: t('global.field.name'),
           flex: 3,
-          valueGetter: ({ row }: { row: IdentityProvider }) =>
+          valueGetter: ({ row }) =>
             row.displayName ?? (
               <>
                 <ReportProblemIcon color="error" fontSize="small" />

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -402,8 +402,8 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
         {
           field: 'displayName',
           headerName: t('global.field.name'),
-          flex: 2,
-          renderCell: ({ row }: { row: IdentityProvider }) =>
+          flex: 3,
+          valueGetter: ({ row }: { row: IdentityProvider }) =>
             row.displayName ?? (
               <>
                 <ReportProblemIcon color="error" fontSize="small" />


### PR DESCRIPTION
## Description

Full name not displaying on identity provider configuration page.
Also, updated validation for 'Display name' as per api response in IdP configuration.

Changelog entry:

```
- **Identity Provider Configuration**:
  - fixed displaying of full name with tooltip on hover and updated validation for 'Display name' as per API response in IdP configuration. [#1502](https://github.com/eclipse-tractusx/portal-frontend/pull/1502)
```

## Why

Validation does not match with API response

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1397

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally