### PR TITLE
fix: do not show search results for empty search

### DIFF
--- a/src/components/pages/PartnerNetwork/index.tsx
+++ b/src/components/pages/PartnerNetwork/index.tsx
@@ -156,6 +156,7 @@ const PartnerNetwork = () => {
               setBpn('')
               setExpr('')
               setPage(0)
+              return
             }
             if (expr !== '' && !validateSearchText(expr)) return
             setAllItems([])


### PR DESCRIPTION
## Description

do not show any result in the partner network table for empty search string

### Changelog

Partner Network
- do not allow to execute search feature for empty string

## Why

Partner network search allows to search for empty string

## Issue

#1496 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally