### PR TITLE
fix(service overview): fix technical user setup display

### DIFF
--- a/src/components/pages/ServiceReleaseProcess/ServiceOverview/ServiceDetails.tsx
+++ b/src/components/pages/ServiceReleaseProcess/ServiceOverview/ServiceDetails.tsx
@@ -30,6 +30,7 @@ import {
   ServiceTypeIdsEnum,
   useFetchDocumentMutation,
   useFetchServiceStatusQuery,
+  useFetchServiceTechnicalUserProfilesQuery,
 } from 'features/serviceManagement/apiSlice'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -39,6 +40,7 @@ import { useParams } from 'react-router-dom'
 import { download } from 'utils/downloadUtils'
 import { type DocumentData } from 'features/apps/types'
 import { DocumentTypeId } from 'features/appManagement/apiSlice'
+import { TechUserTable } from 'components/shared/basic/ReleaseProcess/TechnicalIntegration/TechUserTable'
 
 export default function ServiceDetails() {
   const { t } = useTranslation('servicerelease')
@@ -48,6 +50,8 @@ export default function ServiceDetails() {
   }).data
   const [fetchDocument] = useFetchDocumentMutation()
   const [leadImg, setLeadImg] = useState<string>('')
+  const { data: technicalUserProfiles } =
+    useFetchServiceTechnicalUserProfilesQuery(serviceId ?? '')
 
   const getServiceTypes = useCallback(() => {
     const newArr: string[] = []
@@ -256,6 +260,21 @@ export default function ServiceDetails() {
                 )}
               </ul>
             </div>
+
+            <Divider className="verify-validate-form-divider" />
+            <div className="margin-h-40">
+              <Typography variant="h4">
+                {t('adminboardDetail.technicalUserSetup.heading')}
+              </Typography>
+              <Typography variant="body2" className="form-field" sx={{ mb: 4 }}>
+                {t('adminboardDetail.technicalUserSetup.message')}
+              </Typography>
+              <TechUserTable
+                userProfiles={technicalUserProfiles ?? []}
+                disableActions={true}
+              />
+            </div>
+
             <Divider className="verify-validate-form-divider" />
             <div className="margin-h-40">
               <Typography variant="h4" sx={{ mb: 4 }}>

--- a/src/components/pages/ServiceReleaseProcess/ServiceReleaseProcessForm/style.scss
+++ b/src/components/pages/ServiceReleaseProcess/ServiceReleaseProcessForm/style.scss
@@ -34,10 +34,9 @@
 }
 
 .textContainer {
-  width: 40%;
-  padding: 30px 30px;
-  margin: auto;
-  margin-top: 30px;
+  width: 100%;
+  max-width: 970px;
+  margin: 30px auto;
 }
 
 .margin-h-40 {


### PR DESCRIPTION
## Description

Fixed service details page to display technical user setup in Service Overview

Changelog entry:

```
- **Service overview**:
  - fixed service details page to display technical user setup in Service Overview. [#1508](https://github.com/eclipse-tractusx/portal-frontend/pull/1508)
```

## Why

Since technical user setup was not displaying in service details page in Service Overview

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1504

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally