### PR TITLE
fix: handle js error on creating new company site/address

### DIFF
--- a/src/components/pages/CompanyData/CompanyAddressList.tsx
+++ b/src/components/pages/CompanyData/CompanyAddressList.tsx
@@ -141,7 +141,7 @@ export const CompanyAddressList = ({
 
   const getStatus = (id: string) =>
     sharingStates?.filter((state) => id === state.externalId)[0]
-      .sharingStateType
+      ?.sharingStateType
 
   const onRowClick = (params: GridCellParams) => {
     const sharingStateInfo = sharingStates


### PR DESCRIPTION
## Description

console error is leading to empty screen on creating new data in company data page. add a check and fix the issue to render updated data in the table

### Chnagelog

```
**Company data**
- add check for sharing state data to resolve empty page issue [#1511](https://github.com/eclipse-tractusx/portal-frontend/pull/1511)
```

## Why

create site/address leads empty page

## Issue

#1497 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally