### PR TITLE
fix(technical integration): fix enable/disable continue button 

### DIFF
--- a/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
+++ b/src/components/shared/basic/ReleaseProcess/TechnicalIntegration/AddTechUserForm.tsx
@@ -440,7 +440,11 @@ export const AddTechUserForm = ({
             {t('global.actions.close')}
           </Button>
           <Button
-            disabled={!selectedRoleType}
+            disabled={
+              !selectedRoleType ||
+              (selectedRoleType !== RoleType.NONE &&
+                selectedUserRoles.length === 0)
+            }
             variant="contained"
             onClick={() => {
               handleConfirm(


### PR DESCRIPTION
## Description

Fixed validation of continue button to enable/disable while adding technical user profile

Changelog entry:

```
- **Technical Integration**:
  - fixed validation of continue button to enable/disable while adding technical user profile. [#1513](https://github.com/eclipse-tractusx/portal-frontend/pull/1513)
 ```
 
## Why

Getting 400 error when clicking continue button without selecting any role for technical user profile.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1501

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally