### PR TITLE
fix: enable revocation of own company credentials

### DIFF
--- a/src/components/pages/CompanyWallet/RuleCard.tsx
+++ b/src/components/pages/CompanyWallet/RuleCard.tsx
@@ -63,7 +63,7 @@ export default function RuleCard({
 
   const canShowRevoke = (item: WalletContent) => {
     return (
-      userHasSsiCredentialRole(ROLES.REVOKE_CREDENTIALS_ISSUER) &&
+      userHasSsiCredentialRole(ROLES.REVOKE_CREDENTIAL) &&
       item.status === CredentialSubjectStatus.ACTIVE &&
       item?.credentialType !== CredentialType.MEMBERSHIP &&
       item.credentialType !== CredentialType.BUSINESS_PARTNER_NUMBER

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -232,6 +232,7 @@ export enum ROLES {
   DELETE_CERTIFICATES = 'delete_certificates',
   MY_ACCOUNT = 'view_own_user_account',
   CREDENTIAL_REQUESTS = 'view_credential_requests',
+  REVOKE_CREDENTIAL = 'revoke_credential',
   REVOKE_CREDENTIALS_ISSUER = 'revoke_credentials_issuer',
   VIEW_REGISTRATION = 'view_registration',
   READ_PARTNER_MEMBER = 'read_partner_member',


### PR DESCRIPTION
## Description

enable revocation of owned company credentials by introducing revoke_credential role.

Changelog entry:

```
- **Company Wallet**
  - enabled - Company, Business and IT - admin roles to revoke own company credentials
```

## Why

owned company credentials could only be revoked by the CX Admin role

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1521

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
