### PR TITLE
fix(company subscriptions): fix filter search

### DIFF
--- a/src/types/Patterns.ts
+++ b/src/types/Patterns.ts
@@ -49,7 +49,7 @@ export const Patterns = {
   COMPANY_NAME:
     /^(?!.*\s$)([\p{L}\u0E00-\u0E7F\d\p{Sc}@%*+_\-/\\,.:;=<>!?&^#'\x22()[\]]\s?){1,160}$/u,
   personName: personNamePattern,
-  name: /^([A-Za-z\u00C0-\u017F-,.'](?!.*[-,.]{2})[A-Za-z\u00C0-\u017F-,.']{0,40} ?)[^ –]{1,40}$/,
+  name: /^([A-Za-z\u00C0-\u017F-,.'](?!.*[-,.]{2})[A-Za-z\u00C0-\u017F-,. ']{0,40} ?)[^ –]{1,40}$/,
   zipcode: /^[A-Z0-9-]{1,8}$/,
   streetNumber: /^[0-9A-Za-z- ]{1,20}$/,
   regionName: /^[0-9A-Za-z- ]{2,20}$/,


### PR DESCRIPTION
## Description

On searching by title, if user enters complete title, it should filter the results properly

Changelog entry:

- **Company Subscriptions**:
  - Fixed company subscriptions filter search. 


## Why

When searched for title with more than one space (Eg: test app lavanya), the filter does not work properly

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1520

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally