### PR TITLE
chore(workflow): update obsolete logic for restricted dependencies

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -51,18 +51,6 @@ jobs:
       - name: Generate Dependencies file
         run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.1.1.jar yarn.lock -project automotive.tractusx -summary DEPENDENCIES || true
 
-      - name: Check if dependencies were changed
-        id: dependencies-changed
-        run: |
-          changed=$(git diff DEPENDENCIES)
-          if [[ -n "$changed" ]]; then
-            echo "dependencies changed"
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "dependencies not changed"
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Check for restricted dependencies
         run: |
           restricted=$(grep ' restricted,' DEPENDENCIES || true)
@@ -70,16 +58,12 @@ jobs:
             echo "The following dependencies are restricted: $restricted"
             exit 1
           fi
-        if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Upload DEPENDENCIES file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           path: DEPENDENCIES
-        if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Signal need to update DEPENDENCIES
         run: |
           echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
-          exit 1
-        if: steps.dependencies-changed.outputs.changed == 'true'

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -59,11 +59,26 @@ jobs:
             exit 1
           fi
 
+      - name: Check if dependencies were changed
+        id: dependencies-changed
+        run: |
+          changed=$(git diff DEPENDENCIES)
+          if [[ -n "$changed" ]]; then
+            echo "dependencies changed"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "dependencies not changed"
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Upload DEPENDENCIES file
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           path: DEPENDENCIES
+        if: steps.dependencies-changed.outputs.changed == 'true'
 
       - name: Signal need to update DEPENDENCIES
         run: |
           echo "Dependencies need to be updated (updated DEPENDENCIES file has been uploaded to workflow run)"
+          exit 1
+        if: steps.dependencies-changed.outputs.changed == 'true'

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -253,7 +253,7 @@ npm/npmjs/-/getos/3.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/getpass/0.1.7, MIT, approved, clearlydefined
 npm/npmjs/-/glob-parent/5.1.2, ISC, approved, clearlydefined
 npm/npmjs/-/glob-parent/6.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/glob/7.2.3, ISC, approved, clearlydefined
+npm/npmjs/-/glob/7.2.3, ISC AND (CC-BY-SA-4.0 AND ISC) AND (ISC AND MIT) AND CC-BY-SA-4.0, approved, #19366
 npm/npmjs/-/global-dirs/3.0.1, MIT, approved, clearlydefined
 npm/npmjs/-/globals/11.12.0, MIT, approved, clearlydefined
 npm/npmjs/-/globals/13.24.0, MIT, approved, #11962
@@ -293,7 +293,7 @@ npm/npmjs/-/ieee754/1.2.1, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/ignore/5.3.2, MIT, approved, #11665
 npm/npmjs/-/immer/10.1.1, MIT, approved, clearlydefined
 npm/npmjs/-/immutable/4.3.7, MIT, approved, #7353
-npm/npmjs/-/import-fresh/3.3.0, MIT, approved, clearlydefined
+npm/npmjs/-/import-fresh/3.3.0, MIT, approved, #19299
 npm/npmjs/-/import-local/3.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/imurmurhash/0.1.4, MIT, approved, clearlydefined
 npm/npmjs/-/indent-string/4.0.0, MIT, approved, clearlydefined
@@ -424,7 +424,7 @@ npm/npmjs/-/locate-path/6.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/lodash.debounce/4.0.8, MIT, approved, clearlydefined
 npm/npmjs/-/lodash.memoize/4.1.2, MIT, approved, clearlydefined
 npm/npmjs/-/lodash.merge/4.6.2, MIT, approved, clearlydefined
-npm/npmjs/-/lodash.once/4.1.1, MIT, approved, clearlydefined
+npm/npmjs/-/lodash.once/4.1.1, CC0-1.0 AND MIT, approved, clearlydefined
 npm/npmjs/-/lodash.uniq/4.5.0, MIT, approved, clearlydefined
 npm/npmjs/-/lodash/4.17.21, CC0-1.0 AND MIT, approved, #2096
 npm/npmjs/-/log-symbols/4.1.0, MIT, approved, clearlydefined
@@ -642,7 +642,7 @@ npm/npmjs/-/tough-cookie/5.0.0, CC-BY-3.0 AND BSD-3-Clause AND MIT, approved, #1
 npm/npmjs/-/tr46/3.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/tree-kill/1.2.2, MIT, approved, clearlydefined
 npm/npmjs/-/ts-api-utils/1.3.0, MIT, approved, clearlydefined
-npm/npmjs/-/ts-jest/29.2.5, MIT, approved, clearlydefined
+npm/npmjs/-/ts-jest/29.2.5, MIT, approved, #19364
 npm/npmjs/-/ts-node/10.9.2, MIT, approved, clearlydefined
 npm/npmjs/-/tsconfck/3.1.3, MIT, approved, #16028
 npm/npmjs/-/tsconfig-paths/3.15.0, MIT, approved, #12111
@@ -652,7 +652,7 @@ npm/npmjs/-/tunnel-agent/0.6.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/tweetnacl/0.14.5, Unlicense, approved, #1035
 npm/npmjs/-/type-check/0.4.0, MIT, approved, clearlydefined
 npm/npmjs/-/type-detect/4.0.8, MIT, approved, clearlydefined
-npm/npmjs/-/type-fest/0.20.2, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
+npm/npmjs/-/type-fest/0.20.2, CC0-1.0 AND MIT, approved, clearlydefined
 npm/npmjs/-/type-fest/0.21.3, MIT OR (CC0-1.0 AND MIT), approved, clearlydefined
 npm/npmjs/-/typed-array-buffer/1.0.2, MIT, approved, #9658
 npm/npmjs/-/typed-array-buffer/1.0.3, MIT, approved, #9658
@@ -699,7 +699,7 @@ npm/npmjs/-/wrap-ansi/6.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/wrap-ansi/7.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/wrappy/1.0.2, ISC, approved, clearlydefined
 npm/npmjs/-/write-file-atomic/4.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/ws/8.18.0, MIT, approved, clearlydefined
+npm/npmjs/-/ws/8.18.0, MIT, approved, #19631
 npm/npmjs/-/xml-name-validator/4.0.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/xmlchars/2.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/y18n/5.0.8, ISC, approved, clearlydefined
@@ -889,7 +889,7 @@ npm/npmjs/@rollup/rollup-win32-arm64-msvc/4.24.0, MIT AND (ISC AND MIT), approve
 npm/npmjs/@rollup/rollup-win32-ia32-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16913
 npm/npmjs/@rollup/rollup-win32-x64-msvc/4.24.0, MIT AND (ISC AND MIT), approved, #16902
 npm/npmjs/@rtsao/scc/1.1.0, MIT, approved, clearlydefined
-npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, clearlydefined
+npm/npmjs/@sinclair/typebox/0.27.8, MIT, approved, #19220
 npm/npmjs/@sinonjs/commons/3.0.1, BSD-3-Clause, approved, #12905
 npm/npmjs/@sinonjs/fake-timers/10.3.0, BSD-3-Clause, approved, #9214
 npm/npmjs/@svgr/babel-plugin-add-jsx-attribute/8.0.0, MIT, approved, clearlydefined
@@ -934,7 +934,7 @@ npm/npmjs/@types/lodash/4.17.14, MIT, approved, #18358
 npm/npmjs/@types/node/20.16.15, MIT, approved, #16051
 npm/npmjs/@types/node/22.7.4, MIT, approved, #16398
 npm/npmjs/@types/papaparse/5.3.15, MIT, approved, #10964
-npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/@types/parse-json/4.0.2, MIT, approved, #19199
 npm/npmjs/@types/prop-types/15.7.13, MIT, approved, #16176
 npm/npmjs/@types/qs/6.9.18, MIT, approved, #14071
 npm/npmjs/@types/react-dom/18.3.1, MIT, approved, #18409


### PR DESCRIPTION
## Description

Update obsolete logic for restricted dependencies

## Why

After the improvement done during of https://github.com/eclipse-tractusx/portal-frontend/issues/1306, it is  noticed that the [check if the dependencies file was changed](https://github.com/eclipse-tractusx/portal-frontend/blob/v2.3.0/.github/workflows/dependencies.yaml#L46) is obsolete. 
The relevant step (Check for restricted dependencies) affected by this constraint should be executed every time the workflow is triggered.


```
- **Dependencies Workflow**:
  - Update obsolete logic for restricted dependencies [#1524](https://github.com/eclipse-tractusx/portal-frontend/pull/1524)
```


## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1518

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
