### PR TITLE
fix(service marketplace): fix filters and translations

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1452,7 +1452,7 @@
       "tabs": {
         "all": "Alle Services",
         "dataspaceService": "Datenraum Services",
-        "consultancyService": "Beratungsservices"
+        "consultancyService": "Beratungs Services"
       },
       "sortOptions": {
         "new": "Newest First",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1452,7 +1452,7 @@
       "tabs": {
         "all": "Alle Services",
         "dataspaceService": "Datenraum Services",
-        "consultancyService": "Beratungs Services"
+        "consultancyService": "Beratungsservices"
       },
       "sortOptions": {
         "new": "Newest First",

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -12,7 +12,7 @@
   "requiredtitle": "Requirement Lorem ipsum",
   "requiredExplaination": "Erläuterung der Anforderung",
   "consultancyService": "Beratungsleistung",
-  "dataspaceService": "Tool/Service",
+  "dataspaceService": "Datenraum Services",
   "loadmore": "Mehr laden",
   "documentDeleteSuccess": "Document deleted successfully",
   "documentDeleteError": "Something went wrong.",

--- a/src/types/Constants.ts
+++ b/src/types/Constants.ts
@@ -254,7 +254,7 @@ export const serviceTypeMapping: Record<string, ServiceTypeIdsEnum> = {
   'Consultancy Services': ServiceTypeIdsEnum.CONSULTANCY_SERVICES,
   // de
   'Datenraum Services': ServiceTypeIdsEnum.DATASPACE_SERVICES,
-  'Beratungs Services': ServiceTypeIdsEnum.CONSULTANCY_SERVICES,
+  Beratungsservices: ServiceTypeIdsEnum.CONSULTANCY_SERVICES,
 }
 
 export enum COMPANY_ROLES {


### PR DESCRIPTION
## Description

Fixed service marketplace filters when the language is set to german.
Also updated german translations.

Changelog entry:

```
- **Service Marketplace**:
  - Fixed filters when the language is set to german and also updated german translation for `Dataspace Services`  [#1531](https://github.com/eclipse-tractusx/portal-frontend/pull/1531)
```

## Why

In the Service Marketplace, the filter for services based on 'Service Type' is not working when the language is set to german (DE). Also, german translations are not updated.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1208

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
