### PR TITLE
fix(company subscription): fix back button returns on wrong tab

### DIFF
--- a/src/components/pages/CompanySubscriptions/CompanySubscriptionDetail.tsx
+++ b/src/components/pages/CompanySubscriptions/CompanySubscriptionDetail.tsx
@@ -95,7 +95,9 @@ export default function CompanySubscriptionDetail() {
             backButtonLabel={t('global.actions.back')}
             backButtonVariant="text"
             onBackButtonClick={() => {
-              navigate(`/${PAGES.COMPANY_SUBSCRIPTIONS}`)
+              navigate(`/${PAGES.COMPANY_SUBSCRIPTIONS}`, {
+                state: { activeTab: items.app ? 0 : 1 },
+              })
             }}
           />
         </Box>

--- a/src/components/pages/CompanySubscriptions/index.tsx
+++ b/src/components/pages/CompanySubscriptions/index.tsx
@@ -46,6 +46,7 @@ import {
   useUnsubscribeServiceMutation,
 } from 'features/serviceSubscription/serviceSubscriptionApiSlice'
 import { Box } from '@mui/material'
+import { useLocation } from 'react-router-dom'
 
 interface FetchHookArgsType {
   statusId: string
@@ -55,6 +56,7 @@ interface FetchHookArgsType {
 export default function CompanySubscriptions() {
   const { t } = useTranslation()
   const dispatch = useDispatch()
+  const location = useLocation()
   const [refresh, setRefresh] = useState(0)
   const [searchExpr, setSearchExpr] = useState<string>('')
   const [fetchHookArgs, setFetchHookArgs] = useState<FetchHookArgsType>()
@@ -73,7 +75,9 @@ export default function CompanySubscriptions() {
   const [unsubscribeAppMutation] = useUnsubscribeAppMutation()
   const [unsubscribeServiceMutation] = useUnsubscribeServiceMutation()
   const [enableErrorMessage, setEnableErrorMessage] = useState<boolean>(false)
-  const [currentActive, setCurrentActive] = useState<number>(0)
+  const [currentActive, setCurrentActive] = useState<number>(
+    location.state?.activeTab ?? 0
+  )
 
   const setView = (e: React.MouseEvent<HTMLInputElement>) => {
     const viewValue = e.currentTarget.value


### PR DESCRIPTION
## Description

Clicking Back button on Service Company Subscription page Returns to App Company Subscription

Changelog entry:

```
- **Company Subscription**:
  - fixed back button on details page returns on wrong tab. [#1532](https://github.com/eclipse-tractusx/portal-frontend/pull/1532)
```

## Why

Clicking Back button on Service Company Subscription page should be in on the same page.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1367

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
