### PR TITLE
fix(notifications): fix notification display

### DIFF
--- a/src/assets/locales/en/notification.json
+++ b/src/assets/locales/en/notification.json
@@ -49,7 +49,7 @@
       "content": "New user roles have been added for the app <strong>{{app}}</strong> which you can now assign.\n\nNew Roles: {{roles}}"
     },
     "TECHNICAL_USER_CREATION": {
-      "title": "{{appName}} subscription created a new technical user",
+      "title": "{{offer}} subscription created a new technical user",
       "content": "This is a default text and will get enhanced later."
     },
     "SERVICE_RELEASE_REQUEST": {

--- a/src/components/pages/NotificationCenter/NotificationItem.tsx
+++ b/src/components/pages/NotificationCenter/NotificationItem.tsx
@@ -92,6 +92,7 @@ const NotificationContent = ({
   const newUrl = item.contentParsed?.newUrl
   const roles = item.contentParsed?.Roles
   const userEmail = item.contentParsed?.UserEmail
+  const serviceName = item.contentParsed?.ServiceName
 
   return (
     <>
@@ -112,6 +113,7 @@ const NotificationContent = ({
             newUrl,
             roles: roles?.join(', '),
             useremail: userEmail,
+            serviceName: serviceName,
           }}
         >
           <NameLink
@@ -228,6 +230,8 @@ const NotificationConfig = ({ item }: { item: CXNotificationContent }) => {
     case NotificationType.SUBSCRIPTION_URL_UPDATE:
       return <NotificationContent item={item} />
     case NotificationType.APP_ROLE_ADDED:
+      return <NotificationContent item={item} />
+    case NotificationType.SERVICE_RELEASE_APPROVAL:
       return <NotificationContent item={item} />
     default:
       return <pre>{JSON.stringify(item, null, 2)}</pre>

--- a/src/features/notification/types.ts
+++ b/src/features/notification/types.ts
@@ -121,6 +121,7 @@ export interface NotificationContent {
   newUrl?: string
   Roles?: string[]
   UserEmail?: string
+  ServiceName?: string
 }
 
 export interface CXNotificationContent {


### PR DESCRIPTION
## Description

Fixed notification to display as text and also fixed technical user creation title.

## Why

As a service provider registering a new service, a notification is received to notify the provider/user of successful activation. This activation notification currently is not in "text form" as the activation of e.g. an app release, but contains seemingly a code object as the response.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1533

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally