### PR TITLE
fix(user management): fix  app roles display

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1126,8 +1126,8 @@
     "addUserRight": {
       "headline": "Assign app roles to your user(s)",
       "noRolesFound": "No user roles found",
-      "selectUsersDescription": "Assign the appropriate application roles to your users to ensure they have the necessary permissions and access levels required for their tasks.",
-      "addRolesDescription": "Assign the appropriate application roles to your users to ensure they have the necessary permissions and access levels required for their tasks.",
+      "selectUsersDescription": "Ordnen Sie Ihren Benutzern die entsprechenden Anwendungsrollen zu, um sicherzustellen, dass sie über die erforderlichen Berechtigungen und Zugriffsrechte für ihre Aufgaben verfügen.",
+      "addRolesDescription": "Ordnen Sie Ihren Benutzern die entsprechenden Anwendungsrollen zu, um sicherzustellen, dass sie über die erforderlichen Berechtigungen und Zugriffsrechte für ihre Aufgaben verfügen.",
       "confirmSelectedUsers": "Confirm selected users",
       "confirmSelectedRoles": "Confirm selected roles",
       "selectRoles": "Select Roles:",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1126,8 +1126,8 @@
     "addUserRight": {
       "headline": "Assign app roles to your user(s)",
       "noRolesFound": "No user roles found",
-      "selectUsersDescription": "[abstract] Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.",
-      "addRolesDescription": "[abstract] Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.",
+      "selectUsersDescription": "Assign the appropriate application roles to your users to ensure they have the necessary permissions and access levels required for their tasks.",
+      "addRolesDescription": "Assign the appropriate application roles to your users to ensure they have the necessary permissions and access levels required for their tasks.",
       "confirmSelectedUsers": "Confirm selected users",
       "confirmSelectedRoles": "Confirm selected roles",
       "selectRoles": "Select Roles:",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1126,8 +1126,8 @@
     "addUserRight": {
       "headline": "Assign app roles to your user(s)",
       "noRolesFound": "No user roles found",
-      "selectUsersDescription": "[abstract] Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.",
-      "addRolesDescription": "[abstract] Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.",
+      "selectUsersDescription": "Assign the appropriate application roles to your users to ensure they have the necessary permissions and access levels required for their tasks.",
+      "addRolesDescription": "Assign the appropriate application roles to your users to ensure they have the necessary permissions and access levels required for their tasks.",
       "confirmSelectedUsers": "Confirm selected users",
       "confirmSelectedRoles": "Confirm selected roles",
       "selectRoles": "Select Roles:",

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -34,6 +34,7 @@ import './style.scss'
 import { setSearchInput } from 'features/appManagement/actions'
 import { appManagementSelector } from 'features/appManagement/slice'
 import { isSearchUserEmail } from 'types/Patterns'
+import { getClientId } from 'services/EnvironmentService'
 
 interface FetchHookArgsType {
   appId?: string
@@ -156,16 +157,35 @@ export const UserList = ({
                   scrollbarWidth: 'none',
                 }}
               >
-                {roles.length
-                  ? roles.map((role: RoleType | string) => (
-                      <StatusTag
-                        key={typeof role === 'string' ? role : role.roleId}
-                        color="label"
-                        label={typeof role === 'string' ? role : role.roleName}
-                        className="statusTag"
-                      />
-                    ))
-                  : ''}
+                {isDetail
+                  ? roles.length
+                    ? roles
+                        .filter(
+                          (role: RoleType | string) =>
+                            typeof role !== 'string' &&
+                            role.clientId === getClientId()
+                        )
+                        .map((role: RoleType) => (
+                          <StatusTag
+                            key={role.roleId}
+                            color="label"
+                            label={role.roleName}
+                            className="statusTag"
+                          />
+                        ))
+                    : ''
+                  : roles.length
+                    ? roles.map((role: RoleType | string) => (
+                        <StatusTag
+                          key={typeof role === 'string' ? role : role.roleId}
+                          color="label"
+                          label={
+                            typeof role === 'string' ? role : role.roleName
+                          }
+                          className="statusTag"
+                        />
+                      ))
+                    : ''}
               </span>
             ),
           },

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -34,7 +34,6 @@ import './style.scss'
 import { setSearchInput } from 'features/appManagement/actions'
 import { appManagementSelector } from 'features/appManagement/slice'
 import { isSearchUserEmail } from 'types/Patterns'
-import { getClientId } from 'services/EnvironmentService'
 
 interface FetchHookArgsType {
   appId?: string
@@ -158,20 +157,14 @@ export const UserList = ({
                 }}
               >
                 {roles.length
-                  ? roles
-                      .filter(
-                        (role: RoleType | string) =>
-                          typeof role !== 'string' &&
-                          role.clientId === getClientId()
-                      )
-                      .map((role: RoleType) => (
-                        <StatusTag
-                          key={role.roleId}
-                          color="label"
-                          label={role.roleName}
-                          className="statusTag"
-                        />
-                      ))
+                  ? roles.map((role: RoleType | string) => (
+                      <StatusTag
+                        key={typeof role === 'string' ? role : role.roleId}
+                        color="label"
+                        label={typeof role === 'string' ? role : role.roleName}
+                        className="statusTag"
+                      />
+                    ))
                   : ''}
               </span>
             ),


### PR DESCRIPTION
## Description

Fixed app roles display in user list table in app user management. Also, updated dummy boilerplate text to accurate description.

Changelog entry:
 
```
- **User management**:
  - fixed app roles display in user list table in app user management. Also, updated dummy boilerplate text to accurate description. [#1546](https://github.com/eclipse-tractusx/portal-frontend/pull/1546)
```

## Why

App roles are not displayed in user list table in app user management.
In menu screen "Assign app roles to your user(s)" a dummy boilerplate text is shown, not an accurate description of what is expected. So, replaced with accurate text/description.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1516

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
