### PR TITLE
feat: empty table messages

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2456,7 +2456,9 @@
     },
     "table": {
       "search": "Enter email to search",
-      "searchName": "Enter name to search"
+      "searchName": "Enter name to search",
+      "emptyDataMsg": "Keine Einträge vorhanden.\nEinträge werden hier angezeigt, sobald sie hinzugefügt werden.",
+      "noSearchResults": "Keine Ergebnisse gefunden.\nBitte versuchen Sie es mit anderen Suchbegriffen."
     },
     "noData": {
       "heading": "No data available",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -2456,7 +2456,9 @@
     },
     "table": {
       "search": "Enter email to search",
-      "searchName": "Enter name to search"
+      "searchName": "Enter name to search",
+      "emptyDataMsg": "No items to display.\nItems will appear here once they are added.",
+      "noSearchResults": "No results found.\nPlease try again with different keywords."
     },
     "noData": {
       "heading": "No data available",

--- a/src/components/overlays/AddAppUserRoles/UserListContent.tsx
+++ b/src/components/overlays/AddAppUserRoles/UserListContent.tsx
@@ -66,7 +66,6 @@ export default function UserListContent() {
       onSelection={(id: GridRowId[]) => {
         dispatch(setSelectedUserToAdd(id))
       }}
-      noRowsMsg={t('content.usermanagement.table.noRowsMsg')}
       title={t('content.usermanagement.table.title')}
       loadLabel={t('global.actions.loadmore')}
       fetchHook={useFetchAppUsersSearchQuery}

--- a/src/components/overlays/AddAppUserRoles/UserListContent.tsx
+++ b/src/components/overlays/AddAppUserRoles/UserListContent.tsx
@@ -93,6 +93,8 @@ export default function UserListContent() {
         },
       ]}
       checkboxSelection
+      emptyDataMsg={t('global.table.emptyDataMsg')}
+      noSearchResultsMsg={t('global.table.noSearchResults')}
     />
   )
 }

--- a/src/components/pages/Admin/RegistrationRequests/RequestList/index.tsx
+++ b/src/components/pages/Admin/RegistrationRequests/RequestList/index.tsx
@@ -154,6 +154,8 @@ export const RequestList = ({
         )}${t('content.admin.registration-requests.introText2')}`}
         defaultFilter={group}
         filterViews={filterView}
+        emptyDataMsg={t('global.table.emptyDataMsg')}
+        noSearchResultsMsg={t('global.table.noSearchResults')}
       />
     </section>
   )

--- a/src/components/pages/AdminCredential/AdminCredentialElements.tsx
+++ b/src/components/pages/AdminCredential/AdminCredentialElements.tsx
@@ -436,6 +436,8 @@ export default function AdminCredentialElements() {
             setSortOption(value)
           }}
           disableColumnSelector={true}
+          emptyDataMsg={t('global.table.emptyDataMsg')}
+          noSearchResultsMsg={t('global.table.noSearchResults')}
         />
       </div>
     </>

--- a/src/components/pages/AppOverview/AddRoles.tsx
+++ b/src/components/pages/AppOverview/AddRoles.tsx
@@ -61,6 +61,7 @@ export default function AddRoles() {
   const navigate = useNavigate()
   const appId = useParams().appId
   const [isLoading, setIsLoading] = useState(false)
+  const [noRowsMsg, setNoRowsMsg] = useState<string>('')
   const { state } = useLocation()
   const items = state
   const app = items?.filter((item: ItemType) => item.id === appId)
@@ -73,6 +74,14 @@ export default function AddRoles() {
     // eslint-disable-next-line
     [`${(<Checkbox disabled={true} />)}`],
   ])
+
+  const appRolesData =
+    data && data.length > 0
+      ? appRoles.map((item, i) => ({
+          establishedRoles: item[0],
+          id: i,
+        }))
+      : []
 
   useEffect(() => {
     refetch()
@@ -91,13 +100,11 @@ export default function AddRoles() {
     )
   }, [data])
 
-  const appRolesData =
-    data && data.length > 0
-      ? appRoles.map((item, i) => ({
-          establishedRoles: item[0],
-          id: i,
-        }))
-      : []
+  useEffect(() => {
+    if (appRolesData && appRolesData.length === 0) {
+      setNoRowsMsg(t('global.table.emptyDataMsg'))
+    }
+  }, [appRolesData])
 
   const columns = [
     {
@@ -194,6 +201,7 @@ export default function AddRoles() {
               rows={appRolesData}
               getRowId={(row) => uniqueId(row.urn)}
               hasBorder={false}
+              noRowsMsg={noRowsMsg}
             />
           </Box>
         </div>

--- a/src/components/pages/CompanyData/CompanyAddressList.tsx
+++ b/src/components/pages/CompanyData/CompanyAddressList.tsx
@@ -18,7 +18,7 @@
  ********************************************************************************/
 
 import { Chip, IconButton, Table } from '@catena-x/portal-shared-components'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { Box } from '@mui/material'
 import { useTranslation } from 'react-i18next'
@@ -60,6 +60,7 @@ export const CompanyAddressList = ({
   handleConfirm: () => void
 }) => {
   const { t } = useTranslation()
+  const [noRowsMsg, setNoRowsMsg] = useState<string>('')
   const [page, setPage] = useState<number>(0)
   const {
     data,
@@ -79,6 +80,8 @@ export const CompanyAddressList = ({
   const [details, setDetails] = useState<boolean>(false)
   const dispatch = useDispatch()
   const refetch = useSelector(companyRefetch)
+
+  const rows = useMemo(() => inputs.concat(outputs), [inputs, outputs])
 
   const getInputItems = async () => {
     const params = sharingStates
@@ -138,6 +141,12 @@ export const CompanyAddressList = ({
       )
     }
   }, [data])
+
+  useEffect(() => {
+    if (rows && rows.length === 0) {
+      setNoRowsMsg(t('global.table.emptyDataMsg'))
+    }
+  }, [rows])
 
   const getStatus = (id: string) =>
     sharingStates?.filter((state) => id === state.externalId)[0]
@@ -212,9 +221,7 @@ export const CompanyAddressList = ({
         columnHeadersBackgroundColor={'#FFFFFF'}
         searchDebounce={1000}
         noRowsMsg={
-          !isFetching && !isOutputLoading && !isInputLoading
-            ? t('content.companyData.table.noRowsMsg')
-            : ''
+          !isFetching && !isOutputLoading && !isInputLoading ? noRowsMsg : ''
         }
         title={t('content.companyData.table.title')}
         getRowId={(row: { [key: string]: string }) => row.createdAt}

--- a/src/components/pages/CompanySubscriptions/index.tsx
+++ b/src/components/pages/CompanySubscriptions/index.tsx
@@ -229,6 +229,8 @@ export default function CompanySubscriptions() {
         onClearSearch={() => {
           setSearchExpr('')
         }}
+        emptyDataMsg={t('global.table.emptyDataMsg')}
+        noSearchResultsMsg={t('global.table.noSearchResults')}
       />
     </div>
   )

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -517,7 +517,6 @@ const EdcConnector = () => {
               fetchHookRefresh={refresh}
               getRowId={(row: { [key: string]: string }) => row.id}
               columns={managedConnectorCols}
-              noRowsMsg={t('content.edcconnector.noConnectorsMessage')}
               onCellClick={(params: GridCellParams) => {
                 onTableCellClick(params)
               }}

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -504,6 +504,8 @@ const EdcConnector = () => {
               onCellClick={(params: GridCellParams) => {
                 onTableCellClick(params)
               }}
+              emptyDataMsg={t('global.table.emptyDataMsg')}
+              noSearchResultsMsg={t('global.table.noSearchResults')}
             />
           </div>
         </TabPanel>
@@ -520,6 +522,8 @@ const EdcConnector = () => {
               onCellClick={(params: GridCellParams) => {
                 onTableCellClick(params)
               }}
+              emptyDataMsg={t('global.table.emptyDataMsg')}
+              noSearchResultsMsg={t('global.table.noSearchResults')}
             />
           </div>
         </TabPanel>

--- a/src/components/pages/IDPManagement/IDPList.tsx
+++ b/src/components/pages/IDPManagement/IDPList.tsx
@@ -88,6 +88,7 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
 
   const [disableLoading, setDisableLoading] = useState(false)
   const [deleteLoading, setDeleteLoading] = useState(false)
+  const [noRowsMsg, setNoRowsMsg] = useState<string>('')
 
   const { data, isFetching } = useFetchIDPListQuery()
   const idpsData = data
@@ -106,6 +107,13 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
   useEffect(() => {
     setIdpsManagedData(managedIdpsData)
   }, [data])
+
+  useEffect(() => {
+    const dataRows = isManagementOSP ? idpsManagedData : idpsData
+    if (dataRows && dataRows.length === 0) {
+      setNoRowsMsg(t('global.table.emptyDataMsg'))
+    }
+  }, [isManagementOSP, idpsData, idpsManagedData])
 
   const doDelete = async (
     e: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -474,6 +482,7 @@ export const IDPList = ({ isManagementOSP }: { isManagementOSP?: boolean }) => {
       rows={(isManagementOSP ? idpsManagedData : idpsData) ?? []}
       getRowId={(row: { [key: string]: string }) => row.identityProviderId}
       hasBorder={false}
+      noRowsMsg={noRowsMsg}
       searchPlaceholder={
         isManagementOSP
           ? t('content.onboardingServiceProvider.search')

--- a/src/components/pages/InviteBusinessPartner/InviteList/index.tsx
+++ b/src/components/pages/InviteBusinessPartner/InviteList/index.tsx
@@ -135,6 +135,8 @@ export const InviteList = ({
             ),
           },
         ]}
+        emptyDataMsg={t('global.table.emptyDataMsg')}
+        noSearchResultsMsg={t('global.table.noSearchResults')}
       />
     </section>
   )

--- a/src/components/pages/OnboardingServiceProvider/OnboardingServiceProvider.tsx
+++ b/src/components/pages/OnboardingServiceProvider/OnboardingServiceProvider.tsx
@@ -404,6 +404,8 @@ const OnboardingServiceProvider = () => {
                   sortable: false,
                 },
               ]}
+              emptyDataMsg={t('global.table.emptyDataMsg')}
+              noSearchResultsMsg={t('global.table.noSearchResults')}
             />
           </div>
         </TabPanel>

--- a/src/components/pages/PartnerNetwork/index.tsx
+++ b/src/components/pages/PartnerNetwork/index.tsx
@@ -47,6 +47,7 @@ const PartnerNetwork = () => {
   const { t } = useTranslation()
   const [expr, setExpr] = useState<string>('')
   const [bpn, setBpn] = useState<string>('')
+  const [noRowsMsg, setNoRowsMsg] = useState<string>('')
   const searchInputData = useSelector(updatePartnerSelector)
   const columns = PartnerNetworksTableColumns(t)
   const [mutationRequest] = useFetchBusinessPartnerAddressMutation()
@@ -88,6 +89,16 @@ const PartnerNetwork = () => {
     setLoading(true)
     if (data && data.length > 0) fetchAllMembers()
   }, [data, fetchArgs])
+
+  useEffect(() => {
+    if (allItems) {
+      if (!(expr || bpn) && allItems.length === 0) {
+        setNoRowsMsg(t('global.table.emptyDataMsg'))
+      } else if ((expr || bpn) && allItems.length === 0) {
+        setNoRowsMsg(t('global.table.noSearchResults'))
+      }
+    }
+  }, [allItems, expr, bpn])
 
   const setCountryAttributes = (payload: PaginResult<BusinessPartner>) => {
     let finalObj = JSON.parse(JSON.stringify(payload?.content))
@@ -171,7 +182,7 @@ const PartnerNetwork = () => {
           loading={loading}
           rows={allItems}
           rowsCount={allItems?.length}
-          noRowsMsg={t('content.companyData.table.noRowsMsg')}
+          noRowsMsg={noRowsMsg}
           nextPage={() => {
             setPage(page + 1)
           }}

--- a/src/components/pages/SemanticHub/ModelTable.tsx
+++ b/src/components/pages/SemanticHub/ModelTable.tsx
@@ -51,6 +51,7 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
   const [selectedFilter, setSelectedFilter] = useState<SelectedFilter>({
     status: [DefaultStatus],
   })
+  const [noRowsMsg, setNoRowsMsg] = useState<string>('')
   const rowCount = 10
   const filter = [
     {
@@ -93,6 +94,16 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
   const [deleteModelById] = useDeleteModelByIdMutation()
 
   const { uploadedModel } = useSelector(semanticModelsSelector)
+
+  useEffect(() => {
+    if (models) {
+      if (!searchValue && models.length === 0) {
+        setNoRowsMsg(t('global.table.emptyDataMsg'))
+      } else if (searchValue && models.length === 0) {
+        setNoRowsMsg(t('global.table.noSearchResults'))
+      }
+    }
+  }, [models, searchValue])
 
   useEffect(() => {
     if (modelList) {
@@ -156,6 +167,7 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
     <section>
       <Table
         autoFocus={false}
+        searchExpr={searchValue}
         rowsCount={modelList?.totalItems}
         hideFooter
         loading={loadingModelList}
@@ -184,7 +196,7 @@ const ModelTable = ({ onModelSelect }: ModelTableProps) => {
         reload={() => {
           setPageNumber(0)
         }}
-        noRowsMsg={t('global.noData.heading')}
+        noRowsMsg={noRowsMsg}
       />
       <div className="load-more-button-container">
         {modelList?.totalPages !== pageNumber && (

--- a/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
+++ b/src/components/pages/TechnicalUserManagement/TechnicalUserTable.tsx
@@ -208,6 +208,8 @@ export const TechnicalUserTable = () => {
             ),
           },
         ]}
+        emptyDataMsg={t('global.table.emptyDataMsg')}
+        noSearchResultsMsg={t('global.table.noSearchResults')}
       />
     </div>
   )

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -208,6 +208,8 @@ export const UserList = ({
           },
         ]}
         disableColumnMenu
+        emptyDataMsg={t('global.table.emptyDataMsg')}
+        noSearchResultsMsg={t('global.table.noSearchResults')}
       />
     </section>
   )

--- a/src/components/shared/frame/UserList/index.tsx
+++ b/src/components/shared/frame/UserList/index.tsx
@@ -120,7 +120,6 @@ export const UserList = ({
           onSearch(expr)
         }}
         searchDebounce={1000}
-        noRowsMsg={t('content.usermanagement.appUserDetails.table.noRowsMsg')}
         title={t(tableLabel)}
         loadLabel={t('global.actions.more')}
         fetchHook={fetchHook}

--- a/src/components/shared/templates/StaticTemplateResponsive/index.tsx
+++ b/src/components/shared/templates/StaticTemplateResponsive/index.tsx
@@ -39,6 +39,7 @@ import { uniqueId } from 'lodash'
 import TitleDescriptionAndSectionlink from './Cards/TitleDescriptionAndSectionlink'
 import { StandardLibrariesTableColumns } from './Cards/StandardLibrariesTableColumns'
 import { type StandardLibraryType } from 'features/staticContent/staticContentApiSlice'
+import { useTranslation } from 'react-i18next'
 
 const TemplateConfig = ({
   provider,
@@ -239,6 +240,7 @@ export const StaticTemplateResponsive = ({
   baseUrl: string
   stdLibraries?: StandardLibraryType
 }) => {
+  const { t } = useTranslation()
   const [showScroll, setShowScroll] = useState(false)
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'), {
@@ -313,6 +315,11 @@ export const StaticTemplateResponsive = ({
                       rows={stdLibraries.rows}
                       getRowId={(row) => uniqueId(row.uid)}
                       hasBorder={false}
+                      noRowsMsg={
+                        stdLibraries.rows.length === 0
+                          ? t('global.table.emptyDataMsg')
+                          : ''
+                      }
                     />
                   )}
                 </div>


### PR DESCRIPTION
## Description
Table(empty or with applied filters) message should be consistent. Since we don't have any translation config in shared components so we somehow need to provide translations from the Portal(which is not the best solution) for the messages otherwise we either have to add translations in shared-components or refactor the shared-components itself which is hug task but for now I make it work with the work-around to unblock the process.

This PR has the dependent change in shared-component and this is also the reason of failed pipeline. Once this PR of shared-component will be merged then the pipeline should work fine. Please also review this one
https://github.com/eclipse-tractusx/portal-shared-components/pull/446

**Changelog entry**
```
- **Tables**:
  - Fixed empty Table messages with/without filters[#1549](https://github.com/eclipse-tractusx/portal-frontend/pull/1549
)
```

## Why
Different messages for every table is not the best UX practice for the users so messages should be the same for general use cases.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1548

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
