### PR TITLE
feat(App/Service & Technical User): hide secret/password

### DIFF
--- a/src/components/overlays/AddTechnicalUser/index.tsx
+++ b/src/components/overlays/AddTechnicalUser/index.tsx
@@ -138,6 +138,7 @@ export const AddTechnicalUser = () => {
                   clientSecret: {
                     label: t('content.techUser.details.clientSercret'),
                     value: data.secret,
+                    hideSecret: true,
                   },
                 }}
                 variant="wide"

--- a/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/ActivateSubscriptionOverlay/index.tsx
@@ -26,12 +26,19 @@ import {
   DialogHeader,
   Input,
   LoadingButton,
+  StaticTable,
+  type TableType,
   Typography,
+  CircleProgress,
 } from '@catena-x/portal-shared-components'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { useTranslation, Trans } from 'react-i18next'
 import { isKeycloakURL } from 'types/Patterns'
-import { useAddUserSubscribtionMutation } from 'features/appSubscription/appSubscriptionApiSlice'
+import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined'
+import {
+  type SubscriptionActivationResponse,
+  useAddUserSubscribtionMutation,
+} from 'features/appSubscription/appSubscriptionApiSlice'
 import { useState } from 'react'
 import { useDispatch } from 'react-redux'
 import './style.scss'
@@ -39,7 +46,6 @@ import type { store } from 'features/store'
 import { setSuccessType } from 'features/appSubscription/slice'
 import { Link } from 'react-router-dom'
 import { useFetchTechnicalUserProfilesQuery } from 'features/appManagement/apiSlice'
-import { success, error } from 'services/NotifyService'
 
 const TentantHelpURL =
   '/documentation/?path=user%2F04.+App%28s%29%2F05.+App+Subscription%2F04.+Subscription+Activation+%28App+Provider%29.md'
@@ -51,6 +57,8 @@ interface ActivateSubscriptionProps {
   appId: string
   subscriptionId: string
   title: string
+  companyName: string
+  bpnNumber: string
   handleOverlayClose: () => void
 }
 
@@ -59,6 +67,8 @@ const ActivateSubscriptionOverlay = ({
   appId,
   subscriptionId,
   title,
+  companyName,
+  bpnNumber,
   handleOverlayClose,
 }: ActivateSubscriptionProps) => {
   const { t } = useTranslation()
@@ -66,6 +76,8 @@ const ActivateSubscriptionOverlay = ({
   const [inputURL, setInputURL] = useState('')
   const [URLErrorMsg, setURLErrorMessage] = useState('')
   const [loading, setLoading] = useState(false)
+  const [activationResponse, setActivationResponse] =
+    useState<SubscriptionActivationResponse>()
 
   const [addUserSubscribtion] = useAddUserSubscribtionMutation()
   const { data } = useFetchTechnicalUserProfilesQuery(appId)
@@ -82,158 +94,281 @@ const ActivateSubscriptionOverlay = ({
   const addTentantURL = async () => {
     setLoading(true)
     try {
-      await addUserSubscribtion({
+      const subscriptionData = await addUserSubscribtion({
         requestId: subscriptionId,
         offerUrl: inputURL,
       }).unwrap()
-      dispatch(setSuccessType(true))
-      success(t('content.appSubscription.configuration'))
-    } catch (err) {
-      dispatch(setSuccessType(false))
-      error(t('content.appSubscription.error'), '', err as object)
-    } finally {
-      setLoading(false)
-      handleOverlayClose()
+      setActivationResponse(subscriptionData)
+    } catch (error) {
+      console.log(error)
     }
+    setLoading(false)
+  }
+
+  const closeActivationOverlay = () => {
+    dispatch(setSuccessType(true))
+    handleOverlayClose()
+  }
+
+  const tableData1: TableType = {
+    head: [t('content.appSubscription.activation.clientDetails'), ''],
+    body: [
+      [t('content.appSubscription.activation.customer'), `${companyName}`],
+      [t('content.appSubscription.activation.bpn'), `${bpnNumber}`],
+    ],
+  }
+
+  const activationData = activationResponse?.technicalUserInfo
+    ?.map((userdata) => [
+      [
+        t('content.appSubscription.activation.technicalClientId'),
+        `${userdata?.technicalClientId}`,
+      ],
+      [
+        t('content.appSubscription.activation.technicalSecret'),
+        `${userdata?.technicalUserSecret}`,
+      ],
+      [
+        t('content.appSubscription.activation.technicalPermission'),
+        `${userdata?.technicalUserPermissions?.toString()}`,
+      ],
+    ])
+    .flat(1)
+
+  activationData?.unshift([
+    t('content.appSubscription.activation.appClientId'),
+    `${activationResponse?.clientInfo?.clientId}`,
+  ])
+
+  const tableData2: TableType = {
+    head: [t('content.appSubscription.activation.technicalDetails'), ''],
+    body: activationData ?? [],
+    edit:
+      activationResponse?.technicalUserInfo
+        ?.map((userData) => [
+          [
+            {
+              icon: false,
+            },
+            {
+              icon: false,
+            },
+          ],
+          [
+            {
+              icon: false,
+            },
+            {
+              icon: false,
+            },
+          ],
+          [
+            {
+              icon: false,
+            },
+            {
+              icon: false,
+              copyValue: userData?.technicalUserSecret,
+            },
+          ],
+        ])
+        .flat(1) ?? [],
   }
 
   return (
-    <Dialog
-      open={openDialog}
-      sx={{
-        '.MuiDialog-paper': {
-          maxWidth: '45%',
-        },
-      }}
-    >
-      <DialogHeader
-        title={t('content.appSubscription.activation.heading')}
-        intro={t('content.appSubscription.activation.intro').replace(
-          '{{companyName}}',
-          title
-        )}
-        closeWithIcon={false}
-      />
-      <DialogContent>
-        <div className="appSubscriptionMain">
-          <Trans
-            values={{
-              companyName: title,
+    <>
+      {activationResponse ? (
+        <div className="activationOverlay">
+          <Dialog
+            open={true}
+            sx={{
+              '.MuiDialog-paper': {
+                maxWidth: '45%',
+              },
             }}
           >
-            <Typography variant="body2">
-              {t('content.appSubscription.activation.stepDescription')}
-            </Typography>
-          </Trans>
-          <ol>
-            <li>
-              <Typography variant="body2">
-                {t('content.appSubscription.activation.step1')}
-              </Typography>
-            </li>
-            <li>
-              <Typography variant="body2">
-                {t('content.appSubscription.activation.step2')}
-              </Typography>
-            </li>
-            <li>
-              <Typography variant="body2">
-                {t('content.appSubscription.activation.step3')}
-              </Typography>
-            </li>
-          </ol>
-          <Typography variant="h5" className="addTentalURLHeading">
-            {t('content.appSubscription.activation.addTentalURLHeading')}
-          </Typography>
-          <Typography variant="body2">
-            {t('content.appSubscription.activation.addTentalURLDescription')}
-          </Typography>
-          <Link to={TentantHelpURL} target="_blank">
-            <Typography variant="body2" className="helpText">
-              <HelpOutlineIcon />
-              {t('pages.help')}
-            </Typography>
-          </Link>
-          <Input
-            name="tentant_url"
-            label={
-              <Typography variant="label3">
-                {t('content.appSubscription.activation.enterURL')}
-              </Typography>
-            }
-            placeholder={t('content.appSubscription.activation.enterURL')}
-            onChange={(e) => {
-              addInputURL(e.target.value)
-            }}
-            value={inputURL}
-          />
-          <p className="errorMsg">{URLErrorMsg}</p>
-          <Typography variant="h5" className="addTentalURLHeading">
-            {t(
-              'content.appSubscription.activation.technicalUserDetailsHeading'
-            )}
-          </Typography>
-          <Typography variant="body2">
-            {t(
-              'content.appSubscription.activation.technicalUserDetailsDescription'
-            )}
-          </Typography>
-          <Link to={ProfileHelpURL} target="_blank">
-            <Typography variant="body2" className="helpText">
-              <HelpOutlineIcon />
-              {t('pages.help')}
-            </Typography>
-          </Link>
-          <div className="technicalUserProfile">
-            <Typography variant="h5" sx={{ marginBottom: '20px' }}>
-              {t(
-                'content.appSubscription.activation.technicalUserProfileHeading'
+            <DialogHeader
+              title=" "
+              intro={t('content.appSubscription.activation.successDescription')}
+              closeWithIcon={true}
+              icon={true}
+              iconComponent={
+                <CheckCircleOutlinedIcon
+                  sx={{ fontSize: 60 }}
+                  color="success"
+                />
+              }
+              onCloseWithIcon={() => {
+                handleOverlayClose()
+              }}
+            />
+            <DialogContent>
+              {loading ? (
+                <div className="loading-progress">
+                  <CircleProgress
+                    size={40}
+                    step={1}
+                    interval={0.1}
+                    colorVariant={'primary'}
+                    variant={'indeterminate'}
+                    thickness={8}
+                  />
+                </div>
+              ) : (
+                <>
+                  <StaticTable data={tableData1} horizontal={false} />
+                  <StaticTable data={tableData2} horizontal={false} />
+                </>
               )}
-            </Typography>
-            {data?.map((profiles) => {
-              return profiles.userRoles?.map((userRole) => (
-                <Typography variant="body2" key={userRole.roleId}>
-                  {userRole.roleName}
-                </Typography>
-              ))
-            })}
-          </div>
+            </DialogContent>
+            <DialogActions>
+              <Button variant="outlined" onClick={closeActivationOverlay}>
+                {t('global.actions.close')}
+              </Button>
+            </DialogActions>
+          </Dialog>
         </div>
-      </DialogContent>
-      <DialogActions>
-        <Button
-          variant="outlined"
-          onClick={() => {
-            handleOverlayClose()
+      ) : (
+        <Dialog
+          open={openDialog}
+          sx={{
+            '.MuiDialog-paper': {
+              maxWidth: '45%',
+            },
           }}
         >
-          {t('global.actions.close')}
-        </Button>
-        {loading ? (
-          <LoadingButton
-            color="primary"
-            helperText=""
-            helperTextColor="success"
-            label=""
-            loadIndicator="Loading ..."
-            loading
-            size="medium"
-            onButtonClick={() => {
-              // do nothing
-            }}
-            sx={{ marginLeft: '10px' }}
+          <DialogHeader
+            title={t('content.appSubscription.activation.heading')}
+            intro={t('content.appSubscription.activation.intro').replace(
+              '{{companyName}}',
+              title
+            )}
+            closeWithIcon={false}
           />
-        ) : (
-          <Button
-            variant="contained"
-            disabled={!inputURL || URLErrorMsg !== ''}
-            onClick={addTentantURL}
-          >
-            {t('global.actions.confirm')}
-          </Button>
-        )}
-      </DialogActions>
-    </Dialog>
+          <DialogContent>
+            <div className="appSubscriptionMain">
+              <Trans
+                values={{
+                  companyName: title,
+                }}
+              >
+                <Typography variant="body2">
+                  {t('content.appSubscription.activation.stepDescription')}
+                </Typography>
+              </Trans>
+              <ol>
+                <li>
+                  <Typography variant="body2">
+                    {t('content.appSubscription.activation.step1')}
+                  </Typography>
+                </li>
+                <li>
+                  <Typography variant="body2">
+                    {t('content.appSubscription.activation.step2')}
+                  </Typography>
+                </li>
+                <li>
+                  <Typography variant="body2">
+                    {t('content.appSubscription.activation.step3')}
+                  </Typography>
+                </li>
+              </ol>
+              <Typography variant="h5" className="addTentalURLHeading">
+                {t('content.appSubscription.activation.addTentalURLHeading')}
+              </Typography>
+              <Typography variant="body2">
+                {t(
+                  'content.appSubscription.activation.addTentalURLDescription'
+                )}
+              </Typography>
+              <Link to={TentantHelpURL} target="_blank">
+                <Typography variant="body2" className="helpText">
+                  <HelpOutlineIcon />
+                  {t('pages.help')}
+                </Typography>
+              </Link>
+              <Input
+                name="tentant_url"
+                label={
+                  <Typography variant="label3">
+                    {t('content.appSubscription.activation.enterURL')}
+                  </Typography>
+                }
+                placeholder={t('content.appSubscription.activation.enterURL')}
+                onChange={(e) => {
+                  addInputURL(e.target.value)
+                }}
+                value={inputURL}
+              />
+              <p className="errorMsg">{URLErrorMsg}</p>
+              <Typography variant="h5" className="addTentalURLHeading">
+                {t(
+                  'content.appSubscription.activation.technicalUserDetailsHeading'
+                )}
+              </Typography>
+              <Typography variant="body2">
+                {t(
+                  'content.appSubscription.activation.technicalUserDetailsDescription'
+                )}
+              </Typography>
+              <Link to={ProfileHelpURL} target="_blank">
+                <Typography variant="body2" className="helpText">
+                  <HelpOutlineIcon />
+                  {t('pages.help')}
+                </Typography>
+              </Link>
+              <div className="technicalUserProfile">
+                <Typography variant="h5" sx={{ marginBottom: '20px' }}>
+                  {t(
+                    'content.appSubscription.activation.technicalUserProfileHeading'
+                  )}
+                </Typography>
+                {data?.map((profiles) => {
+                  return profiles.userRoles?.map((userRole) => (
+                    <Typography variant="body2" key={userRole.roleId}>
+                      {userRole.roleName}
+                    </Typography>
+                  ))
+                })}
+              </div>
+            </div>
+          </DialogContent>
+          <DialogActions>
+            <Button
+              variant="outlined"
+              onClick={() => {
+                handleOverlayClose()
+              }}
+            >
+              {t('global.actions.close')}
+            </Button>
+            {loading ? (
+              <LoadingButton
+                color="primary"
+                helperText=""
+                helperTextColor="success"
+                label=""
+                loadIndicator="Loading ..."
+                loading
+                size="medium"
+                onButtonClick={() => {
+                  // do nothing
+                }}
+                sx={{ marginLeft: '10px' }}
+              />
+            ) : (
+              <Button
+                variant="contained"
+                disabled={!inputURL || URLErrorMsg !== ''}
+                onClick={addTentantURL}
+              >
+                {t('global.actions.confirm')}
+              </Button>
+            )}
+          </DialogActions>
+        </Dialog>
+      )}
+    </>
   )
 }
 

--- a/src/components/shared/basic/UserDetailInfo/UserDetailCard.tsx
+++ b/src/components/shared/basic/UserDetailInfo/UserDetailCard.tsx
@@ -32,6 +32,8 @@ import EditIcon from '@mui/icons-material/ModeEditOutlineOutlined'
 import { OVERLAYS } from 'types/Constants'
 import { useParams } from 'react-router-dom'
 import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 
 export type UserDetail = {
   companyUserId: string
@@ -54,6 +56,7 @@ export interface UserCardProps {
 interface UserItemsTranslation {
   label: string
   value: string | string[]
+  hideSecret?: boolean
 }
 
 export interface UserItems {
@@ -70,6 +73,11 @@ export const UserDetailCard = ({
   const { userId } = useParams()
   const openEditOverlay = () => dispatch(show(OVERLAYS.ADD_BPN, userId))
   const [copied, setCopied] = useState<boolean>(false)
+  const [hideSecret, setHideSecret] = useState<boolean>(
+    cardContentItems.clientSecret?.hideSecret !== undefined
+      ? cardContentItems.clientSecret.hideSecret
+      : true
+  )
 
   const copyText = (value: string | string[]) => {
     setCopied(true)
@@ -99,7 +107,9 @@ export const UserDetailCard = ({
                   <br />
                 </span>
               ))
-            : value?.value}
+            : param === 'clientSecret' && hideSecret
+              ? value?.value.toString().replace(/./g, '*')
+              : value?.value}
         </span>
       )}
       {userId && value?.label === 'BPN' && (
@@ -128,13 +138,40 @@ export const UserDetailCard = ({
       )}
       <span>
         {param === 'clientSecret' && (
-          <ContentCopyIcon
-            style={{ cursor: 'pointer' }}
-            sx={{ marginLeft: '10px', color: copied ? '#44aa44' : '#cccccc' }}
-            onClick={() => {
-              copyText(value?.value as string)
-            }}
-          />
+          <>
+            <ContentCopyIcon
+              style={{ cursor: 'pointer' }}
+              sx={{ marginLeft: '10px', color: copied ? '#44aa44' : '#cccccc' }}
+              onClick={() => {
+                copyText(value?.value as string)
+              }}
+            />
+            {hideSecret ? (
+              <VisibilityOffIcon
+                style={{ cursor: 'pointer' }}
+                sx={{
+                  marginLeft: '10px',
+                  color: '#cccccc',
+                  fontSize: '20px',
+                }}
+                onClick={() => {
+                  setHideSecret(!hideSecret)
+                }}
+              />
+            ) : (
+              <VisibilityIcon
+                style={{ cursor: 'pointer' }}
+                sx={{
+                  marginLeft: '10px',
+                  color: '#cccccc',
+                  fontSize: '20px',
+                }}
+                onClick={() => {
+                  setHideSecret(!hideSecret)
+                }}
+              />
+            )}
+          </>
         )}
       </span>
     </>

--- a/src/components/shared/basic/UserDetailInfo/UserDetailCard.tsx
+++ b/src/components/shared/basic/UserDetailInfo/UserDetailCard.tsx
@@ -89,93 +89,110 @@ export const UserDetailCard = ({
   const renderValue = (
     value: UserItemsTranslation | undefined,
     param: string
-  ) => (
-    <>
-      <strong style={{ marginRight: '5px' }}>{value?.label}:</strong>
-      {value?.value && value?.value.length > 0 && (
-        <span
-          style={{
-            marginLeft: variant === 'wide' ? 'auto' : '',
-            display: 'inline-grid',
-            fontSize: '14px',
-          }}
-        >
-          {Array.isArray(value?.value)
-            ? value?.value.map((bpn, i) => (
-                <span key={i}>
-                  {bpn}
-                  <br />
-                </span>
-              ))
-            : param === 'clientSecret' && hideSecret
-              ? value?.value.toString().replace(/./g, '*')
-              : value?.value}
-        </span>
-      )}
-      {userId && value?.label === 'BPN' && (
-        <Box
-          sx={{
-            borderRadius: '50%',
-            width: '35px',
-            height: '35px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            marginLeft: '5px',
-            '&:hover': {
-              backgroundColor: 'rgba(176, 206, 235, 0.4)',
-            },
-          }}
-        >
-          <EditIcon
-            onClick={openEditOverlay}
-            sx={{
-              cursor: 'pointer',
-              color: '#0F71CB',
+  ) => {
+    const getLabelValue = (
+      value: UserItemsTranslation | undefined,
+      param: string,
+      hideSecret: boolean
+    ) => {
+      if (Array.isArray(value?.value)) {
+        return value.value.map((bpn, i) => (
+          <span key={i}>
+            {bpn}
+            <br />
+          </span>
+        ))
+      }
+
+      if (param === 'clientSecret' && hideSecret) {
+        return value?.value.toString().replace(/./g, '*')
+      }
+
+      return value?.value
+    }
+
+    return (
+      <>
+        <strong style={{ marginRight: '5px' }}>{value?.label}:</strong>
+        {value?.value && value?.value.length > 0 && (
+          <span
+            style={{
+              marginLeft: variant === 'wide' ? 'auto' : '',
+              display: 'inline-grid',
+              fontSize: '14px',
             }}
-          />
-        </Box>
-      )}
-      <span>
-        {param === 'clientSecret' && (
-          <>
-            <ContentCopyIcon
-              style={{ cursor: 'pointer' }}
-              sx={{ marginLeft: '10px', color: copied ? '#44aa44' : '#cccccc' }}
-              onClick={() => {
-                copyText(value?.value as string)
+          >
+            {getLabelValue(value, param, hideSecret)}
+          </span>
+        )}
+        {userId && value?.label === 'BPN' && (
+          <Box
+            sx={{
+              borderRadius: '50%',
+              width: '35px',
+              height: '35px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              marginLeft: '5px',
+              '&:hover': {
+                backgroundColor: 'rgba(176, 206, 235, 0.4)',
+              },
+            }}
+          >
+            <EditIcon
+              onClick={openEditOverlay}
+              sx={{
+                cursor: 'pointer',
+                color: '#0F71CB',
               }}
             />
-            {hideSecret ? (
-              <VisibilityOffIcon
-                style={{ cursor: 'pointer' }}
-                sx={{
-                  marginLeft: '10px',
-                  color: '#cccccc',
-                  fontSize: '20px',
-                }}
-                onClick={() => {
-                  setHideSecret(!hideSecret)
-                }}
-              />
-            ) : (
-              <VisibilityIcon
-                style={{ cursor: 'pointer' }}
-                sx={{
-                  marginLeft: '10px',
-                  color: '#cccccc',
-                  fontSize: '20px',
-                }}
-                onClick={() => {
-                  setHideSecret(!hideSecret)
-                }}
-              />
-            )}
-          </>
+          </Box>
         )}
-      </span>
-    </>
-  )
+        <span>
+          {param === 'clientSecret' && (
+            <>
+              <ContentCopyIcon
+                style={{ cursor: 'pointer' }}
+                sx={{
+                  marginLeft: '10px',
+                  color: copied ? '#44aa44' : '#cccccc',
+                }}
+                onClick={() => {
+                  copyText(value?.value as string)
+                }}
+              />
+              {hideSecret ? (
+                <VisibilityOffIcon
+                  style={{ cursor: 'pointer' }}
+                  sx={{
+                    marginLeft: '10px',
+                    color: '#cccccc',
+                    fontSize: '20px',
+                  }}
+                  onClick={() => {
+                    setHideSecret(!hideSecret)
+                  }}
+                />
+              ) : (
+                <VisibilityIcon
+                  style={{ cursor: 'pointer' }}
+                  sx={{
+                    marginLeft: '10px',
+                    color: '#cccccc',
+                    fontSize: '20px',
+                  }}
+                  onClick={() => {
+                    setHideSecret(!hideSecret)
+                  }}
+                />
+              )}
+            </>
+          )}
+        </span>
+      </>
+    )
+  }
 
   const renderContentSwitch = (
     param: string,

--- a/src/components/shared/basic/UserDetailInfo/UserDetailCard.tsx
+++ b/src/components/shared/basic/UserDetailInfo/UserDetailCard.tsx
@@ -74,9 +74,7 @@ export const UserDetailCard = ({
   const openEditOverlay = () => dispatch(show(OVERLAYS.ADD_BPN, userId))
   const [copied, setCopied] = useState<boolean>(false)
   const [hideSecret, setHideSecret] = useState<boolean>(
-    cardContentItems.clientSecret?.hideSecret !== undefined
-      ? cardContentItems.clientSecret.hideSecret
-      : true
+    cardContentItems.clientSecret?.hideSecret ?? true
   )
 
   const copyText = (value: string | string[]) => {

--- a/src/components/shared/templates/Subscription/SubscriptionElements.tsx
+++ b/src/components/shared/templates/Subscription/SubscriptionElements.tsx
@@ -391,6 +391,8 @@ export default function SubscriptionElements({
           appId={subscriptionDetail.appId}
           subscriptionId={subscriptionDetail.subscriptionId}
           title={subscriptionDetail.title}
+          companyName={subscriptionDetail.companyName}
+          bpnNumber={subscriptionDetail.bpnNumber}
           handleOverlayClose={() => {
             setSubscriptionDetail(SubscriptionInitialData)
             refetch()


### PR DESCRIPTION
## Description

1. Introduce Icons of Visibility-on/Visibility-off in `UserDetailCard` component for the toggle functionality of show/hide secrets.
2. Added conditional check in `StaticTable` for the secret.

The shared-component PR should be reviewed first before merging this PR since this PR has dependency change on this below PR
https://github.com/eclipse-tractusx/portal-shared-components/issues/447
https://github.com/eclipse-tractusx/portal-shared-components/pull/448

**Changelog entry**
```
- **App/Service Subscription/Technical User**:
  - Static Vertical Table support hide/show secrets with toggle [#1553](https://github.com/eclipse-tractusx/portal-frontend/pull/1553)
```

## Why
Secrets are a sensitive information and it should be hidden by default until some action performed to reveal them.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1552

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
