### PR TITLE
feat(Connector): added a view for provided connector

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -601,7 +601,8 @@
         "sdDescription": "SD Registration",
         "sdRegistrationToolTip": "Das SD-Dokument ist noch nicht geladen. Dies könnte auf die Deaktivierung der SD-Fabrik zurückzuführen sein. Dieser Prozess wird so bald wie möglich vom CX-Administrator neu ausgelöst.",
         "hostCompanyName": "Host",
-        "providerCompanyName": "Customer",
+        "customerCompanyName": "Customer",
+        "providerCompanyName": "Provider",
         "connectorUrl": "Connector-URL"
       },
       "details": {

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -671,6 +671,8 @@
       "tabletitle": "Owned Connectors",
       "managedtabletitle": "Managed Connectors",
       "noConnectorsMessage": "Derzeit sind keine Konnektoren vorhanden. Neue Konnektoren werden hier hinzugefügt, sobald diese hinzugefügt wurden.",
+      "providedtabletitle": "Provided Connectors",
+      "noProvidedConnectorsMessage": "Derzeit stellt Ihr Unternehmen Ihrem Kunden keinen Konnektor zur Verfügung.",
       "imagetext": "Connectoren kombiniert die Vorteile von IDS-Konnektoren (sichere und standardisierte Kommunikation, Kontrolle der Datennutzung) mit der Interoperabilität.",
       "addconnectorbutton": "Connector registrieren",
       "snackbar": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -601,7 +601,8 @@
         "sdDescription": "SD Registration",
         "sdRegistrationToolTip": "The SD Document is not yet loaded. This could be due to the deactivation of the Sd Factory. This process will be retriggered as soon as possible by the CX Admin",
         "hostCompanyName": "Host",
-        "providerCompanyName": "Customer",
+        "customerCompanyName": "Customer",
+        "providerCompanyName": "Provider",
         "connectorUrl": "Connector URL"
       },
       "details": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -671,6 +671,8 @@
       "tabletitle": "Owned Connectors",
       "managedtabletitle": "Managed Connectors",
       "noConnectorsMessage": "Currently there are no onboarded connectors existing. New registered connectors will get added here as soon as available.",
+      "providedTableTitle": "Provided Connectors",
+      "noProvidedConnectorsMessage": "Currently there are no connector provided by your company to your customer.",
       "imagetext": "The connector combines the benefits of IDS connectors (secure and standardized communication, data usage control) with the interoperability. To register your connector inside the network and create your connector self-description, please register your connector below.",
       "addconnectorbutton": "Register Connector",
       "snackbar": {

--- a/src/components/pages/EdcConnector/EdcManagedConnectorTableColumns.tsx
+++ b/src/components/pages/EdcConnector/EdcManagedConnectorTableColumns.tsx
@@ -27,7 +27,7 @@ export const ManagedConnectorTableColumns = (): Array<GridColDef> => {
   return [
     {
       field: 'providerCompanyName',
-      headerName: t('content.edcconnector.columns.hostCompanyName'),
+      headerName: t('content.edcconnector.columns.providerCompanyName'),
       flex: 1,
       sortable: false,
       disableColumnMenu: true,

--- a/src/components/pages/EdcConnector/edcProvidedConnectorTableColumns.tsx
+++ b/src/components/pages/EdcConnector/edcProvidedConnectorTableColumns.tsx
@@ -1,6 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2023 Mercedes-Benz Group AG and BMW Group AG
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -21,13 +20,13 @@
 import type { GridColDef } from '@mui/x-data-grid'
 import { useTranslation } from 'react-i18next'
 
-export const ManagedConnectorTableColumns = (): Array<GridColDef> => {
+export const ProvidedConnectorTableColumns = (): Array<GridColDef> => {
   const { t } = useTranslation()
 
   return [
     {
-      field: 'providerCompanyName',
-      headerName: t('content.edcconnector.columns.hostCompanyName'),
+      field: 'hostCompanyName',
+      headerName: t('content.edcconnector.columns.providerCompanyName'),
       flex: 1,
       sortable: false,
       disableColumnMenu: true,

--- a/src/components/pages/EdcConnector/edcProvidedConnectorTableColumns.tsx
+++ b/src/components/pages/EdcConnector/edcProvidedConnectorTableColumns.tsx
@@ -26,7 +26,7 @@ export const ProvidedConnectorTableColumns = (): Array<GridColDef> => {
   return [
     {
       field: 'hostCompanyName',
-      headerName: t('content.edcconnector.columns.providerCompanyName'),
+      headerName: t('content.edcconnector.columns.customerCompanyName'),
       flex: 1,
       sortable: false,
       disableColumnMenu: true,

--- a/src/components/pages/EdcConnector/index.tsx
+++ b/src/components/pages/EdcConnector/index.tsx
@@ -49,6 +49,7 @@ import {
   type ConnectorResponseBody,
   useFetchManagedConnectorsQuery,
   type ConnectorDetailsType,
+  useFetchProvidedConnectorsQuery,
 } from 'features/connector/connectorApiSlice'
 import { ServerResponseOverlay } from 'components/overlays/ServerResponse'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
@@ -65,6 +66,7 @@ import ConnectorDetailsOverlay from './ConnectorDetailsOverlay'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward'
 import { Box } from '@mui/material'
+import { ProvidedConnectorTableColumns } from './edcProvidedConnectorTableColumns'
 
 const EdcConnector = () => {
   const { t } = useTranslation()
@@ -148,10 +150,13 @@ const EdcConnector = () => {
   const rawColumns = ConnectorTableColumns(onDelete) // Common col values for own and managed connectors
   let ownConnectorCols = OwnConnectorTableColumns() // unique col values from own connectors
   let managedConnectorCols = ManagedConnectorTableColumns() // unique col values from managed connectors
+  let providedConnectorCols = ProvidedConnectorTableColumns() // unique col values from provided connectors
   ownConnectorCols.push(...rawColumns)
   ownConnectorCols = swap(ownConnectorCols, 2, 0) //swap position according to the design
   managedConnectorCols.push(...rawColumns)
   managedConnectorCols = swap(managedConnectorCols, 2, 0) //swap position according to the design
+  providedConnectorCols.push(...rawColumns)
+  providedConnectorCols = swap(providedConnectorCols, 2, 0) //swap position according to the design
 
   const closeAndResetModalState = () => {
     setAddConnectorOverlayCurrentStep(0)
@@ -467,15 +472,6 @@ const EdcConnector = () => {
           <Tab
             icon={getTabIcon(1)}
             iconPosition="start"
-            sx={{
-              width: '100%',
-              maxWidth: '550px',
-              '&.Mui-selected': {
-                borderBottom: '3px solid #0f71cb',
-              },
-              textTransform: 'none',
-              display: 'inline-flex',
-            }}
             label={t('content.edcconnector.tabletitle')}
             id={`simple-tab-${activeTab}`}
             aria-controls={`simple-tabpanel-${activeTab}`}
@@ -483,16 +479,14 @@ const EdcConnector = () => {
           <Tab
             icon={getTabIcon(2)}
             iconPosition="start"
-            sx={{
-              width: '100%',
-              maxWidth: '550px',
-              '&.Mui-selected': {
-                borderBottom: '3px solid #0f71cb',
-              },
-              textTransform: 'none',
-              display: 'inline-flex',
-            }}
             label={t('content.edcconnector.managedtabletitle')}
+            id={`simple-tab-${activeTab}`}
+            aria-controls={`simple-tabpanel-${activeTab}`}
+          />
+          <Tab
+            icon={getTabIcon(3)}
+            iconPosition="start"
+            label={t('content.edcconnector.providedTableTitle')}
             id={`simple-tab-${activeTab}`}
             aria-controls={`simple-tabpanel-${activeTab}`}
           />
@@ -524,6 +518,23 @@ const EdcConnector = () => {
               getRowId={(row: { [key: string]: string }) => row.id}
               columns={managedConnectorCols}
               noRowsMsg={t('content.edcconnector.noConnectorsMessage')}
+              onCellClick={(params: GridCellParams) => {
+                onTableCellClick(params)
+              }}
+            />
+          </div>
+        </TabPanel>
+        <TabPanel value={activeTab} index={2}>
+          <div className="connector-table-container">
+            <PageLoadingTable<ConnectorResponseBody, unknown>
+              toolbarVariant="premium"
+              title={t('content.edcconnector.providedTableTitle')}
+              loadLabel={t('global.actions.more')}
+              fetchHook={useFetchProvidedConnectorsQuery}
+              fetchHookRefresh={refresh}
+              getRowId={(row: { [key: string]: string }) => row.id}
+              columns={providedConnectorCols}
+              noRowsMsg={t('content.edcconnector.noProvidedConnectorsMessage')}
               onCellClick={(params: GridCellParams) => {
                 onTableCellClick(params)
               }}

--- a/src/features/connector/connectorApiSlice.ts
+++ b/src/features/connector/connectorApiSlice.ts
@@ -156,6 +156,13 @@ export const apiSlice = createApi({
       query: (filters) =>
         `/api/administration/connectors/managed?page=${filters.page}&size=10`,
     }),
+    fetchProvidedConnectors: builder.query<
+      PaginResult<ConnectorResponseBody>,
+      PaginFetchArgs
+    >({
+      query: (filters) =>
+        `/api/administration/Connectors/provided?page=${filters.page}&size=10`,
+    }),
     fetchOfferSubscriptions: builder.query<EdcSubscriptionsType[], void>({
       query: () => ({
         url: '/api/administration/Connectors/offerSubscriptions?connectorIdSet=false',
@@ -195,6 +202,7 @@ export const apiSlice = createApi({
 export const {
   useCreateConnectorMutation,
   useCreateManagedConnectorMutation,
+  useFetchProvidedConnectorsQuery,
   useFetchConnectorDetailsQuery,
   useDeleteConnectorMutation,
   useFetchConnectorsQuery,


### PR DESCRIPTION
## Description

Added a new tab for Provided Connector, which will show the connector list provided by the logged-in company to their customer.
Changelog entry:

```
- **Connector registration**:
  - Added a new tab for provided connector. [#1087](https://github.com/eclipse-tractusx/portal-backend/issues/1087)
```

## Why

There was no view where the provider could see the connectors that were provided to their customer. With this new view, they can manage the connector provided to their customer.

## Issue

eclipse-tractusx/portal-backend#1087

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
