### PR TITLE
feat(connector): only show available tech user

### DIFF
--- a/src/components/pages/EdcConnector/AddConnectorOverlay/ConnectorInsertForm.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/ConnectorInsertForm.tsx
@@ -271,7 +271,10 @@ any) => {
   useEffect(() => {
     if (fetchServiceAccountUsers)
       setServiceAccountUsers(
-        fetchServiceAccountUsers?.filter((item: { name: string }) => item.name)
+        fetchServiceAccountUsers?.filter(
+          (item: { name: string; offer: unknown; connector: unknown }) =>
+            item.offer == null && item.connector == null && item.name
+        )
       )
   }, [fetchServiceAccountUsers])
 

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -66,6 +66,9 @@ export interface ServiceAccountListEntry {
   offer?: {
     name?: string
   }
+  connector?: {
+    name?: string
+  }
 }
 
 export interface ConnectedObject {


### PR DESCRIPTION
## Description

Filter out the technical user which is not linked to any connector or offer in Connector registration
```
- **Connector registration**:
  - added logic to show only available tech user. [#1570](https://github.com/eclipse-tractusx/portal-backend/issues/1570)
```
## Why

Previously it was allowing same technical user or technical user of offer to be linked with more than one connector

## Issue

#1547 
eclipse-tractusx/portal-backend#1139

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
