### PR TITLE
feat: upgrade catena-x shared components to 4.0.1

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -764,7 +764,7 @@ npm/npmjs/@babel/traverse/7.26.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD
 npm/npmjs/@babel/types/7.25.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #16040
 npm/npmjs/@babel/types/7.26.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #17734
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/4.0.0, Apache-2.0 AND MIT, approved, #20858
+npm/npmjs/@catena-x/portal-shared-components/4.0.1, Apache-2.0 AND MIT, approved, #20858
 npm/npmjs/@colors/colors/1.5.0, MIT, approved, clearlydefined
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
 npm/npmjs/@cypress/request/3.0.6, Apache-2.0, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^4.0.0",
+    "@catena-x/portal-shared-components": "^4.0.1",
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
     "@hookform/error-message": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,10 +388,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-4.0.0.tgz#29b5a90f5c616198af0b27937922609b59fc2deb"
-  integrity sha512-lm8UXSgXQ7ZOEfmfc7vuBJUdE0vW8ql7igweojfDcAsiyGXrZ86/mNBvjTf+5I/o+PjkUZZC+zKjc572zUaE2Q==
+"@catena-x/portal-shared-components@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-4.0.1.tgz#e581ab04b60bd1dd86c4e93ff792ef4302614804"
+  integrity sha512-WtSdtrisbEJUfQEiK7Qs71cNPfz9MAEe7YCGkiRHHLGU3zXE+S9oiP+493cEyPlxhPUuvzSKUrQHsXbKqgYzIw==
   dependencies:
     "@date-io/date-fns" "^3.0.0"
     "@emotion/react" "^11.14.0"


### PR DESCRIPTION
## Description

Integrate Catena-X shared components version update of 4.0.0 -> 4.0.1.

## Why

Dependency updates are now included.

## Issue

eclipse-tractusx/portal-frontend#1560

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
