### PR TITLE
fix: sectioner contain width changed to auto-100%

### DIFF
--- a/src/components/pages/TechnicalUserManagement/style.scss
+++ b/src/components/pages/TechnicalUserManagement/style.scss
@@ -18,6 +18,14 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+// Table to span full available width
+main {
+  section {
+    max-width: 100%;
+    margin: 0 50px;
+  }
+}
+
 // Content technical user
 .content-technical-user {
   display: flex;

--- a/src/components/pages/TechnicalUserManagement/style.scss
+++ b/src/components/pages/TechnicalUserManagement/style.scss
@@ -19,11 +19,9 @@
  ********************************************************************************/
 
 // Table to span full available width
-main {
-  section {
-    max-width: 100%;
-    margin: 0 50px;
-  }
+main > section {
+  max-width: 100%;
+  margin: 0 50px;
 }
 
 // Content technical user

--- a/src/components/styles/main.scss
+++ b/src/components/styles/main.scss
@@ -44,8 +44,8 @@ main {
 }
 
 section {
-  max-width: 1200px;
-  margin: auto;
+  max-width: 100%;
+  margin: 0 50px;
   padding: 50px 30px;
 
   .section-title {

--- a/src/components/styles/main.scss
+++ b/src/components/styles/main.scss
@@ -44,8 +44,8 @@ main {
 }
 
 section {
-  max-width: 100%;
-  margin: 0 50px;
+  max-width: 1200px;
+  margin: auto;
   padding: 50px 30px;
 
   .section-title {


### PR DESCRIPTION
## Description
The Table column (in this case technicaluser management)  columns were stagnated because of hard coded max-width value. Now, with the resolution the width technically shouldn't be of fixed value rather dynamic so I make the max-width to 100% - adaptive.
## After fix

![screencapture-localhost-3001-technicalUserManagement-2025-05-21-11_29_52](https://github.com/user-attachments/assets/670f04ce-53db-4911-aa2b-d697663c83c5)

## Changelog
```
- **Technical User**:
  - Make Technical User table to span to full available width [1602](https://github.com/eclipse-tractusx/portal-frontend/pull/1602)
```


## Why
The value for the section was of 1200px in which we are rendering Table component that was the reason of column stagnation

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1596

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
