### PR TITLE
fix: user role selection for app access

### DIFF
--- a/src/components/overlays/AddAppUserRoles/AppRoles.tsx
+++ b/src/components/overlays/AddAppUserRoles/AppRoles.tsx
@@ -32,9 +32,9 @@ export const AppRoles = () => {
   const dispatch = useDispatch()
   const { appId } = useParams()
   const { data } = useFetchAppRolesQuery(appId ?? '')
+  const roles = useSelector((state: RootState) => state.admin.user.rolesToAdd)
 
   const selectRole = (roleName: string, select: boolean) => {
-    const roles = useSelector((state: RootState) => state.admin.user.rolesToAdd)
     const isSelected = roles.includes(roleName)
     if (!isSelected && select) {
       dispatch(setRolesToAdd([...roles, roleName]))


### PR DESCRIPTION
## Description
App has the roles for access and and only granted user will be able to access the app who has the right/role to access it!
Due to some adopted practice the role selection wasn't happening for apps!

## Changelog
```
- **User Management | App Access Management**:
  - persist user selection on navigating back from role selection [#1603](https://github.com/eclipse-tractusx/portal-frontend/pull/1603)

```
## Why
We were calling the hook inside the function which is not allowed to do so just moved the selector based hook out the function body to inside the main function body and it works!

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1597

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
