### PR TITLE
fix: show pre-selected user after role selector navigation

### DIFF
--- a/src/components/overlays/AddAppUserRoles/AppRoles.tsx
+++ b/src/components/overlays/AddAppUserRoles/AppRoles.tsx
@@ -32,9 +32,9 @@ export const AppRoles = () => {
   const dispatch = useDispatch()
   const { appId } = useParams()
   const { data } = useFetchAppRolesQuery(appId ?? '')
+  const roles = useSelector((state: RootState) => state.admin.user.rolesToAdd)
 
   const selectRole = (roleName: string, select: boolean) => {
-    const roles = useSelector((state: RootState) => state.admin.user.rolesToAdd)
     const isSelected = roles.includes(roleName)
     if (!isSelected && select) {
       dispatch(setRolesToAdd([...roles, roleName]))

--- a/src/components/overlays/AddAppUserRoles/UserListContent.tsx
+++ b/src/components/overlays/AddAppUserRoles/UserListContent.tsx
@@ -77,15 +77,19 @@ export default function UserListContent() {
         {
           field: 'name',
           headerName: t('global.field.name'),
-          flex: 4,
+          width: 300,
           valueGetter: (_value_, row: TenantUser) =>
             `${row.firstName} ${row.lastName}`,
         },
-        { field: 'email', headerName: t('global.field.email'), flex: 5 },
+        {
+          field: 'email',
+          headerName: t('global.field.email'),
+          width: 300,
+        },
         {
           field: 'status',
           headerName: t('global.field.status'),
-          flex: 2,
+          width: 200,
           renderCell: ({ value: status }) => {
             return (
               <StatusTag color="label" label={t(`global.field.${status}`)} />

--- a/src/components/overlays/AddAppUserRoles/index.tsx
+++ b/src/components/overlays/AddAppUserRoles/index.tsx
@@ -116,36 +116,40 @@ export default function AddAppUserRoles() {
         <div style={{ width: '40%', margin: '0 auto 40px' }}>
           <Stepper list={AddStepsList} showSteps={2} activeStep={activeStep} />
         </div>
-        {activeStep === 1 && (
-          <Box sx={{ margin: '50px 110px' }}>
-            <Typography variant="label3">
-              {t('content.addUserRight.selectUsersDescription')}
-            </Typography>
-            <Box sx={{ mt: '46px' }}>
-              <UserListContent />
-            </Box>
+        <Box
+          sx={{
+            margin: '50px 110px',
+            display: activeStep === 1 ? 'block' : 'none',
+          }}
+        >
+          <Typography variant="label3">
+            {t('content.addUserRight.selectUsersDescription')}
+          </Typography>
+          <Box sx={{ mt: '46px' }}>
+            <UserListContent />
           </Box>
-        )}
-        {activeStep === 2 && (
-          <Box sx={{ margin: '50px 110px' }}>
-            <Typography variant="label3">
-              {t('content.addUserRight.addRolesDescription')}
+        </Box>
+        <Box
+          sx={{
+            margin: '50px 110px',
+            display: activeStep === 2 ? 'block' : 'none',
+          }}
+        >
+          <Typography variant="label3">
+            {t('content.addUserRight.addRolesDescription')}
+          </Typography>
+          <Box sx={{ mt: '46px' }}>
+            <Typography variant="label1">
+              {t('content.addUserRight.selectRoles')}
             </Typography>
-            <Box sx={{ mt: '46px' }}>
-              <Typography variant="label1">
-                {t('content.addUserRight.selectRoles')}
-              </Typography>
-            </Box>
-            <Box sx={{ mb: '30px' }}>
-              <Typography variant="body2">
-                <a href="">{`> ${t(
-                  'content.addUserRight.roleDescriptions'
-                )}`}</a>
-              </Typography>
-            </Box>
-            <AppRoles />
           </Box>
-        )}
+          <Box sx={{ mb: '30px' }}>
+            <Typography variant="body2">
+              <a href="">{`> ${t('content.addUserRight.roleDescriptions')}`}</a>
+            </Typography>
+          </Box>
+          <AppRoles />
+        </Box>
       </DialogContent>
 
       <DialogActions>


### PR DESCRIPTION
## Description
In app access management once we select the user and moves forward with its role selection and then navigate back to the user list we don't see the previously selected user. Expected results are we should see the user if we navigate back!

## Why
The problem lies in our component pattern(PageLoading Table). What is happening is if we navigate back to the UserList the entire component gets re-render and we list the DOM node from tree and hence we lost the selected user.
Now as part of the bug resolution I hide the List in Stepper component rather than its absence from DOM tree.


## Issue
https://cofinity-x.atlassian.net/browse/PM2-2870

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
