### PR TITLE
fix: redirect onboarded companies away from osp form

### DIFF
--- a/src/components/pages/OSPConsent/index.tsx
+++ b/src/components/pages/OSPConsent/index.tsx
@@ -27,7 +27,6 @@ import {
   useUpdateAgreementConsentsMutation,
   CONSENT_STATUS,
   ApplicationStatus,
-  ApplicationType,
   type SubmitData,
 } from 'features/registration/registrationApiSlice'
 import './style.scss'
@@ -59,8 +58,8 @@ export const OSPConsent = () => {
   const applicationId = applicationData?.[0].applicationId
 
   if (
-    applicationData?.[0].applicationStatus === ApplicationStatus.SUBMITTED &&
-    applicationData?.[0].applicationType === ApplicationType.INTERNAL
+    applicationData?.[0].applicationStatus === ApplicationStatus.SUBMITTED ||
+    applicationData?.[0].applicationStatus === ApplicationStatus.CONFIRMED
   ) {
     navigate('/')
   }

--- a/src/components/pages/OSPConsent/index.tsx
+++ b/src/components/pages/OSPConsent/index.tsx
@@ -26,16 +26,20 @@ import {
   useFetchAgreementConsentsQuery,
   useUpdateAgreementConsentsMutation,
   CONSENT_STATUS,
+  ApplicationStatus,
+  ApplicationType,
   type SubmitData,
 } from 'features/registration/registrationApiSlice'
 import './style.scss'
 import { SuccessRegistration } from './SuccessRegistration'
 import { ErrorRegistration } from './ErrorRegistration'
 import { CompanyDetails } from './CompanyDetails'
+import { useNavigate } from 'react-router-dom'
 
 export const OSPConsent = () => {
   const { t } = useTranslation('registration')
   const theme = useTheme()
+  const navigate = useNavigate()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'), {
     defaultMatches: true,
   })
@@ -53,6 +57,13 @@ export const OSPConsent = () => {
 
   const { data: applicationData, refetch } = useFetchApplicationsQuery()
   const applicationId = applicationData?.[0].applicationId
+
+  if (
+    applicationData?.[0].applicationStatus === ApplicationStatus.SUBMITTED &&
+    applicationData?.[0].applicationType === ApplicationType.INTERNAL
+  ) {
+    navigate('/')
+  }
 
   const { data: consentData } = useFetchAgreementConsentsQuery(
     applicationId ?? ''

--- a/src/components/pages/OSPConsent/index.tsx
+++ b/src/components/pages/OSPConsent/index.tsx
@@ -28,6 +28,7 @@ import {
   CONSENT_STATUS,
   ApplicationStatus,
   type SubmitData,
+  ApplicationType,
 } from 'features/registration/registrationApiSlice'
 import './style.scss'
 import { SuccessRegistration } from './SuccessRegistration'
@@ -58,6 +59,7 @@ export const OSPConsent = () => {
   const applicationId = applicationData?.[0].applicationId
 
   if (
+    applicationData?.[0].applicationType === ApplicationType.INTERNAL ||
     applicationData?.[0].applicationStatus === ApplicationStatus.SUBMITTED ||
     applicationData?.[0].applicationStatus === ApplicationStatus.CONFIRMED
   ) {


### PR DESCRIPTION
## Description

Added redirect on the OSP summary form page to redirect back to the homepage if the company is already onboarded.

## Why

Companies who are fully onboarded are still able to access the OSP summary form. 

```
OSP Registration form
- Redirect companies already fully onboarded back to portal home page [1608](https://github.com/eclipse-tractusx/portal-frontend/pull/1608)
```

## Issue

#1606 

## Checklist

- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

