### PR TITLE
fix: adjust row cell logic to work on all browsers

### DIFF
--- a/src/components/pages/CompanySubscriptions/index.tsx
+++ b/src/components/pages/CompanySubscriptions/index.tsx
@@ -200,12 +200,13 @@ export default function CompanySubscriptions() {
       <PageLoadingTable<SubscribedActiveApps, FetchHookArgsType>
         sx={{
           '.MuiDataGrid-cell': {
-            alignContent: 'center !important',
+            display: 'flex',
+            alignItems: 'center',
           },
         }}
         autoFocus={false}
         searchExpr={searchExpr}
-        alignCell="start"
+        alignCell="flex-start"
         defaultFilter={group}
         filterViews={filterView}
         toolbarVariant={'searchAndFilter'}


### PR DESCRIPTION
## Description

- Adjusted MUI table row center align logic

## Why

 The previous logic to center align row cell components does not work on every browser. Browsers such a Firefox and Chrome were not center aligning the cells where as Safari does. 
 
 ```
Company Subscription 
- Center align row cells with multi-browser friendly logic [1611](https://github.com/eclipse-tractusx/portal-frontend/pull/1611)
```

## Issue

[1598](https://github.com/eclipse-tractusx/portal-frontend/issues/1598)

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally

**Steps to reproduce**

- Open up to portal in Chrome & Firefox browsers
- Login as a company admin
- Navigate to the Company subscriptions page