### PR TITLE
fix: pull fresh technical user - own connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
   - fixed app roles display and text to accurate description in user list table in app user management [#1546](https://github.com/eclipse-tractusx/portal-frontend/pull/1546)
 - **App/Service Release Process**:
   - added missing translation for consent and terms step [#1557](https://github.com/eclipse-tractusx/portal-frontend/pull/1557)
+- **Connector Registration**:
+  - Fetch updated technical user list for new connector [1612](https://github.com/eclipse-tractusx/portal-frontend/pull/1612)
 
 ### Technical Support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,6 @@
   - fixed app roles display and text to accurate description in user list table in app user management [#1546](https://github.com/eclipse-tractusx/portal-frontend/pull/1546)
 - **App/Service Release Process**:
   - added missing translation for consent and terms step [#1557](https://github.com/eclipse-tractusx/portal-frontend/pull/1557)
-- **Connector Registration**:
-  - Fetch updated technical user list for new connector [1612](https://github.com/eclipse-tractusx/portal-frontend/pull/1612)
 
 ### Technical Support
 

--- a/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
+++ b/src/components/pages/EdcConnector/AddConnectorOverlay/index.tsx
@@ -101,7 +101,8 @@ const AddConnectorOverlay = ({
   const { data } = useFetchOfferSubscriptionsQuery()
   const { data: ownCompanyDetails } = useFetchOwnCompanyDetailsQuery('')
   const [page, setPage] = useState<number>(0)
-  const { data: serviceAccounts } = useFetchServiceAccountUsersQuery(page)
+  const { data: serviceAccounts, refetch } =
+    useFetchServiceAccountUsersQuery(page)
   const [newTechnicalUSer, setNewTechnicalUSer] = useState(false)
   const [allAccounts, setAllAccounts] = useState<ServiceAccountListEntry[]>([])
 
@@ -119,6 +120,17 @@ const AddConnectorOverlay = ({
   })
 
   const [selected, setSelected] = useState<ConnectorType>({})
+
+  useEffect(() => {
+    if (openDialog) {
+      setPage(0)
+      setAllAccounts([])
+    }
+  }, [openDialog, connectorStep])
+
+  useEffect(() => {
+    refetch()
+  }, [page, refetch])
 
   useEffect(() => {
     if (openDialog || connectorStep === 0) {


### PR DESCRIPTION
## Description
Once the technical user is assigned to any OWN connector then it the same technical user shouldn't be allowed to assigned to any other OWN connector until the connector gets deleted and user gets released.One technical user can only be assigned to one connector one at a time!

## Changelog
```
- **Connector Registration**:
  - Fetch updated technical user list for new connector [1612](https://github.com/eclipse-tractusx/portal-frontend/pull/1612)
```

## Why
we weren't fetching the fresh list of technical user after an assignment to connector and hence were missing the new updated list of technical user.

## Issue
https://github.com/eclipse-tractusx/portal-frontend/issues/1601

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally