### PR TITLE
fix: add missing user technical profiles

### DIFF
--- a/src/components/pages/AdminBoardDetail/BoardTechnicalUserSetup/index.tsx
+++ b/src/components/pages/AdminBoardDetail/BoardTechnicalUserSetup/index.tsx
@@ -57,7 +57,9 @@ export default function BoardTechnicalUserSetup({
         {t('content.adminboardDetail.technicalUserSetup.message')}
       </Typography>
       {item.technicalUserProfile &&
-        getTechnicalUserData(Object.values(item?.technicalUserProfile)[0])}
+        getTechnicalUserData(
+          Object.values(item?.technicalUserProfile).flat() as string[]
+        )}
     </>
   )
 }

--- a/src/components/pages/ServiceAdminBoardDetail/index.tsx
+++ b/src/components/pages/ServiceAdminBoardDetail/index.tsx
@@ -251,7 +251,7 @@ export default function ServiceAdminBoardDetail() {
 
           {serviceData.technicalUserProfile &&
             getTechUserData(
-              Object.values(serviceData?.technicalUserProfile)[0]
+              Object.values(serviceData.technicalUserProfile).flat() as string[]
             )}
 
           <div className="divider-height" />


### PR DESCRIPTION
## Description

 - Added logging to join all objects with an array to display all available user profiles for both app and service admin details.

## Why

- Only the first index of the user profile array was being displayed, although there can be one or multiple.

```
App & Service admin detail board
- Add missing user technical profiles on admin detail board [1615](https://github.com/eclipse-tractusx/portal-frontend/pull/1615)
```

## Issue

#1613
#1614  

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
