### PR TITLE
chore(cleanup): remove unused axios library from yarn.lock

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -30,7 +30,7 @@ npm/npmjs/-/array.prototype.flatmap/1.3.3, MIT, approved, #4651
 npm/npmjs/-/array.prototype.tosorted/1.1.4, MIT, approved, #5051
 npm/npmjs/-/arraybuffer.prototype.slice/1.0.3, MIT, approved, #9657
 npm/npmjs/-/arraybuffer.prototype.slice/1.0.4, MIT, approved, #9657
-npm/npmjs/-/asn1/0.2.6, MIT, approved, clearlydefined
+npm/npmjs/-/asn1/0.2.6, MIT, approved, #21125
 npm/npmjs/-/assert-plus/1.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/astral-regex/2.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/async/3.2.6, Apache-2.0 AND MIT, approved, #1553
@@ -41,7 +41,6 @@ npm/npmjs/-/autosuggest-highlight/3.3.4, MIT, approved, clearlydefined
 npm/npmjs/-/available-typed-arrays/1.0.7, MIT, approved, clearlydefined
 npm/npmjs/-/aws-sign2/0.7.0, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/aws4/1.13.2, MIT, approved, clearlydefined
-npm/npmjs/-/axios/1.8.4, MIT, approved, #19551
 npm/npmjs/-/babel-jest/29.7.0, MIT, approved, clearlydefined
 npm/npmjs/-/babel-plugin-istanbul/6.1.1, BSD-3-Clause, approved, clearlydefined
 npm/npmjs/-/babel-plugin-jest-hoist/29.6.3, MIT, approved, clearlydefined
@@ -151,7 +150,7 @@ npm/npmjs/-/dom-helpers/5.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/domexception/4.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/dot-case/3.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/dunder-proto/1.0.1, MIT, approved, #17824
-npm/npmjs/-/ecc-jsbn/0.1.2, , approved, #17389
+npm/npmjs/-/ecc-jsbn/0.1.2, MIT AND LicenseRef-MIT-style, approved, #17389
 npm/npmjs/-/ejs/3.1.10, Apache-2.0, approved, #1373
 npm/npmjs/-/electron-to-chromium/1.5.80, ISC, approved, #16451
 npm/npmjs/-/emittery/0.13.1, MIT, approved, clearlydefined
@@ -230,7 +229,6 @@ npm/npmjs/-/find-up/4.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/find-up/5.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/flat-cache/3.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/flatted/3.3.1, ISC AND (ISC AND MIT), approved, #13460
-npm/npmjs/-/follow-redirects/1.15.9, MIT, approved, #10782
 npm/npmjs/-/for-each/0.3.3, MIT, approved, clearlydefined
 npm/npmjs/-/forever-agent/0.6.1, Apache-2.0, approved, clearlydefined
 npm/npmjs/-/form-data/4.0.1, MIT, approved, clearlydefined
@@ -516,7 +514,6 @@ npm/npmjs/-/process/0.11.10, MIT, approved, CQ23452
 npm/npmjs/-/prompts/2.4.2, MIT, approved, clearlydefined
 npm/npmjs/-/prop-types/15.8.1, MIT, approved, clearlydefined
 npm/npmjs/-/proxy-from-env/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/proxy-from-env/1.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/psl/1.9.0, MIT AND CC0-1.0, approved, #3080
 npm/npmjs/-/pump/3.0.2, MIT, approved, clearlydefined
 npm/npmjs/-/punycode/2.3.1, MIT, approved, #6373

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,15 +2356,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@^1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
-  integrity sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -3948,11 +3939,6 @@ flatted@^3.2.9:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
-
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -6078,11 +6064,6 @@ proxy-from-env@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.9.0"


### PR DESCRIPTION
## Description

Remove axios library from yarn.lock and update DEPENDENCIES file.

## Why

PR [#1525](https://github.com/eclipse-tractusx/portal-frontend/pull/1525) did not removed axios library from yarn.lock even though it is not in use anymore.

## Issue

Caused by: [#1525](https://github.com/eclipse-tractusx/portal-frontend/pull/1525)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have checked that new and existing tests pass locally with my changes
