### PR TITLE
feat(App/Service Subscription): Ability to Decline the Subscription requests

### DIFF
--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1492,7 +1492,8 @@
         "authType": "Auth Type",
         "clientSercret": "Client Secret"
       }
-    },"appServiceSubscription": {
+    },
+    "appServiceSubscription": {
       "appsOffered": "Angebotene Apps",
       "subscriptions": "Abos"
     },
@@ -1516,17 +1517,20 @@
       "error": "Error",
       "success": "Aktivierung erfolgreich",
       "configuration": "Konfiguration erfolgreich",
-       "pending": "Abo ausstehend",
+      "pending": "Abo ausstehend",
       "active": "Abo aktiv",
-      "inactive": "Abo abbestellt","unsubscribed": "Abo abbestellt",
-      "process": "Abo in Bearbeitung", "offersHeading": "Angebotene Apps",
+      "inactive": "Abo abbestellt",
+      "unsubscribed": "Abo abbestellt",
+      "process": "Abo in Bearbeitung",
+      "offersHeading": "Angebotene Apps",
       "appSubscriptionHeading": "Abos",
       "tabs": {
         "request": "Request",
-        "active": "Active","inactive": "Abbestellt",
+        "active": "Active",
+        "inactive": "Abbestellt",
         "showAll": "Show All"
       },
-     "sortOptions": {
+      "sortOptions": {
         "customer": "Kunde A–Z",
         "offer": "Angebot A-Z",
         "apps": "Apps A–Z"
@@ -1592,11 +1596,12 @@
         "technicalClientId": "Technical User Client ID",
         "technicalSecret": "Technical User Secret",
         "technicalPermission": "Technical User Permission"
-      },"decline": {
+      },
+      "decline": {
         "heading": "{{subscriptionType}} Abonnement ablehnen?",
         "intro": "Für {{appName}}",
         "description": "{{companyName}} erhält eine E-Mail-Benachrichtigung mit der Option, die App erneut zu abonnieren.",
-        "success": "App Abonnement abgelehnt",
+        "success": "{{subscriptionType}} Abonnement abgelehnt",
         "cancelBtn": "Abbrechen",
         "declineBtn": "Ablehnen"
       },

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -2031,6 +2031,7 @@
       "description": "Verwalten und organisieren Sie Ihre Unternehmenszertifikate einfach und effizient. Diese Seite bietet eine benutzerfreundliche Oberfläche zum Anzeigen, Hinzufügen, Bearbeiten und Löschen von Unternehmenszertifikaten. Behalten Sie den Überblick über Ihren Zertifikatsverwaltungsprozess und stellen Sie mühelos die Einhaltung sicher.",
       "tabs": {
         "inactive": "Inactive",
+        "unsubscribed": "Abo abbestellt",
         "active": " Active",
         "all": "All certificates"
       },

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1524,6 +1524,7 @@
       "process": "Abo in Bearbeitung",
       "offersHeading": "Angebotene Apps",
       "appSubscriptionHeading": "Abos",
+      "loadMore": "Mehr laden",
       "tabs": {
         "request": "Request",
         "active": "Active",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1518,7 +1518,7 @@
       "configuration": "Konfiguration erfolgreich",
        "pending": "Abo ausstehend",
       "active": "Abo aktiv",
-      "inactive": "Abo abbestellt",
+      "inactive": "Abo abbestellt","unsubscribed": "Abo abbestellt",
       "process": "Abo in Bearbeitung", "offersHeading": "Angebotene Apps",
       "appSubscriptionHeading": "Abos",
       "tabs": {
@@ -1593,7 +1593,7 @@
         "technicalSecret": "Technical User Secret",
         "technicalPermission": "Technical User Permission"
       },"decline": {
-        "heading": "App Abonnement ablehnen?",
+        "heading": "{{subscriptionType}} Abonnement ablehnen?",
         "intro": "Für {{appName}}",
         "description": "{{companyName}} erhält eine E-Mail-Benachrichtigung mit der Option, die App erneut zu abonnieren.",
         "success": "App Abonnement abgelehnt",

--- a/src/assets/locales/de/main.json
+++ b/src/assets/locales/de/main.json
@@ -1492,6 +1492,9 @@
         "authType": "Auth Type",
         "clientSercret": "Client Secret"
       }
+    },"appServiceSubscription": {
+      "appsOffered": "Angebotene Apps",
+      "subscriptions": "Abos"
     },
     "appSubscription": {
       "headline": "App Subscription",
@@ -1506,25 +1509,27 @@
       "newServices": "New Services",
       "recommendations": "Recommendations",
       "allServices": "All Services",
-      "viewDetails": "Display more details",
+      "viewDetails": "Details anzeigen",
       "activateBtn": "Aktivieren",
       "configureBtn": "Konfigurieren",
       "pleaseEnterValidURL": "Please enter a valid URL",
       "error": "Error",
       "success": "Aktivierung erfolgreich",
       "configuration": "Konfiguration erfolgreich",
-      "pending": "Das Abonnement steht noch aus",
-      "active": "Das Abonnement ist aktiv",
-      "inactive": "Das Abonnement ist inaktiv",
-      "process": "Das Abonnement ist in Bearbeitung",
+       "pending": "Abo ausstehend",
+      "active": "Abo aktiv",
+      "inactive": "Abo abbestellt",
+      "process": "Abo in Bearbeitung", "offersHeading": "Angebotene Apps",
+      "appSubscriptionHeading": "Abos",
       "tabs": {
         "request": "Request",
-        "active": "Active",
+        "active": "Active","inactive": "Abbestellt",
         "showAll": "Show All"
       },
-      "sortOptions": {
-        "customer": "By Customer A-Z",
-        "offer": "By Offer"
+     "sortOptions": {
+        "customer": "Kunde A–Z",
+        "offer": "Angebot A-Z",
+        "apps": "Apps A–Z"
       },
       "document": {
         "heading": "Relevant Documents",
@@ -1587,6 +1592,13 @@
         "technicalClientId": "Technical User Client ID",
         "technicalSecret": "Technical User Secret",
         "technicalPermission": "Technical User Permission"
+      },"decline": {
+        "heading": "App Abonnement ablehnen?",
+        "intro": "Für {{appName}}",
+        "description": "{{companyName}} erhält eine E-Mail-Benachrichtigung mit der Option, die App erneut zu abonnieren.",
+        "success": "App Abonnement abgelehnt",
+        "cancelBtn": "Abbrechen",
+        "declineBtn": "Ablehnen"
       },
       "detailOverlay": {
         "title": "Provider View",

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -166,13 +166,13 @@
     "activateBtn": "Activate",
     "pleaseEnterValidURL": "Please enter a valid URL",
     "tabs": {
-       "request": "Anfragen",
+      "request": "Anfragen",
       "active": "Aktiv",
       "inactive": "Abbestellt",
       "showAll": "Alle"
     },
     "sortOptions": {
-     "customer": "Kunde A–Z",
+      "customer": "Kunde A–Z",
       "offer": "Angebot A-Z",
       "apps": "Apps A–Z"
     },

--- a/src/assets/locales/de/servicerelease.json
+++ b/src/assets/locales/de/servicerelease.json
@@ -166,13 +166,15 @@
     "activateBtn": "Activate",
     "pleaseEnterValidURL": "Please enter a valid URL",
     "tabs": {
-      "request": "Request",
-      "active": "Active",
-      "showAll": "Show All"
+       "request": "Anfragen",
+      "active": "Aktiv",
+      "inactive": "Abbestellt",
+      "showAll": "Alle"
     },
     "sortOptions": {
-      "customer": "By Customer A-Z",
-      "offer": "By Offer"
+     "customer": "Kunde A–Z",
+      "offer": "Angebot A-Z",
+      "apps": "Apps A–Z"
     },
     "document": {
       "heading": "Relevant Documents",
@@ -206,7 +208,9 @@
       "technicaluserType": "Assigned Permissions:",
       "close": "Close"
     },
-    "offersHeading": "Services Offered",
+    "offersHeading": "Angebotene Services",
+    "serviceSubscriptionHeading": "Abos",
+    "loadMore": "Mehr laden",
     "success": "Aktivierung erfolgreich",
     "configuration": "Konfiguration erfolgreich",
     "failure": "Fehler bei der Konfiguration des Service Abonnements"

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1523,6 +1523,8 @@
       "inactive": "Inactive",
       "unsubscribed": "Unsubscribed",
       "process": "Subscription in progress",
+      "offersHeading": "Apps Offered",
+      "appSubscriptionHeading": "Subscriptions",
       "tabs": {
         "request": "Request",
         "active": "Active",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1518,7 +1518,7 @@
       "configuration": "Configuration successful",
     "pending": "Subscription pending",
       "active": "Subscription active",
-      "inactive": "Inactive",
+      "inactive": "Inactive", "unsubscribed": "Unsubscribed",
       "process": "Subscription in progress",
       "tabs": {
         "request": "Request",
@@ -1591,7 +1591,7 @@
         "technicalSecret": "Technical User Secret",
         "technicalPermission": "Technical User Permission"
       }, "decline": {
-        "heading": "Decline app subscription?",
+      "heading": "Decline {{subscriptionType}} subscription?",
         "intro": "For {{appName}}",
         "description": "{{companyName}} receives an e-mail notification with the option to re-subscribe again.",
         "success": "App subscription declined",
@@ -2024,7 +2024,7 @@
       "description": "Efficiently manage and organize your company certificates with ease. This page provides a user-friendly interface to view, add, edit, and delete company certificates. Stay on top of your certificate management process and ensure compliance effortlessly.",
       "tabs": {
         "inactive": "Inactive",
-        "active": " Active",
+        "active": " Active","unsubscribed": "Unsubscribed",
         "all": "All certificates"
       },
       "sort": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1492,6 +1492,9 @@
         "authType": "Auth Type",
         "clientSercret": "Client Secret"
       }
+    }, "appServiceSubscription": {
+      "appsOffered": "Apps Offered",
+      "subscriptions": "Subscriptions"
     },
     "appSubscription": {
       "headline": "App Subscription",
@@ -1508,15 +1511,15 @@
       "allServices": "All Services",
       "viewDetails": "Display more details",
       "activateBtn": "Activate",
-      "configureBtn": "Configure",
+      "configureBtn": "Configure","declineBtn": "Decline",
       "pleaseEnterValidURL": "Please enter a valid URL",
       "error": "Error",
       "success": "Activation successful",
       "configuration": "Configuration successful",
-      "pending": "Subscription is Pending",
-      "active": "Subscription is Active",
-      "inactive": "Subscription is Inactive",
-      "process": "Subscription is in Progress",
+    "pending": "Subscription pending",
+      "active": "Subscription active",
+      "inactive": "Inactive",
+      "process": "Subscription in progress",
       "tabs": {
         "request": "Request",
         "active": "Active",
@@ -1587,6 +1590,13 @@
         "technicalClientId": "Technical User Client ID",
         "technicalSecret": "Technical User Secret",
         "technicalPermission": "Technical User Permission"
+      }, "decline": {
+        "heading": "Decline app subscription?",
+        "intro": "For {{appName}}",
+        "description": "{{companyName}} receives an e-mail notification with the option to re-subscribe again.",
+        "success": "App subscription declined",
+        "cancelBtn": "Cancel",
+        "declineBtn": "Decline"
       },
       "detailOverlay": {
         "title": "Provider View",

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1492,7 +1492,8 @@
         "authType": "Auth Type",
         "clientSercret": "Client Secret"
       }
-    }, "appServiceSubscription": {
+    },
+    "appServiceSubscription": {
       "appsOffered": "Apps Offered",
       "subscriptions": "Subscriptions"
     },
@@ -1511,14 +1512,16 @@
       "allServices": "All Services",
       "viewDetails": "Display more details",
       "activateBtn": "Activate",
-      "configureBtn": "Configure","declineBtn": "Decline",
+      "configureBtn": "Configure",
+      "declineBtn": "Decline",
       "pleaseEnterValidURL": "Please enter a valid URL",
       "error": "Error",
       "success": "Activation successful",
       "configuration": "Configuration successful",
-    "pending": "Subscription pending",
+      "pending": "Subscription pending",
       "active": "Subscription active",
-      "inactive": "Inactive", "unsubscribed": "Unsubscribed",
+      "inactive": "Inactive",
+      "unsubscribed": "Unsubscribed",
       "process": "Subscription in progress",
       "tabs": {
         "request": "Request",
@@ -1590,11 +1593,12 @@
         "technicalClientId": "Technical User Client ID",
         "technicalSecret": "Technical User Secret",
         "technicalPermission": "Technical User Permission"
-      }, "decline": {
-      "heading": "Decline {{subscriptionType}} subscription?",
+      },
+      "decline": {
+        "heading": "Decline {{subscriptionType}} subscription?",
         "intro": "For {{appName}}",
         "description": "{{companyName}} receives an e-mail notification with the option to re-subscribe again.",
-        "success": "App subscription declined",
+        "success": "{{subscriptionType}} subscription declined",
         "cancelBtn": "Cancel",
         "declineBtn": "Decline"
       },
@@ -2024,7 +2028,8 @@
       "description": "Efficiently manage and organize your company certificates with ease. This page provides a user-friendly interface to view, add, edit, and delete company certificates. Stay on top of your certificate management process and ensure compliance effortlessly.",
       "tabs": {
         "inactive": "Inactive",
-        "active": " Active","unsubscribed": "Unsubscribed",
+        "active": " Active",
+        "unsubscribed": "Unsubscribed",
         "all": "All certificates"
       },
       "sort": {

--- a/src/assets/locales/en/main.json
+++ b/src/assets/locales/en/main.json
@@ -1525,6 +1525,7 @@
       "process": "Subscription in progress",
       "offersHeading": "Apps Offered",
       "appSubscriptionHeading": "Subscriptions",
+      "loadMore": "Load more",
       "tabs": {
         "request": "Request",
         "active": "Active",

--- a/src/assets/locales/en/servicerelease.json
+++ b/src/assets/locales/en/servicerelease.json
@@ -167,13 +167,14 @@
     "pleaseEnterValidURL": "Please enter a valid URL",
     "tabs": {
       "request": "Request",
-      "active": "Active",        "inactive": "Unsubscribed",
+      "active": "Active",
+      "inactive": "Unsubscribed",
       "showAll": "Show All"
     },
     "sortOptions": {
-    "customer": "Customer A–Z",
-        "offer": "Offer",
-        "apps": "Apps A–Z"
+      "customer": "Customer A–Z",
+      "offer": "Offer",
+      "apps": "Apps A–Z"
     },
     "document": {
       "heading": "Relevant Documents",
@@ -207,9 +208,10 @@
       "technicaluserType": "Assigned Permissions:",
       "close": "Close"
     },
-          "offersHeading": "Services Offered",
+    "offersHeading": "Services Offered",
     "serviceSubscriptionHeading": "Subscriptions",
-    "loadMore": "Load More", "success": "Activation successful",
+    "loadMore": "Load More",
+    "success": "Activation successful",
     "configuration": "Configuration successful",
     "failure": "Error while configuring service subscription"
   },

--- a/src/assets/locales/en/servicerelease.json
+++ b/src/assets/locales/en/servicerelease.json
@@ -167,12 +167,13 @@
     "pleaseEnterValidURL": "Please enter a valid URL",
     "tabs": {
       "request": "Request",
-      "active": "Active",
+      "active": "Active",        "inactive": "Unsubscribed",
       "showAll": "Show All"
     },
     "sortOptions": {
-      "customer": "By Customer A-Z",
-      "offer": "By Offer"
+    "customer": "Customer A–Z",
+        "offer": "Offer",
+        "apps": "Apps A–Z"
     },
     "document": {
       "heading": "Relevant Documents",
@@ -206,8 +207,9 @@
       "technicaluserType": "Assigned Permissions:",
       "close": "Close"
     },
-    "offersHeading": "Services Offered",
-    "success": "Activation successful",
+          "offersHeading": "Services Offered",
+    "serviceSubscriptionHeading": "Subscriptions",
+    "loadMore": "Load More", "success": "Activation successful",
     "configuration": "Configuration successful",
     "failure": "Error while configuring service subscription"
   },

--- a/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
@@ -72,7 +72,12 @@ const DeclineSubscriptionOverlay = ({
         await declineServiceSubscription(subscriptionId).unwrap()
       }
       declineSubscriptionAction(subscriptionId)
-      success(t('content.appSubscription.decline.success'))
+      success(
+        t('content.appSubscription.decline.success').replace(
+          '{{subscriptionType}}',
+          capitalize(subscriptionType)
+        )
+      )
     } catch (err) {
       error(t('content.appSubscription.error'), '', err as object)
     } finally {

--- a/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
@@ -29,7 +29,7 @@ import {
 } from '@catena-x/portal-shared-components'
 import { useTranslation, Trans } from 'react-i18next'
 import { useDeclineAppSubscriptionMutation } from 'features/appSubscription/appSubscriptionApiSlice'
-import { useDeclineServiceSubscriptionMutation } from 'features/admin/serviceApiSlice'
+import { useDeclineServiceSubscriptionMutation } from 'features/serviceSubscription/serviceSubscriptionApiSlice'
 import { useState } from 'react'
 import './style.scss'
 import { success, error } from 'services/NotifyService'
@@ -44,6 +44,7 @@ interface DeclineSubscriptionProps {
   subscriptionType: string
   handleOverlayClose: () => void
   refetch?: () => void
+  declineSubscriptionAction: (subscriptionId: string) => void
 }
 
 const DeclineSubscriptionOverlay = ({
@@ -51,9 +52,9 @@ const DeclineSubscriptionOverlay = ({
   subscriptionId,
   title,
   appName,
-  subscriptionType,
+  subscriptionType = SubscriptionTypes.APP_SUBSCRIPTION,
   handleOverlayClose,
-  refetch,
+  declineSubscriptionAction,
 }: DeclineSubscriptionProps) => {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
@@ -69,8 +70,8 @@ const DeclineSubscriptionOverlay = ({
       } else {
         await declineServiceSubscription(subscriptionId).unwrap()
       }
+      declineSubscriptionAction(subscriptionId)
       success(t('content.appSubscription.decline.success'))
-      if (refetch) refetch() // Call refetch after success
     } catch (err) {
       error(t('content.appSubscription.error'), '', err as object)
     } finally {
@@ -78,7 +79,6 @@ const DeclineSubscriptionOverlay = ({
       handleOverlayClose()
     }
   }
-
   return (
     <Dialog
       open={openDialog}

--- a/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
@@ -1,0 +1,150 @@
+/********************************************************************************
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogHeader,
+  LoadingButton,
+  Typography,
+} from '@catena-x/portal-shared-components'
+import { useTranslation, Trans } from 'react-i18next'
+import { useDeclineAppSubscriptionMutation } from 'features/appSubscription/appSubscriptionApiSlice'
+import { useDeclineServiceSubscriptionMutation } from 'features/admin/serviceApiSlice'
+import { useState } from 'react'
+import './style.scss'
+import { success, error } from 'services/NotifyService'
+import { SubscriptionTypes } from 'components/shared/templates/Subscription'
+
+interface DeclineSubscriptionProps {
+  openDialog: boolean
+  appId: string
+  subscriptionId: string
+  title: string
+  appName: string
+  subscriptionType: string
+  handleOverlayClose: () => void
+  refetch?: () => void
+}
+
+const DeclineSubscriptionOverlay = ({
+  openDialog = false,
+  subscriptionId,
+  title,
+  appName,
+  subscriptionType,
+  handleOverlayClose,
+  refetch,
+}: DeclineSubscriptionProps) => {
+  const { t } = useTranslation()
+  const [loading, setLoading] = useState(false)
+
+  const [declineAppSubscription] = useDeclineAppSubscriptionMutation()
+  const [declineServiceSubscription] = useDeclineServiceSubscriptionMutation()
+
+  const handleDecline = async (subscriptionId: string) => {
+    setLoading(true)
+    try {
+      if (subscriptionType === SubscriptionTypes.APP_SUBSCRIPTION) {
+        await declineAppSubscription(subscriptionId).unwrap()
+      } else {
+        await declineServiceSubscription(subscriptionId).unwrap()
+      }
+      success(t('content.appSubscription.decline.success'))
+      if (refetch) refetch() // Call refetch after success
+    } catch (err) {
+      error(t('content.appSubscription.error'), '', err as object)
+    } finally {
+      setLoading(false)
+      handleOverlayClose()
+    }
+  }
+
+  return (
+    <Dialog
+      open={openDialog}
+      sx={{
+        '.MuiDialog-paper': {
+          maxWidth: '45%',
+          width: '400px',
+        },
+      }}
+    >
+      <DialogHeader
+        title={t('content.appSubscription.decline.heading')}
+        intro={t('content.appSubscription.decline.intro').replace(
+          '{{appName}}',
+          appName
+        )}
+        closeWithIcon={false}
+      />
+      <DialogContent>
+        <div className="appSubscriptionMain">
+          <Trans
+            values={{
+              companyName: title,
+            }}
+          >
+            <Typography variant="body2">
+              {t('content.appSubscription.decline.description')}
+            </Typography>
+          </Trans>
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button
+          variant="outlined"
+          onClick={() => {
+            handleOverlayClose()
+          }}
+        >
+          {t('content.appSubscription.decline.cancelBtn')}
+        </Button>
+        {loading ? (
+          <LoadingButton
+            color="primary"
+            helperText=""
+            helperTextColor="success"
+            label=""
+            loadIndicator="Loading ..."
+            loading
+            size="medium"
+            onButtonClick={() => {
+              // do nothing
+            }}
+            sx={{ marginLeft: '10px' }}
+          />
+        ) : (
+          <Button
+            className="cx-decline-btn"
+            variant="contained"
+            onClick={() => handleDecline(subscriptionId)}
+          >
+            {t('content.appSubscription.decline.declineBtn')}
+          </Button>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default DeclineSubscriptionOverlay

--- a/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
+++ b/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/index.tsx
@@ -34,6 +34,7 @@ import { useState } from 'react'
 import './style.scss'
 import { success, error } from 'services/NotifyService'
 import { SubscriptionTypes } from 'components/shared/templates/Subscription'
+import { capitalize } from 'components/shared/cfx/generic'
 
 interface DeclineSubscriptionProps {
   openDialog: boolean
@@ -52,7 +53,7 @@ const DeclineSubscriptionOverlay = ({
   subscriptionId,
   title,
   appName,
-  subscriptionType = SubscriptionTypes.APP_SUBSCRIPTION,
+  subscriptionType,
   handleOverlayClose,
   declineSubscriptionAction,
 }: DeclineSubscriptionProps) => {
@@ -90,7 +91,10 @@ const DeclineSubscriptionOverlay = ({
       }}
     >
       <DialogHeader
-        title={t('content.appSubscription.decline.heading')}
+        title={t('content.appSubscription.decline.heading').replace(
+          '{{subscriptionType}}',
+          capitalize(subscriptionType)
+        )}
         intro={t('content.appSubscription.decline.intro').replace(
           '{{appName}}',
           appName

--- a/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/style.scss
+++ b/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/style.scss
@@ -1,0 +1,79 @@
+/********************************************************************************
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+.appSubscriptionMain {
+  padding-left: 10px;
+  text-align: center !important;
+  ol {
+    color: #888888;
+    margin-top: 30px;
+  }
+  .errorMsg {
+    color: #e43333;
+  }
+  .mt-30 {
+    margin-top: 30px;
+  }
+  .addTentalURLHeading {
+    margin: 30px 0 20px;
+  }
+  .helpText {
+    display: flex;
+    color: #0d55af;
+    margin-top: 30px;
+    text-decoration: none;
+    svg {
+      font-size: 20px;
+    }
+  }
+  .technicalUserProfile {
+    margin: 30px auto;
+  }
+}
+
+.activationOverlay {
+  p {
+    font-weight: 600;
+  }
+}
+
+.activationResponse {
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  border-collapse: collapse;
+
+  tr td {
+    border-top: 1px solid rgb(220, 220, 220);
+    padding: 10px;
+  }
+
+  tr:first-of-type td {
+    border: none;
+  }
+}
+.actions-main {
+  .cx-decline-btn {
+    background-color: #b62100;
+    &:hover {
+      background-color: #6d1400;
+    }
+  }
+}

--- a/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/style.scss
+++ b/src/components/pages/AppSubscription/DeclineSubscriptionOverlay/style.scss
@@ -71,9 +71,9 @@
 }
 .actions-main {
   .cx-decline-btn {
-    background-color: #b62100;
+    background-color: #0f71cb;
     &:hover {
-      background-color: #6d1400;
+      background-color: #2962ba;
     }
   }
 }

--- a/src/components/pages/AppSubscription/index.tsx
+++ b/src/components/pages/AppSubscription/index.tsx
@@ -44,12 +44,13 @@ export default function AppSubscription() {
       searchPlaceHoder={t('content.appSubscription.search')}
       sortOptionLabels={{
         customer: t('content.appSubscription.sortOptions.customer'),
-        offer: t('content.appSubscription.sortOptions.offer'),
+        offer: t('content.appSubscription.sortOptions.apps'),
       }}
       tabLabels={{
         request: t('content.appSubscription.tabs.request'),
         active: t('content.appSubscription.tabs.active'),
         showAll: t('content.appSubscription.tabs.showAll'),
+        inactive: t('content.appSubscription.tabs.inactive'),
       }}
     />
   )

--- a/src/components/pages/AppSubscription/index.tsx
+++ b/src/components/pages/AppSubscription/index.tsx
@@ -52,6 +52,9 @@ export default function AppSubscription() {
         showAll: t('content.appSubscription.tabs.showAll'),
         inactive: t('content.appSubscription.tabs.inactive'),
       }}
+      activeAppHeading={t('content.appSubscription.offersHeading')}
+      subscriptionHeading={t('content.appSubscription.appSubscriptionHeading')}
+      loadMoreButtonText={t('content.appSubscription.loadMore')}
     />
   )
 }

--- a/src/components/pages/ServiceSubscription/index.tsx
+++ b/src/components/pages/ServiceSubscription/index.tsx
@@ -46,12 +46,13 @@ export default function ServiceSubscription() {
       searchPlaceHoder={t('serviceSubscription.search')}
       sortOptionLabels={{
         customer: t('serviceSubscription.sortOptions.customer'),
-        offer: t('serviceSubscription.sortOptions.offer'),
+        offer: t('serviceSubscription.sortOptions.apps'),
       }}
       tabLabels={{
         request: t('serviceSubscription.tabs.request'),
         active: t('serviceSubscription.tabs.active'),
         showAll: t('serviceSubscription.tabs.showAll'),
+        inactive: t('serviceSubscription.tabs.inactive'),
       }}
       doNotShowAutoSetup={true}
       type={SubscriptionTypes.SERVICE_SUBSCRIPTION}

--- a/src/components/pages/ServiceSubscription/index.tsx
+++ b/src/components/pages/ServiceSubscription/index.tsx
@@ -57,6 +57,8 @@ export default function ServiceSubscription() {
       doNotShowAutoSetup={true}
       type={SubscriptionTypes.SERVICE_SUBSCRIPTION}
       activeAppHeading={t('serviceSubscription.offersHeading')}
+      subscriptionHeading={t('serviceSubscription.serviceSubscriptionHeading')}
+      loadMoreButtonText={t('serviceSubscription.loadMore')}
     />
   )
 }

--- a/src/components/shared/cfx/generic.ts
+++ b/src/components/shared/cfx/generic.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2023 BMW Group AG
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+export const capitalize = (str: string) => {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
+}

--- a/src/components/shared/templates/Subscription/SubscriptionElements.tsx
+++ b/src/components/shared/templates/Subscription/SubscriptionElements.tsx
@@ -137,12 +137,14 @@ export default function SubscriptionElements({
   refetch,
   isSuccess,
   subscriptionHeading,
+  declineSubscription,
 }: {
   subscriptions?: SubscriptionContent[]
   type: string
   refetch: () => void
   isSuccess: boolean
   subscriptionHeading: string
+  declineSubscription: (subscriptionId: string) => void
 }) {
   const theme = useTheme()
   const { t } = useTranslation()
@@ -277,7 +279,9 @@ export default function SubscriptionElements({
               label={t('content.appSubscription.activateBtn')}
               type="plain"
               variant="filled"
-              onClick={() => handleActivate(subscription.subscriptionId)}
+              onClick={() => {
+                handleActivate(subscription.subscriptionId)
+              }}
             />
             <Tooltips
               color="dark"
@@ -422,11 +426,11 @@ export default function SubscriptionElements({
           title={subscriptionDecline.companyName}
           handleOverlayClose={() => {
             setSubscriptionDecline(SubscriptionInitialData)
-            refetch()
           }}
           refetch={refetch}
           appName={subscriptionDecline.title}
           subscriptionType={type ?? SubscriptionTypes.APP_SUBSCRIPTION}
+          declineSubscriptionAction={declineSubscription}
         />
       )}
     </div>

--- a/src/components/shared/templates/Subscription/SubscriptionElements.tsx
+++ b/src/components/shared/templates/Subscription/SubscriptionElements.tsx
@@ -43,10 +43,12 @@ import { useState, useReducer } from 'react'
 import { SubscriptionStatus } from 'features/apps/types'
 import ActivateServiceSubscription from 'components/overlays/ActivateServiceSubscription'
 import { SubscriptionTypes } from '.'
-import { getAssetBase } from 'services/EnvironmentService'
-import AddTaskIcon from '@mui/icons-material/AddTask'
+import AddTaskIcon from '@mui/icons-material/CheckCircleOutlineOutlined'
 import HistoryIcon from '@mui/icons-material/History'
+import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined'
+import PublishedWithChangesOutlinedIcon from '@mui/icons-material/PublishedWithChangesOutlined'
 import { error, success } from 'services/NotifyService'
+import DeclineSubscriptionOverlay from 'components/pages/AppSubscription/DeclineSubscriptionOverlay'
 
 type ViewDetail = {
   appId: string
@@ -150,6 +152,8 @@ export default function SubscriptionElements({
   const [viewDetails, setViewDetails] = useState<ViewDetail>(ViewDetailData)
   const [subscriptionDetail, setSubscriptionDetail] =
     useState<SubscriptionDataType>(SubscriptionInitialData)
+  const [subscriptionDecline, setSubscriptionDecline] =
+    useState<SubscriptionDataType>(SubscriptionInitialData)
 
   const [activateSubscription] = useActivateSubscriptionMutation()
 
@@ -176,7 +180,6 @@ export default function SubscriptionElements({
       />
     )
   }
-
   const renderStatus = (
     subscriptionData: SubscriptionContent,
     subscription: CompanySubscriptionData
@@ -200,7 +203,7 @@ export default function SubscriptionElements({
           tooltipPlacement="top-start"
           tooltipText={t('content.appSubscription.inactive')}
         >
-          <HistoryIcon className="statusIcon inactive" />
+          <CancelOutlinedIcon className="statusIcon inactive" />
         </Tooltips>
       )
     } else if (
@@ -212,6 +215,23 @@ export default function SubscriptionElements({
         return (
           <>
             <Chip
+              className="cx-chip-decline"
+              color="primary"
+              label={t('content.appSubscription.declineBtn')}
+              type="plain"
+              variant="filled"
+              onClick={() => {
+                setSubscriptionDecline({
+                  appId: subscriptionData.offerId,
+                  subscriptionId: subscription.subscriptionId,
+                  title: subscriptionData.offerName,
+                  companyName: subscription.companyName,
+                  bpnNumber: subscription.bpnNumber,
+                })
+              }}
+            />
+            <Chip
+              className="cx-chip-configure"
               color="primary"
               label={t('content.appSubscription.configureBtn')}
               type="plain"
@@ -278,11 +298,7 @@ export default function SubscriptionElements({
             tooltipPlacement="top-start"
             tooltipText={t('content.appSubscription.process')}
           >
-            <img
-              src={`${getAssetBase()}/images/icons/process.svg`}
-              className="statusIcon"
-              alt="subscription process"
-            />
+            <PublishedWithChangesOutlinedIcon className="statusIcon process" />
           </Tooltips>
         )
       }
@@ -316,6 +332,10 @@ export default function SubscriptionElements({
                     <Typography variant="body3" className="secondSection">
                       {subscriptionData.offerName}
                     </Typography>
+
+                    <div className="forthSection">
+                      {renderStatus(subscriptionData, subscription)}
+                    </div>
                     <div
                       className="viewDetails"
                       onClick={() => {
@@ -337,9 +357,6 @@ export default function SubscriptionElements({
                           <ArrowForwardIcon />
                         </Tooltips>
                       </IconButton>
-                    </div>
-                    <div className="forthSection">
-                      {renderStatus(subscriptionData, subscription)}
                     </div>
                   </li>
                 )
@@ -395,6 +412,21 @@ export default function SubscriptionElements({
             setSubscriptionDetail(SubscriptionInitialData)
             refetch()
           }}
+        />
+      )}
+      {subscriptionDecline.appId && (
+        <DeclineSubscriptionOverlay
+          openDialog={subscriptionDecline.appId ? true : false}
+          appId={subscriptionDecline.appId}
+          subscriptionId={subscriptionDecline.subscriptionId}
+          title={subscriptionDecline.companyName}
+          handleOverlayClose={() => {
+            setSubscriptionDecline(SubscriptionInitialData)
+            refetch()
+          }}
+          refetch={refetch}
+          appName={subscriptionDecline.title}
+          subscriptionType={type ?? SubscriptionTypes.APP_SUBSCRIPTION}
         />
       )}
     </div>

--- a/src/components/shared/templates/Subscription/SubscriptionElements.tsx
+++ b/src/components/shared/templates/Subscription/SubscriptionElements.tsx
@@ -203,9 +203,9 @@ export default function SubscriptionElements({
         <Tooltips
           color="dark"
           tooltipPlacement="top-start"
-          tooltipText={t('content.appSubscription.inactive')}
+          tooltipText={t('content.appSubscription.unsubscribed')}
         >
-          <CancelOutlinedIcon className="statusIcon inactive" />
+          <CancelOutlinedIcon className="statusIcon inactive unsubscribed" />
         </Tooltips>
       )
     } else if (

--- a/src/components/shared/templates/Subscription/index.tsx
+++ b/src/components/shared/templates/Subscription/index.tsx
@@ -55,11 +55,13 @@ enum FilterType {
   REQUEST = 'request',
   ACTIVE = 'active',
   SHOWALL = 'showAll',
+  INACTIVE = 'inactive',
 }
 
 enum StatusIdType {
   PENDING = 'PENDING',
   ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
 }
 
 enum SortType {
@@ -260,6 +262,7 @@ interface SubscriptionType {
   tabLabels: {
     request: string
     active: string
+    inactive: string
     showAll: string
   }
   doNotShowAutoSetup?: boolean
@@ -348,6 +351,8 @@ export default function Subscription({
       status = StatusIdType.PENDING
     } else if (e.currentTarget.value === FilterType.ACTIVE) {
       status = StatusIdType.ACTIVE
+    } else if (e.currentTarget.value === FilterType.INACTIVE) {
+      status = StatusIdType.INACTIVE
     }
     setState({
       type: ActionKind.SET_SORTING_TYPE,

--- a/src/components/shared/templates/Subscription/style.scss
+++ b/src/components/shared/templates/Subscription/style.scss
@@ -108,6 +108,7 @@
     align-items: center;
     margin-top: 30px;
     margin-bottom: 60px;
+    position: relative;
   }
 
   .filterSection .chipContainer {
@@ -121,12 +122,15 @@
     margin-top: 30px;
     margin-bottom: 60px;
     cursor: pointer;
+
     :hover {
       box-shadow: 0px 10px 20px rgb(80 80 80 / 30%);
     }
+
     .activeFilter {
       border: 1px solid #0f71cb !important;
     }
+
     .appName {
       margin: 0 15px 15px 0;
       padding: 10px 28px;
@@ -137,8 +141,8 @@
 
   .sortSection {
     position: absolute;
-    left: 56%;
-    margin-top: 6%;
+    right: 0;
+    margin-top: 150px;
     background: #f9f9f9;
     box-shadow: 0px 10px 20px rgb(80 80 80 / 30%);
     border-radius: 16px;
@@ -209,19 +213,40 @@
           border-radius: 15px;
           padding: 5px;
         }
+
+        .MuiButtonBase-root.MuiChip-root {
+          padding: 0 10px;
+
+          &.cx-chip-configure {
+            background-color: #4d4d4d;
+          }
+
+          &.cx-chip-decline {
+            background-color: #b62100;
+          }
+        }
+
         .statusIcon {
           height: 30px;
           float: right;
         }
+
         .active {
           color: #5bb52e;
         }
+
         .inactive {
           color: #c20909;
         }
+
         .pending {
           color: #989898;
         }
+
+        .process {
+          color: #f58220;
+        }
+
         .statusErrorIcon {
           color: #c20909;
           font-style: italic;

--- a/src/components/shared/templates/Subscription/style.scss
+++ b/src/components/shared/templates/Subscription/style.scss
@@ -195,7 +195,8 @@
       }
 
       .viewDetails {
-        width: 15%;
+            width: 25px;
+    margin: 0 0 0 10px;
       }
 
       .thirdSection {
@@ -206,8 +207,12 @@
       }
 
       .forthSection {
-        width: 15%;
-        display: block;
+            width: 27%;
+    display: flex
+;
+    justify-content: flex-end;
+    gap: 10px;
+    align-items: center;
         button {
           width: 50%;
           border-radius: 15px;
@@ -222,7 +227,7 @@
           }
 
           &.cx-chip-decline {
-            background-color: #b62100;
+            background-color: #0f71cb;
           }
         }
 

--- a/src/components/shared/templates/Subscription/style.scss
+++ b/src/components/shared/templates/Subscription/style.scss
@@ -195,8 +195,8 @@
       }
 
       .viewDetails {
-            width: 25px;
-    margin: 0 0 0 10px;
+        width: 25px;
+        margin: 0 0 0 10px;
       }
 
       .thirdSection {
@@ -207,12 +207,11 @@
       }
 
       .forthSection {
-            width: 27%;
-    display: flex
-;
-    justify-content: flex-end;
-    gap: 10px;
-    align-items: center;
+        width: 27%;
+        display: flex;
+        justify-content: flex-end;
+        gap: 10px;
+        align-items: center;
         button {
           width: 50%;
           border-radius: 15px;

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -190,6 +190,12 @@ export const apiSlice = createApi({
       query: (page) =>
         `/api/administration/serviceaccount/owncompany/serviceaccounts?page=${page}&size=${PAGE_SIZE}&filterForInactive=false&userStatus=ACTIVE`,
     }),
+    declineServiceSubscription: builder.mutation<void, string>({
+      query: (subscriptionId) => ({
+        url: `/api/services/subscription/${subscriptionId}/decline`,
+        method: 'PUT',
+      }),
+    }),
   }),
 })
 
@@ -201,4 +207,5 @@ export const {
   useFetchServiceAccountRolesQuery,
   useResetCredentialMutation,
   useFetchServiceAccountUsersQuery,
+  useDeclineServiceSubscriptionMutation,
 } = apiSlice

--- a/src/features/admin/serviceApiSlice.ts
+++ b/src/features/admin/serviceApiSlice.ts
@@ -190,12 +190,6 @@ export const apiSlice = createApi({
       query: (page) =>
         `/api/administration/serviceaccount/owncompany/serviceaccounts?page=${page}&size=${PAGE_SIZE}&filterForInactive=false&userStatus=ACTIVE`,
     }),
-    declineServiceSubscription: builder.mutation<void, string>({
-      query: (subscriptionId) => ({
-        url: `/api/services/subscription/${subscriptionId}/decline`,
-        method: 'PUT',
-      }),
-    }),
   }),
 })
 
@@ -207,5 +201,4 @@ export const {
   useFetchServiceAccountRolesQuery,
   useResetCredentialMutation,
   useFetchServiceAccountUsersQuery,
-  useDeclineServiceSubscriptionMutation,
 } = apiSlice

--- a/src/features/appSubscription/appSubscriptionApiSlice.ts
+++ b/src/features/appSubscription/appSubscriptionApiSlice.ts
@@ -188,6 +188,7 @@ export const apiSlice = createApi({
         body: data,
       }),
     }),
+
     updateTenantUrl: builder.mutation<void, TenantUrlRequest>({
       query: (data) => ({
         url: `/api/apps/appChange/${data.appId}/subscription/${data.subscriptionId}/tenantUrl`,
@@ -201,6 +202,12 @@ export const apiSlice = createApi({
         method: 'PUT',
       }),
     }),
+    declineAppSubscription: builder.mutation<void, string>({
+      query: (subscriptionId) => ({
+        url: `/api/apps/subscription/${subscriptionId}/decline`,
+        method: 'PUT',
+      }),
+    }),
   }),
 })
 
@@ -211,4 +218,5 @@ export const {
   useAddUserSubscribtionMutation,
   useUpdateTenantUrlMutation,
   useActivateSubscriptionMutation,
+  useDeclineAppSubscriptionMutation,
 } = apiSlice

--- a/src/features/serviceManagement/apiSlice.ts
+++ b/src/features/serviceManagement/apiSlice.ts
@@ -325,6 +325,12 @@ export const apiSlice = createApi({
         method: 'PUT',
       }),
     }),
+    declineServiceSubscribtion: builder.mutation<void, string>({
+      query: (subscriptionId) => ({
+        url: `/api/services/subscription/${subscriptionId}/decline`,
+        method: 'PUT',
+      }),
+    }),
   }),
 })
 
@@ -346,4 +352,5 @@ export const {
   useSaveServiceTechnicalUserProfilesMutation,
   useActivateSubscriptionMutation,
   useDeactivateServiceMutation,
+  useDeclineServiceSubscribtionMutation,
 } = apiSlice

--- a/src/features/serviceSubscription/serviceSubscriptionApiSlice.ts
+++ b/src/features/serviceSubscription/serviceSubscriptionApiSlice.ts
@@ -224,6 +224,12 @@ export const apiSlice = createApi({
         method: 'PUT',
       }),
     }),
+    declineServiceSubscription: builder.mutation<void, string>({
+      query: (subscriptionId) => ({
+        url: `/api/services/subscription/${subscriptionId}/decline`,
+        method: 'PUT',
+      }),
+    }),
   }),
 })
 
@@ -235,4 +241,5 @@ export const {
   useFetchServiceDetailsQuery,
   useFetchCompanyServiceSubscriptionsQuery,
   useUnsubscribeServiceMutation,
+  useDeclineServiceSubscriptionMutation,
 } = apiSlice


### PR DESCRIPTION
## Description

We have apps and service’s subscriptions which we want to “Decline” by App/Service Provider or Admin type of users. Currently we only have Activate and Deactivate Subscription functionality by App/Service Provider type of users.

## Why

- Frontend would still be looking at the isSubscribed param from api/apps/{appId} API to make decisions upon showing different statuses of subscription on App Details Page
- Frontend would need to show another button as “Decline“ on App/Service Subscription page only when "offerSubscriptionStatus": "PENDING" in /api/Apps/provided/subscription-status API.
- Frontend may show a confirmation box to user and then call this new API, when user confirm.
- Frontend would have to refresh the list after the declination.

## Issue

https://github.com/eclipse-tractusx/portal-frontend/issues/1371

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
