### PR TITLE
chore(deps): bump dependencies for 25.09

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -761,7 +761,7 @@ npm/npmjs/@babel/traverse/7.26.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD
 npm/npmjs/@babel/types/7.25.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #16040
 npm/npmjs/@babel/types/7.26.5, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #17734
 npm/npmjs/@bcoe/v8-coverage/0.2.3, ISC AND MIT, approved, clearlydefined
-npm/npmjs/@catena-x/portal-shared-components/4.0.2, Apache-2.0 AND MIT, approved, #20858
+npm/npmjs/@catena-x/portal-shared-components/4.0.1, Apache-2.0 AND MIT, approved, #20858
 npm/npmjs/@colors/colors/1.5.0, MIT, approved, clearlydefined
 npm/npmjs/@cspotcode/source-map-support/0.8.1, MIT, approved, clearlydefined
 npm/npmjs/@cypress/request/3.0.6, Apache-2.0, approved, clearlydefined

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "dependencies": {
-    "@catena-x/portal-shared-components": "^4.0.2",
+    "@catena-x/portal-shared-components": "^4.0.1",
     "@emotion/react": "^11.13.5",
     "@emotion/styled": "^11.13.5",
     "@hookform/error-message": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,14 +388,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@catena-x/portal-shared-components@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-4.0.2.tgz#b2ad1e11c0a2a4fa5d40a8c6b29e88e3b7ff9df1"
-  integrity sha512-J2Rv/WudW3Nq3zHderZ0opnlQHmV/K801QEyZxL3+vaxx+Qq8XmPCoc+hotDigdgBZF1kQMaxYqWlNG7EM/pSg==
+"@catena-x/portal-shared-components@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@catena-x/portal-shared-components/-/portal-shared-components-4.0.1.tgz#e581ab04b60bd1dd86c4e93ff792ef4302614804"
+  integrity sha512-WtSdtrisbEJUfQEiK7Qs71cNPfz9MAEe7YCGkiRHHLGU3zXE+S9oiP+493cEyPlxhPUuvzSKUrQHsXbKqgYzIw==
   dependencies:
     "@date-io/date-fns" "^3.0.0"
     "@emotion/react" "^11.14.0"
-    "@emotion/styled" "^11.14.1"
+    "@emotion/styled" "^11.14.0"
     "@mui/icons-material" "^7.0.0"
     "@mui/material" "^7.0.0"
     "@mui/system" "^7.0.0"
@@ -569,7 +569,7 @@
     "@emotion/use-insertion-effect-with-fallbacks" "^1.1.0"
     "@emotion/utils" "^1.4.2"
 
-"@emotion/styled@^11.14.1":
+"@emotion/styled@^11.14.0":
   version "11.14.1"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-11.14.1.tgz#8c34bed2948e83e1980370305614c20955aacd1c"
   integrity sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==


### PR DESCRIPTION
## Description

- phone
- lodash
- eslint-config-prettier
- form-data

```
### Technical Support
 
 - **Dependencies**
   - upgraded dependencies [#1637](https://github.com/eclipse-tractusx/portal-frontend/pull/1637)
 
```

**NOTE:**
I was not able to upgrade shared-components as there was a breaking change caused by side loading of override not working the same.
## Why

App maintenance and security

## Issue

Refs: #1630

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
