### PR TITLE
fix: send subscription id when updating app roles

### DIFF
--- a/src/components/overlays/EditAppUserRoles/index.tsx
+++ b/src/components/overlays/EditAppUserRoles/index.tsx
@@ -82,7 +82,7 @@ export default function EditAppUserRoles({
     const data: UserRoleRequest = {
       appId,
       companyUserId: id,
-      subscriptionId: subscriptionId,
+      subscriptionId,
       body: roles,
     }
     try {

--- a/src/components/overlays/EditAppUserRoles/index.tsx
+++ b/src/components/overlays/EditAppUserRoles/index.tsx
@@ -42,7 +42,13 @@ import { useParams } from 'react-router-dom'
 import { OVERLAYS } from 'types/Constants'
 import './style.scss'
 
-export default function EditAppUserRoles({ id }: { id: string }) {
+export default function EditAppUserRoles({
+  id,
+  subscriptionId,
+}: {
+  id: string
+  subscriptionId: string
+}) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const { appId } = useParams()
@@ -76,6 +82,7 @@ export default function EditAppUserRoles({ id }: { id: string }) {
     const data: UserRoleRequest = {
       appId,
       companyUserId: id,
+      subscriptionId: subscriptionId,
       body: roles,
     }
     try {

--- a/src/components/pages/AppUserManagement/AppUserDetailsTable/index.tsx
+++ b/src/components/pages/AppUserManagement/AppUserDetailsTable/index.tsx
@@ -35,9 +35,11 @@ import { userHasPortalRole } from 'services/AccessService'
 export const AppUserDetailsTable = ({
   roles,
   userRoleResponse,
+  subscriptionId,
 }: {
   roles: AppRole[] | undefined
   userRoleResponse: string
+  subscriptionId: string
 }) => {
   const { t } = useTranslation()
   const dispatch = useDispatch()
@@ -66,7 +68,13 @@ export const AppUserDetailsTable = ({
       onDetailsClick={
         userHasPortalRole(ROLES.MODIFY_USER_ACCOUNT)
           ? (row: TenantUser) =>
-              dispatch(show(OVERLAYS.EDIT_APP_USER_ROLES, row.companyUserId))
+              dispatch(
+                show(
+                  OVERLAYS.EDIT_APP_USER_ROLES,
+                  row.companyUserId,
+                  subscriptionId
+                )
+              )
           : undefined
       }
     />

--- a/src/components/pages/AppUserManagement/index.tsx
+++ b/src/components/pages/AppUserManagement/index.tsx
@@ -53,6 +53,7 @@ export default function AppUserManagement() {
   const userRoleResponse = useSelector(currentUserRoleResp)
 
   const [showAlert, setShowAlert] = useState<boolean>(false)
+  const [subscriptionId, setSubscriptionId] = useState<string>('')
 
   useEffect(() => {
     setShowAlert(
@@ -60,6 +61,12 @@ export default function AppUserManagement() {
         userRoleResponse === SuccessErrorType.SUCCESS
     )
   }, [userRoleResponse])
+
+  useEffect(() => {
+    setSubscriptionId(
+      appDetails?.offerSubscriptionDetailData?.[0]?.offerSubscriptionId ?? ''
+    )
+  }, [appDetails])
 
   useEffect(() => {
     dispatch(setUserRoleResp(''))
@@ -83,7 +90,11 @@ export default function AppUserManagement() {
         roles={data}
         error={isError ? JSON.stringify(data) : ''}
       />
-      <AppUserDetailsTable roles={data} userRoleResponse={userRoleResponse} />
+      <AppUserDetailsTable
+        subscriptionId={subscriptionId}
+        roles={data}
+        userRoleResponse={userRoleResponse}
+      />
       {/* success or error dialog/overlay */}
       {userRoleResponse && (
         <Dialog

--- a/src/components/pages/CompanyRoleUpdate/index.tsx
+++ b/src/components/pages/CompanyRoleUpdate/index.tsx
@@ -233,6 +233,7 @@ export default function CompanyRoles() {
                       OVERLAYS.UPDATE_COMPANY_ROLE,
                       '',
                       '',
+                      '',
                       false,
                       '',
                       selectedRoles

--- a/src/components/pages/UserDetail/index.tsx
+++ b/src/components/pages/UserDetail/index.tsx
@@ -55,6 +55,7 @@ export default function UserDetail() {
       show(
         OVERLAYS.CONFIRM_USER_ACTION,
         userId,
+        '',
         'resetPassword',
         false,
         `${data.firstName} ${data.lastName}`

--- a/src/features/admin/appuserApiSlice.ts
+++ b/src/features/admin/appuserApiSlice.ts
@@ -32,6 +32,7 @@ import type { TenantUser } from './userApiSlice'
 export interface UserRoleRequest {
   appId: string
   companyUserId: string
+  subscriptionId: string
   body: string[]
 }
 
@@ -108,7 +109,7 @@ export const apiSlice = createApi({
     }),
     updateUserRoles: builder.mutation<UserRoleResponse, UserRoleRequest>({
       query: (data: UserRoleRequest) => ({
-        url: `/api/administration/user/owncompany/users/${data.companyUserId}/apps/${data.appId}/roles`,
+        url: `/api/administration/user/owncompany/users/${data.companyUserId}/apps/${data.appId}/subscription/${data.subscriptionId}/roles`,
         method: 'PUT',
         body: data.body,
       }),

--- a/src/features/admin/appuserApiSlice.ts
+++ b/src/features/admin/appuserApiSlice.ts
@@ -32,7 +32,7 @@ import type { TenantUser } from './userApiSlice'
 export interface UserRoleRequest {
   appId: string
   companyUserId: string
-  subscriptionId: string
+  subscriptionId?: string
   body: string[]
 }
 

--- a/src/features/control/overlay.ts
+++ b/src/features/control/overlay.ts
@@ -27,6 +27,7 @@ export const name = 'control/overlay'
 export type OverlayState = {
   type: OVERLAYS
   id: string
+  subscriptionId: string
   title?: string
   status?: boolean
   subTitle?: string
@@ -36,6 +37,7 @@ export type OverlayState = {
 const initialState = {
   type: OVERLAYS.NONE,
   id: '',
+  subscriptionId: '',
   title: '',
   displayName: '',
   subTitle: '',
@@ -54,6 +56,7 @@ const show = createAction(
   (
     type: OVERLAYS,
     id?: string,
+    subscriptionId?: string,
     title?: string,
     status?: boolean,
     subTitle?: string,
@@ -62,6 +65,7 @@ const show = createAction(
     payload: {
       type,
       id,
+      subscriptionId,
       title,
       status,
       subTitle,

--- a/src/services/AccessService.tsx
+++ b/src/services/AccessService.tsx
@@ -181,7 +181,12 @@ export const getOverlay = (overlay: OverlayState) => {
     case OVERLAYS.ADD_APP_USER_ROLES:
       return <AddAppUserRoles />
     case OVERLAYS.EDIT_APP_USER_ROLES:
-      return <EditAppUserRoles id={overlay.id} />
+      return (
+        <EditAppUserRoles
+          id={overlay.id}
+          subscriptionId={overlay.subscriptionId}
+        />
+      )
     case OVERLAYS.NEWS:
       return <NewsDetail id={overlay.id} />
     case OVERLAYS.ADD_BPN:


### PR DESCRIPTION
## Description

Updating a users app role now requires a subscription id. Result of the following change in backend: https://github.com/eclipse-tractusx/portal-backend/commit/2880f3baa76d7d18b718ba8a0e3312a5bb410dd0

When a user in the app user list is click, the subscription id of the current app is now passed into the modal and sent to the endpoint. 

**Changelog:** 

App user management
  - pass subscriptionId in update app user role endpoint https://github.com/eclipse-tractusx/portal-frontend/pull/1671

## Why

Currently the api call is returning 404 because of the missing subscriptionId.

## Issue

Issue: [1670](https://github.com/eclipse-tractusx/portal-frontend/issues/1670)

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
