### PR TITLE
fix: add missing param from subscription id show overlay

### DIFF
--- a/src/components/overlays/AddAppUserRoles/index.tsx
+++ b/src/components/overlays/AddAppUserRoles/index.tsx
@@ -49,7 +49,11 @@ import {
 import { Box } from '@mui/material'
 import { useState } from 'react'
 
-export default function AddAppUserRoles() {
+export default function AddAppUserRoles({
+  subscriptionId,
+}: {
+  subscriptionId: string
+}) {
   const { t } = useTranslation()
   const dispatch = useDispatch()
   const { appId } = useParams()
@@ -66,6 +70,7 @@ export default function AddAppUserRoles() {
       const data: UserRoleRequest = {
         appId,
         companyUserId: user,
+        subscriptionId,
         body: roles,
       }
       dispatch(setRolesToAdd([]))

--- a/src/components/overlays/CompanyCertificateDetails/index.tsx
+++ b/src/components/overlays/CompanyCertificateDetails/index.tsx
@@ -220,6 +220,7 @@ export default function CompanyCertificateDetails({
                       show(
                         OVERLAYS.COMPANY_CERTIFICATE_CONFIRM_DELETE,
                         id,
+                        '',
                         selected.companyCertificateType
                       )
                     )

--- a/src/components/pages/AppOverview/index.tsx
+++ b/src/components/pages/AppOverview/index.tsx
@@ -237,9 +237,9 @@ export default function AppOverview() {
 
   const showOverlay = (item: AppInfo) => {
     if (item.status === 'created') {
-      dispatch(show(OVERLAYS.APP_OVERVIEW_CONFIRM, item.id, item.name))
+      dispatch(show(OVERLAYS.APP_OVERVIEW_CONFIRM, item.id, '', item.name))
     } else if (item.status === 'in_review') {
-      dispatch(show(OVERLAYS.APP_DETAILS_OVERLAY, item.id, item.name))
+      dispatch(show(OVERLAYS.APP_DETAILS_OVERLAY, item.id, '', item.name))
     }
   }
 

--- a/src/components/pages/AppUserManagement/AppUserDetailsTable/index.tsx
+++ b/src/components/pages/AppUserManagement/AppUserDetailsTable/index.tsx
@@ -50,7 +50,9 @@ export const AppUserDetailsTable = ({
     <UserList
       sectionTitle={'content.usermanagement.appUserDetails.subheadline'}
       addButtonLabel={'content.usermanagement.appUserDetails.table.add'}
-      addButtonClick={() => dispatch(show(OVERLAYS.ADD_APP_USER_ROLES, appId))}
+      addButtonClick={() =>
+        dispatch(show(OVERLAYS.ADD_APP_USER_ROLES, appId, subscriptionId))
+      }
       addButtonDisabled={
         !roles ||
         roles.length === 0 ||

--- a/src/components/pages/MyAccount/index.tsx
+++ b/src/components/pages/MyAccount/index.tsx
@@ -46,7 +46,9 @@ export default function MyAccount() {
   const dispatch = useDispatch()
 
   const handleDeleteUser = () =>
-    dispatch(show(OVERLAYS.CONFIRM_USER_ACTION, data?.companyUserId, 'ownUser'))
+    dispatch(
+      show(OVERLAYS.CONFIRM_USER_ACTION, data?.companyUserId, '', 'ownUser')
+    )
 
   return (
     <main className="my-account">

--- a/src/components/pages/UserDetail/index.tsx
+++ b/src/components/pages/UserDetail/index.tsx
@@ -44,10 +44,10 @@ export default function UserDetail() {
   const { data } = useFetchUserDetailsQuery(userId ?? '')
 
   const handleSuspendUser = () =>
-    dispatch(show(OVERLAYS.CONFIRM_USER_ACTION, userId, 'suspend'))
+    dispatch(show(OVERLAYS.CONFIRM_USER_ACTION, userId, '', 'suspend'))
 
   const handleDeleteUser = () =>
-    dispatch(show(OVERLAYS.CONFIRM_USER_ACTION, userId, 'user'))
+    dispatch(show(OVERLAYS.CONFIRM_USER_ACTION, userId, '', 'user'))
 
   const handleResetPasswordForUser = () =>
     data &&

--- a/src/services/AccessService.tsx
+++ b/src/services/AccessService.tsx
@@ -179,7 +179,7 @@ export const getOverlay = (overlay: OverlayState) => {
     case OVERLAYS.DELETE_TECH_USER:
       return <DeleteTechnicalUser id={overlay.id} />
     case OVERLAYS.ADD_APP_USER_ROLES:
-      return <AddAppUserRoles />
+      return <AddAppUserRoles subscriptionId={overlay.subscriptionId} />
     case OVERLAYS.EDIT_APP_USER_ROLES:
       return (
         <EditAppUserRoles


### PR DESCRIPTION
## Description

This PR is part 2 of: https://github.com/eclipse-tractusx/portal-frontend/pull/1671

Any overlay in the project that uses the show() helper function to display an overlay that passes more than 2 parameters is now behaving incorrectly due to the changes in the first PR.

This PR updates all show() functions using more than 2 parameters to factor in the added param. 

## Why

First PR [1671](https://github.com/eclipse-tractusx/portal-frontend/pull/1671 has introduced an issue to other overlays relying on the show() function. 


## Issue

[1670](https://github.com/eclipse-tractusx/portal-frontend/issues/1670)

## Checklist


- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
