### PR TITLE
fix: fetch subscription id and pass in appManagement url 

### DIFF
--- a/src/components/pages/AppUserManagement/index.tsx
+++ b/src/components/pages/AppUserManagement/index.tsx
@@ -21,7 +21,7 @@
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams, useSearchParams } from 'react-router-dom'
 import CloseIcon from '@mui/icons-material/Close'
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline'
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
@@ -51,9 +51,7 @@ export default function AppUserManagement() {
   const { data, isError } = useFetchAppRolesQuery(appId ?? '')
 
   const userRoleResponse = useSelector(currentUserRoleResp)
-
   const [showAlert, setShowAlert] = useState<boolean>(false)
-  const [subscriptionId, setSubscriptionId] = useState<string>('')
 
   useEffect(() => {
     setShowAlert(
@@ -62,11 +60,8 @@ export default function AppUserManagement() {
     )
   }, [userRoleResponse])
 
-  useEffect(() => {
-    setSubscriptionId(
-      appDetails?.offerSubscriptionDetailData?.[0]?.offerSubscriptionId ?? ''
-    )
-  }, [appDetails])
+  const [searchParams] = useSearchParams()
+  const subscriptionId = searchParams.get('subscriptionId') ?? ''
 
   useEffect(() => {
     dispatch(setUserRoleResp(''))

--- a/src/components/pages/UserManagement/AppArea/index.tsx
+++ b/src/components/pages/UserManagement/AppArea/index.tsx
@@ -61,7 +61,9 @@ export const AppArea = () => {
                   expandOnHover={false}
                   filledBackground={true}
                   onClick={() => {
-                    navigate(`/appUserManagement/${item.offerId}`)
+                    navigate(
+                      `/appUserManagement/${item.offerId}?subscriptionId=${item.subscriptionId}`
+                    )
                   }}
                 />
               )

--- a/src/features/apps/types.ts
+++ b/src/features/apps/types.ts
@@ -104,6 +104,7 @@ export type ActiveSubscriptionItem = {
   name: string
   provider: string
   image?: ImageType
+  subscriptionId: string
 }
 
 export type SubscriptionStatusItem = {


### PR DESCRIPTION
## Description

- Pass subscriptionId in url param to app user management screen 

## Why

The app subscription id was incorrect when adding or updating user roles. The correct subscription id is now correctly being retrieved and passed to the app user management screen.

## Issue

#1670 

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/portal-assets/blob/main/docs/admin/Dev%20Process/How%20to%20contribute.md#commits-branches-and-pull-requests-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes
